### PR TITLE
Use the explicit relative import syntax for backend imports

### DIFF
--- a/fmn/consumer/backends/__init__.py
+++ b/fmn/consumer/backends/__init__.py
@@ -1,5 +1,5 @@
-from mail import EmailBackend  # noqa
-from irc import IRCBackend  # noqa
-from android import GCMBackend  # noqa
-from debug import DebugBackend  # noqa
-from sse import SSEBackend  # noqa
+from .mail import EmailBackend  # noqa
+from .irc import IRCBackend  # noqa
+from .android import GCMBackend  # noqa
+from .debug import DebugBackend  # noqa
+from .sse import SSEBackend  # noqa


### PR DESCRIPTION
Implicit relative imports are both confusing and incompatible with
Python 3.

See https://www.python.org/dev/peps/pep-0328/

Signed-off-by: Jeremy Cline <jeremy@jcline.org>