### PR TITLE
Add a Vagrantfile and Ansible role for FMN development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 *.pyc
 *.egg*
+
+# Ignore the repos checked out within this repo
+fmn.*
+
+.dnf-cache/
+.vagrant/
+Vagrantfile
+*.retry

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,28 @@ components can be found here:
 - `fmn.lib <https://github.com/fedora-infra/fmn.lib>`_
 - `fmn.consumer <https://github.com/fedora-infra/fmn.consumer>`_
 - `fmn.web <https://github.com/fedora-infra/fmn.web>`_
+- `fmn.sse <https://github.com/fedora-infra/fmn.sse>`_
+
+
+Vagrant
+^^^^^^^
+
+A Vagrantfile is provided as ``Vagrantfile.example``. You can get started by
+installing Vagrant and starting your own ``Vagrantfile`` from the example::
+
+    $ sudo dnf install ansible vagrant-libvirt vagrant-sshfs
+    $ cp Vagrantfile.example Vagrantfile
+    $ vagrant up
+
+There are several configurations in the Vagrantfile you may want to alter.
+documentation can be found inline. Note that performing ``vagrant up`` will
+check out ``fmn.rules``, ``fmn.lib``, ``fmn.consumer``, ``fmn.web``, and
+``fmn.sse`` out in the root of the ``fmn`` repository if you haven't already
+done so.
+
+
+Manual
+^^^^^^
 
 If you want to set up fmn for development, you could try something like this:
 

--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -1,0 +1,62 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+ config.vm.box = "fedora/24-cloud-base"
+
+ # Access the web interface for FMN
+ config.vm.network "forwarded_port", guest: 5000, host: 5000
+
+ # Access the SSE server
+ config.vm.network "forwarded_port", guest: 8080, host: 8080
+
+ # Access the HTTP-based RabbitMQ management console
+ config.vm.network "forwarded_port", guest: 15672, host: 15672
+
+ # Vagrant can share the source directory using rsync, NFS, or SSHFS (with the vagrant-sshfs
+ # plugin). By default it rsyncs the current working directory to /vagrant. We disable this
+ # in favor of SSHFS.
+ #
+ # If you would prefer to use NFS to share the directory uncomment this and configure NFS
+ #config.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false
+ config.vm.synced_folder ".", "/vagrant", disabled: true
+ config.vm.synced_folder ".", "/home/vagrant/devel", type: "sshfs", sshfs_opts_append: "-o nonempty"
+
+ # To cache update packages (which is helpful if frequently doing `vagrant destroy && vagrant up`)
+ # you can create a local directory and share it to the guest's DNF cache. The directory needs to
+ # exist, so create it before you uncomment the line below.
+ #config.vm.synced_folder ".dnf-cache", "/var/cache/dnf", type: "sshfs", sshfs_opts_append: "-o nonempty"
+
+ # Comment this line if you would like to disable the automatic update during provisioning
+ config.vm.provision "shell", inline: "sudo dnf upgrade -y"
+
+ # Install packages required for Ansible and configure everything with ansible
+ config.vm.provision "shell", inline: "sudo dnf -y install python2-dnf libselinux-python"
+ config.vm.provision "ansible" do |ansible|
+     ansible.playbook = "ansible/vagrant-playbook.yml"
+ end
+
+
+ # Create the "pagure" box
+ config.vm.define "fmn" do |fmn|
+    fmn.vm.host_name = "fmn-dev.example.com"
+
+    fmn.vm.provider :libvirt do |domain|
+        # Season to taste
+        domain.cpus = 4
+        domain.graphics_type = "spice"
+        domain.memory = 4096
+        domain.video_type = "qxl"
+
+        # Uncomment the following line if you would like to enable libvirt's unsafe cache
+        # mode. It is called unsafe for a reason, as it causes the virtual host to ignore all
+        # fsync() calls from the guest. Only do this if you are comfortable with the possibility of
+        # your development guest becoming corrupted (in which case you should only need to do a
+        # vagrant destroy and vagrant up to get a new one).
+        #
+        #domain.volume_cache = "unsafe"
+    end
+ end
+end

