### PR TITLE
Make fedmsg[crypto] optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 install:
  - sudo apt-get install swig -y
  - pip install --upgrade setuptools pip
- - pip install -r tests-requirements.txt
+ - pip install -r dev-requirements.txt
  - pip install -e .
 script: python -m unittest discover
 

--- a/ansible/roles/fmn-dev/tasks/main.yml
+++ b/ansible/roles/fmn-dev/tasks/main.yml
@@ -79,32 +79,40 @@
   args:
     chdir: /home/{{ ansible_env.SUDO_USER }}/devel
 
-- name: Install Python 2 tests requirements
+- name: Install Python 2 dev requirements for fmn
+  become_user: "{{ ansible_env.SUDO_USER }}"
+  pip:
+    requirements: "dev-requirements.txt"
+    virtualenv: /home/{{ ansible_env.SUDO_USER }}/.virtualenvs/python2-fmn/
+    virtualenv_python: python2
+  args:
+    chdir: /home/{{ ansible_env.SUDO_USER }}/devel
+
+
+- name: Install Python 2 dev requirements for fmn.web and fmn.sse
   become_user: "{{ ansible_env.SUDO_USER }}"
   pip:
     requirements: "{{ item }}/tests-requirements.txt"
     virtualenv: /home/{{ ansible_env.SUDO_USER }}/.virtualenvs/python2-fmn/
     virtualenv_python: python2
   with_items:
-    - "."
     - "fmn.web"
     - "fmn.sse"
   args:
     chdir: /home/{{ ansible_env.SUDO_USER }}/devel
 
 # NOTE: Sadly fmn.web isn't Python 3 compatible yet
-- name: Install Python 3 tests requirements
+- name: Install Python 3 dev requirements for fmn
   become_user: "{{ ansible_env.SUDO_USER }}"
-  shell: "source ~/.bashrc && workon python3-fmn && pip install -r {{ item }}/tests-requirements.txt"
-  with_items:
-    - "."
-    - "fmn.sse"
+  shell: "source ~/.bashrc && workon python3-fmn && pip install -r dev-requirements.txt"
   args:
     chdir: /home/{{ ansible_env.SUDO_USER }}/devel
 
-- name: Install packages necessary to build the documentation
+- name: Install Python 3 dev requirements for fmn.sse
   become_user: "{{ ansible_env.SUDO_USER }}"
-  shell: "source ~/.bashrc && workon python3-fmn && pip install sphinx sqlalchemy_schemadisplay"
+  shell: "source ~/.bashrc && workon python3-fmn && pip install -r tests-requirements.txt"
+  args:
+    chdir: /home/{{ ansible_env.SUDO_USER }}/devel/fmn.sse
 
 - name: Install fmn packages into the Python 2 virtualenv
   become_user: "{{ ansible_env.SUDO_USER }}"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,9 @@
+# Unit test requirements
+flake8
+html5lib
+mock
+nose
+
+# Docs requirements
+sphinx
+sqlalchemy_schemadisplay

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4
 bleach
 docutils
 dogpile.cache
-fedmsg[all]
+fedmsg[consumers, commands]
 fedmsg_meta_fedora_infrastructure
 markupsafe
 moksha.hub

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     download_url="https://pypi.python.org/pypi/fmn/",
     license='LGPLv2+',
     install_requires=requires,
-    tests_require=get_requirements('tests-requirements.txt'),
+    tests_require=get_requirements('dev-requirements.txt'),
     test_suite='fmn.tests',
     packages=find_packages(exclude=('fmn.tests', 'fmn.tests.*')),
     namespace_packages=['fmn'],

--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -1,4 +1,0 @@
-flake8
-html5lib
-mock
-nose


### PR DESCRIPTION
Intially I set the requirement for fedmsg to include all its extra
requirements. However, you do not need the crypto requirements to
install or run FMN, only to validate the signatures on messages. This
makes installing fmn simpler on platforms like Travis or RTD since they
may not have SWIG which is required to install M2crypto from PyPI.

It also adds the requirements to build the docs into the requirements file
that held the test dependencies.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>