### PR TITLE
Update the Ansible role to not update git repos

### DIFF
--- a/ansible/roles/fmn-dev/tasks/main.yml
+++ b/ansible/roles/fmn-dev/tasks/main.yml
@@ -13,6 +13,7 @@
   git:
     repo: https://github.com/fedora-infra/{{ item }}
     dest: /home/{{ ansible_env.SUDO_USER }}/devel/{{ item }}
+    update: no
   with_items:
     - fmn.lib
     - fmn.rules


### PR DESCRIPTION
The Ansible role Vagrant uses conveniently checks out the various git
repositories for you. However, on subsequent provisions, it tries to
update the repositories which fails if you don't have an remote called
`origin`, or have uncommitted changes, etc.

This will cause Ansible to initially check out the repositories, but
leave them alone afterwards.

Signed-off-by: Jeremy Cline jeremy@jcline.org