--- a/ansible/roles/fmn-dev/files/bashrc
+++ b/ansible/roles/fmn-dev/files/bashrc
@@ -1,0 +1,42 @@
+# .bashrc
+
+# Source global definitions
+if [ -f /etc/bashrc ]; then
+    . /etc/bashrc
+fi
+
+# Uncomment the following line if you don't like systemctl's auto-paging feature:
+# export SYSTEMD_PAGER=
+
+# User specific aliases and functions
+# If adding new functions to this file, note that you can add help text to the function
+# by defining a variable with name _<function>_help containing the help text
+
+# Set up virtualenvwrapper
+export WORKON_HOME=$HOME/.virtualenvs
+export PIP_VIRTUALENV_BASE=$WORKON_HOME
+export VIRTUALENV_USE_DISTRIBUTE=true
+export PIP_RESPECT_VIRTUALENV=true
+source /usr/bin/virtualenvwrapper.sh
+
+SERVICES=("fmn-backend" "fmn-digests" "fmn-sse" "fmn-worker" "fmn-web" "fedmsg-hub")
+
+fstart() {
+    _faction start
+}
+
+fstop() {
+    _faction stop
+}
+
+frestart() {
+    _faction restart
+}
+
+fstatus() {
+    _faction status
+}
+
+_faction() {
+    systemctl --user "$1" "${SERVICES[@]}"
+}

--- a/ansible/roles/fmn-dev/files/fedmsg-hub.service
+++ b/ansible/roles/fmn-dev/files/fedmsg-hub.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=FMN.consumer worker
+After=network.target
+Documentation=https://github.com/fedora-infra/fmn.consumer/
+
+[Service]
+ExecStart=/home/vagrant/.virtualenvs/python2-fmn/bin/fedmsg-hub
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/fmn-dev/files/fedmsg.d/base.py
+++ b/ansible/roles/fmn-dev/files/fedmsg.d/base.py
@@ -1,0 +1,54 @@
+# This file is part of fedmsg.
+# Copyright (C) 2012 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Ralph Bean <rbean@redhat.com>
+#
+config = dict(
+    # Set this to dev if you're hacking on fedmsg or an app.
+    # Set to stg or prod if running in the Fedora Infrastructure
+    environment="dev",
+
+    # Default is 0
+    high_water_mark=0,
+    io_threads=1,
+
+    ## For the fedmsg-hub and fedmsg-relay. ##
+
+    # We almost always want the fedmsg-hub to be sending messages with zmq as
+    # opposed to amqp or stomp.
+    zmq_enabled=True,
+
+    # When subscribing to messages, we want to allow splats ('*') so we tell
+    # the hub to not be strict when comparing messages topics to subscription
+    # topics.
+    zmq_strict=False,
+
+    # Number of seconds to sleep after initializing waiting for sockets to sync
+    post_init_sleep=0.5,
+
+    # Wait a whole second to kill all the last io threads for messages to
+    # exit our outgoing queue (if we have any).  This is in milliseconds.
+    zmq_linger=1000,
+
+    # See the following
+    #   - http://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html
+    #   - http://api.zeromq.org/3-2:zmq-setsockopt
+    zmq_tcp_keepalive=1,
+    zmq_tcp_keepalive_cnt=3,
+    zmq_tcp_keepalive_idle=60,
+    zmq_tcp_keepalive_intvl=5,
+)

--- a/ansible/roles/fmn-dev/files/fedmsg.d/endpoints.py
+++ b/ansible/roles/fmn-dev/files/fedmsg.d/endpoints.py
@@ -1,0 +1,43 @@
+# This file is part of fedmsg.
+# Copyright (C) 2012 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Ralph Bean <rbean@redhat.com>
+#
+import socket
+hostname = socket.gethostname().split('.', 1)[0]
+
+config = dict(
+    # This is a dict of possible addresses from which fedmsg can send
+    # messages.  fedmsg.init(...) requires that a 'name' argument be passed
+    # to it which corresponds with one of the keys in this dict.
+    endpoints={
+        # These are here so your local box can listen to the upstream
+        # infrastructure's bus.  Cool, right?  :)
+        "fedora-infrastructure": [
+            "tcp://hub.fedoraproject.org:9940",
+            #"tcp://stg.fedoraproject.org:9940",
+        ],
+
+        # For other, more 'normal' services, fedmsg will try to guess the
+        # name of it's calling module to determine which endpoint definition
+        # to use.  This can be overridden by explicitly providing the name in
+        # the initial call to fedmsg.init(...).
+        #"bodhi.%s" % hostname: ["tcp://127.0.0.1:3001"],
+        #"fas.%s" % hostname: ["tcp://127.0.0.1:3002"],
+        #"fedoratagger.%s" % hostname: ["tcp://127.0.0.1:3003"],
+    },
+)

