### PR TITLE
Modify the fmn-web systemd unit to use the flask app runner

### DIFF
--- a/ansible/roles/fmn-dev/files/fmn-web.service
+++ b/ansible/roles/fmn-dev/files/fmn-web.service
@@ -4,7 +4,9 @@ After=network.target
 Documentation=https://github.com/fedora-infra/fmn.web/
 
 [Service]
-ExecStart=/home/vagrant/.virtualenvs/python2-fmn/bin/python %h/devel/fmn.web/runserver.py --host 0.0.0.0
+Environment="FLASK_APP=/home/vagrant/devel/fmn.web/fmn/web/app.py"
+Environment="FLASK_DEBUG=1"
+ExecStart=/home/vagrant/.virtualenvs/python2-fmn/bin/flask run --host 0.0.0.0 --port 5000
 Type=simple
 
 [Install]


### PR DESCRIPTION
This changes the developer systemd unit to make use of the built-in
Flask application runner (flask >= 0.11 required).

Signed-off-by: Jeremy Cline <jeremy@jcline.org>