### PR TITLE
Remove the Github Pages Sphinx extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
readthedocs.org has an older version of Sphinx that doesn't include this
extension by default, and we are not going to use it, so this turns it
off.

This is the last thing necessary to get RTD working for FMN. I built
[this branch](http://jcline-fmn.readthedocs.io/en/bye-ghpages/) to make sure.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>