--- a/ansible/roles/fmn-dev/files/fedmsg.d/fas_credentials.py
+++ b/ansible/roles/fmn-dev/files/fedmsg.d/fas_credentials.py
@@ -1,0 +1,6 @@
+config = {
+    'fas_credentials': {
+        'username': '<your FAS account>',
+        'password': '<your FAS password>',
+    }
+}

--- a/ansible/roles/fmn-dev/files/fedmsg.d/fmn.py
+++ b/ansible/roles/fmn-dev/files/fedmsg.d/fmn.py
@@ -1,0 +1,97 @@
+import socket
+hostname = socket.gethostname().split('.')[0]
+
+
+config = {
+    # Consumer stuff
+    "fmn.consumer.enabled": True,
+    "fmn.sqlalchemy.uri": "sqlite:////var/tmp/fmn-dev-db.sqlite",
+    "fmn.autocreate": True,  # Should new packagers auto-get accounts?
+    "fmn.junk_suffixes": [
+        '.buildsys.package.list.state.change',
+        '.buildsys.tag',
+        '.buildsys.untag',
+        '.buildsys.repo.init',
+        '.buildsys.repo.done',
+    ],
+    'ignored_copr_owners': [  # Some COPR repos with very high pressure
+        '@rubygems',
+        '@copr'
+    ],
+
+    # Some configuration for the rule processors
+    "fmn.rules.utils.use_pkgdb2": False,
+    "fmn.rules.utils.pkgdb2_api_url": "http://209.132.184.188/api/",
+    "fmn.rules.cache": {
+        'backend': 'dogpile.cache.redis',
+        'arguments': {
+            'host': 'localhost',
+            'port': 6379,
+            'db': 0,
+            'redis_expiration_time': 60 * 60 * 2,   # 2 hours
+            'distributed_lock': True
+        },
+    },
+
+    # Colors:
+    "irc_color_lookup": {
+        "fas": "light blue",
+        "bodhi": "green",
+        "git": "red",
+        "tagger": "brown",
+        "wiki": "purple",
+        "logger": "orange",
+        "pkgdb": "teal",
+        "buildsys": "yellow",
+        "planet": "light green",
+        "fmn": "purple",
+    },
+
+    # Backend stuff
+
+    # This is the list of enabled backends (so we can turn one off globally)
+    # "fmn.backends": ['email', 'irc', 'android', 'sse', 'desktop'],
+    "fmn.backends": ['sse'],
+    "fmn.backends.debug": False,
+
+    # Email
+    "fmn.email.mailserver": "127.0.0.1:25",
+    "fmn.email.from_address": "notifications@fedoraproject.org",
+
+    # IRC
+    "fmn.irc.network": "irc.freenode.net",
+    "fmn.irc.nickname": "fmn-devbot",
+    "fmn.irc.port": 6667,
+    "fmn.irc.timeout": 120,
+
+    # GCM - Android notifs
+    "fmn.gcm.post_url": "wat",
+    "fmn.gcm.api_key": "wat",
+
+    # Confirmation urls:
+    "fmn.base_url": "http://localhost:5000/",
+    "fmn.acceptance_url": "http://localhost:5000/confirm/accept/{secret}",
+    "fmn.rejection_url": "http://localhost:5000/confirm/reject/{secret}",
+    "fmn.support_email": "notifications@fedoraproject.org",
+
+    # Generic stuff
+    "endpoints": {
+        "fmn.%s" % hostname: [
+            "tcp://127.0.0.1:3041",
+            "tcp://127.0.0.1:3042",
+        ],
+    },
+    "logging": dict(
+        loggers=dict(
+            fmn={
+                "level": "DEBUG",
+                "propagate": False,
+                "handlers": ["console"],
+            },
+        ),
+    ),
+
+    # Our web frontend also needs to be able to talk to datanommer to get
+    # example messages that match rules (optional)
+    "datanommer.sqlalchemy.url": "postgresql+psycopg2://datanommer@localhost:5432/datanommer",
+}

--- a/ansible/roles/fmn-dev/files/fedmsg.d/logging.py
+++ b/ansible/roles/fmn-dev/files/fedmsg.d/logging.py
@@ -1,0 +1,33 @@
+# Setup fedmsg logging.
+# See the following for constraints on this format http://bit.ly/Xn1WDn
+config = dict(
+    logging=dict(
+        version=1,
+        formatters=dict(
+            bare={
+                "datefmt": "%Y-%m-%d %H:%M:%S",
+                "format": "[%(asctime)s][%(name)10s %(levelname)7s] %(message)s"
+            },
+        ),
+        handlers=dict(
+            console={
+                "class": "logging.StreamHandler",
+                "formatter": "bare",
+                "level": "DEBUG",
+                "stream": "ext://sys.stdout",
+            }
+        ),
+        loggers=dict(
+            fedmsg={
+                "level": "DEBUG",
+                "propagate": False,
+                "handlers": ["console"],
+            },
+            moksha={
+                "level": "DEBUG",
+                "propagate": False,
+                "handlers": ["console"],
+            },
+        ),
+    ),
+)

--- a/ansible/roles/fmn-dev/files/fedmsg.d/rabbitmq.py
+++ b/ansible/roles/fmn-dev/files/fedmsg.d/rabbitmq.py
@@ -1,0 +1,6 @@
+config = {
+    # pika/rabbitmq config
+    "fmn.pika.host": "localhost",
+    "fmn.pika.port": 5672,
+    "fmn.pika.msg_expiration": 3600000,  # 1 hour in ms
+}

--- a/ansible/roles/fmn-dev/files/fedmsg.d/ssl.py
+++ b/ansible/roles/fmn-dev/files/fedmsg.d/ssl.py
@@ -1,0 +1,62 @@
+# This file is part of fedmsg.
+# Copyright (C) 2012 Red Hat, Inc.
+#
+# fedmsg is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# fedmsg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with fedmsg; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Ralph Bean <rbean@redhat.com>
+#
+import os
+import socket
+
+SEP = os.path.sep
+here = os.getcwd()
+
+config = dict(
+    sign_messages=False,
+    validate_signatures=False,
+    ssldir="/etc/pki/fedmsg",
+
+    crl_location="https://fedoraproject.org/fedmsg/crl.pem",
+    crl_cache="/var/run/fedmsg/crl.pem",
+    crl_cache_expiry=10,
+
+    ca_cert_location="https://fedoraproject.org/fedmsg/ca.crt",
+    ca_cert_cache="/var/run/fedmsg/ca.crt",
+    ca_cert_cache_expiry=0,  # Never expires
+
+    certnames={
+        # In prod/stg, map hostname to the name of the cert in ssldir.
+        # Unfortunately, we can't use socket.getfqdn()
+        #"app01.stg": "app01.stg.phx2.fedoraproject.org",
+    },
+
+    # A mapping of fully qualified topics to a list of cert names for which
+    # a valid signature is to be considered authorized.  Messages on topics not
+    # listed here are considered automatically authorized.
+    routing_policy={
+        # Only allow announcements from production if they're signed by a
+        # certain certificate.
+        "org.fedoraproject.prod.announce.announcement": [
+            "announce-lockbox.phx2.fedoraproject.org",
+        ],
+    },
+
+    # Set this to True if you want messages to be dropped that aren't
+    # explicitly whitelisted in the routing_policy.
+    # When this is False, only messages that have a topic in the routing_policy
+    # but whose cert names aren't in the associated list are dropped; messages
+    # whose topics do not appear in the routing_policy are not dropped.
+    routing_nitpicky=False,
+)

--- a/ansible/roles/fmn-dev/files/fmn-backend.service
+++ b/ansible/roles/fmn-dev/files/fmn-backend.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=FMN.consumer backend
+After=network.target
+Documentation=https://github.com/fedora-infra/fmn.consumer/
+
+[Service]
+ExecStart=/home/vagrant/.virtualenvs/python2-fmn/bin/python %h/devel/fmn.consumer/fmn/consumer/backend.py
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/fmn-dev/files/fmn-digests.service
+++ b/ansible/roles/fmn-dev/files/fmn-digests.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=FMN.consumer digester
+After=network.target
+Documentation=https://github.com/fedora-infra/fmn.consumer/
+
+[Service]
+ExecStart=/home/vagrant/.virtualenvs/python2-fmn/bin/python %h/devel/fmn.consumer/fmn/consumer/digests.py
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/fmn-dev/files/fmn-sse.service
+++ b/ansible/roles/fmn-dev/files/fmn-sse.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=FMN.sse feed for real time feed of fedmsg
+After=network.target
+Documentation=https://github.com/fedora-infra/fmn.sse/
+
+[Service]
+ExecStart=/home/vagrant/.virtualenvs/python2-fmn/bin/python %h/devel/fmn.sse/fmn/sse/sse_webserver.py
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/fmn-dev/files/fmn-web.service
+++ b/ansible/roles/fmn-dev/files/fmn-web.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=FMN.web server
+After=network.target
+Documentation=https://github.com/fedora-infra/fmn.web/
+
+[Service]
+ExecStart=/home/vagrant/.virtualenvs/python2-fmn/bin/python %h/devel/fmn.web/fmn/web/main.py
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/fmn-dev/files/fmn-worker.service
+++ b/ansible/roles/fmn-dev/files/fmn-worker.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=FMN.consumer worker
+After=network.target
+Documentation=https://github.com/fedora-infra/fmn.consumer/
+
+[Service]
+ExecStart=/home/vagrant/.virtualenvs/python2-fmn/bin/python %h/devel/fmn.consumer/fmn/consumer/worker.py
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/fmn-dev/files/motd
+++ b/ansible/roles/fmn-dev/files/motd
@@ -1,0 +1,35 @@
+
+Welcome to the FMN development environment!
+
+NOTE: Before you can run the services, you need to put valid FAS
+credentials in ~/.fedmsg.d/fas_credentials.py; failure to do so
+will cause some services to fail to start.
+
+Here are some tips:
+
+* ~/.fedmsg.d/ contains the application configuration; turn on
+  various backends in ~/.fedmsg.d/fmn.py
+
+* The code is located at ~/devel/
+
+* You can type `workon python2-fmn` to enter a configured Python virtualenv
+
+* Run `fstart` to start all the necessary services as systemd
+  user services. All output is logged by journald! You can see
+  all output with `journalctl` or a particular unit's log with
+  `journalctl --user-unit <unit-name>`
+
+* Run `fstop` to halt all the services
+
+* The RabbitMQ management console is enabled and available at
+  http://localhost:15672/ - the username is "guest" and the password
+  is "guest"
+
+* By default, only the SSE backend is enabled. To enable other backends,
+  turn them on in ~/.fedmsg/fmn.py
+
+Once you run `fstart` you can navigate to http://localhost:5000/
+in your browser to view the FMN web interface.
+
+Happy hacking!
+

--- a/ansible/roles/fmn-dev/tasks/main.yml
+++ b/ansible/roles/fmn-dev/tasks/main.yml
@@ -1,0 +1,133 @@
+---
+
+- name: Install helpful development packages
+  dnf: name={{ item }} state=present
+  with_items:
+    - git
+    - python-sphinx
+    - python-virtualenvwrapper
+    - vim-enhanced
+
+- name: Check out the FMN git repositories
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  git:
+    repo: https://github.com/fedora-infra/{{ item }}
+    dest: /home/{{ ansible_env.SUDO_USER }}/devel/{{ item }}
+  with_items:
+    - fmn.lib
+    - fmn.rules
+    - fmn.consumer
+    - fmn.web
+    - fmn.sse
+
+- name: Install fmn system dependencies
+  dnf: name={{ item }} state=present
+  with_items:
+    - gcc
+    - libffi-devel
+    - openssl-devel
+    - python2-devel
+    - python3-devel
+    - rabbitmq-server
+    - redhat-rpm-config
+    - redis
+    - swig
+    - zeromq-devel
+
+# Add various helpful configuration files
+- name: Install a custom bashrc
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  copy: src=bashrc dest=/home/{{ ansible_env.SUDO_USER }}/.bashrc
+
+- name: Install the message of the day
+  copy: src=motd dest=/etc/motd
+
+- name: Create fmn virtualenv
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  shell: "source ~/.bashrc && mkvirtualenv python2-fmn"
+  args:
+    creates: /home/{{ ansible_env.SUDO_USER }}/.virtualenvs/python2-fmn
+
+# For some reason, doing ``python setup.py develop`` fails to install
+# Flask, whereas doing it with pip works fine
+- name: Install Python runtime requirements
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  pip:
+    requirements: "{{ item }}/requirements.txt"
+    virtualenv: /home/{{ ansible_env.SUDO_USER }}/.virtualenvs/python2-fmn/
+    virtualenv_python: python2
+  with_items:
+    - "fmn.lib"
+    - "fmn.rules"
+    - "fmn.consumer"
+    - "fmn.web"
+    - "fmn.sse"
+  args:
+    chdir: /home/{{ ansible_env.SUDO_USER }}/devel
+
+- name: Install Python 2 tests requirements
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  pip:
+    requirements: "{{ item }}/tests-requirements.txt"
+    virtualenv: /home/{{ ansible_env.SUDO_USER }}/.virtualenvs/python2-fmn/
+    virtualenv_python: python2
+  with_items:
+    - "fmn.lib"
+    - "fmn.rules"
+    - "fmn.consumer"
+    - "fmn.web"
+    - "fmn.sse"
+  args:
+    chdir: /home/{{ ansible_env.SUDO_USER }}/devel
+
+- name: Install fmn packages
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  shell: "pushd {{ item }} && source ~/.bashrc && workon python2-fmn && python setup.py develop && popd"
+  with_items:
+    - "fmn.lib"
+    - "fmn.rules"
+    - "fmn.consumer"
+    - "fmn.web"
+    - "fmn.sse"
+  args:
+    chdir: /home/{{ ansible_env.SUDO_USER }}/devel
+
+- name: Enable the RabbitMQ management console
+  command: rabbitmq-plugins enable rabbitmq_management
+
+- name: Start and enable redis
+  service: name=redis state=started enabled=yes
+
+- name: Start and enable RabbitMQ
+  service: name=rabbitmq-server state=started enabled=yes
+
+- name: Create user systemd directory
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  file:
+    path: /home/{{ ansible_env.SUDO_USER }}/.config/systemd/user/
+    state: directory
+
+- name: Install a fmn service files
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  copy:
+    src: "{{ item }}"
+    dest: /home/{{ ansible_env.SUDO_USER }}/.config/systemd/user/{{ item }}
+  with_items:
+    - "fedmsg-hub.service"
+    - "fmn-backend.service"
+    - "fmn-digests.service"
+    - "fmn-sse.service"
+    - "fmn-worker.service"
+    - "fmn-web.service"
+
+- name: Install fedmsg config to ~/.fedmsg.d
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  copy:
+    src: fedmsg.d/
+    dest: /home/{{ ansible_env.SUDO_USER }}/.fedmsg.d
+
+- name: Create fmn database
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  shell: "source ~/.bashrc && workon python2-fmn && python ~/devel/fmn.lib/createdb.py --with-dev-data"
+  args:
+    creates: /var/tmp/fmn-dev-db.sqlite

--- a/ansible/vagrant-playbook.yml
+++ b/ansible/vagrant-playbook.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  become: true
+  become_method: sudo
+  vars:
+  roles:
+    - fmn-dev


### PR DESCRIPTION
This Vagrantfile and Ansible role sets up a development environment in a
virtual machine to make hacking on FMN easy. It adds a set of systemd
service files that can launch all the necessary development services
under for the user under  systemd which greatly eases certain tasks
like restarting all the services, collecting and filtering logs, etc.

Signed-off-by: Jeremy Cline jeremy@jcline.org
