### PR TITLE
Update the README to use the readthedocs link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 FedMSG Notifications
 ====================
 
+.. image:: https://readthedocs.org/projects/fmn/badge/?version=latest
+        :alt: Documentation
+        :target: https://fmn.readthedocs.io/en/latest/
+
 ``fmn`` is a family of systems to manage end-user notifications triggered by
 `fedmsg, the FEDerated MESsage bus <http://fedmsg.com>`_. ``fmn`` provides a
 single place for all applications using ``fedmsg`` to notify users of events.
@@ -14,7 +18,7 @@ FMN is deployed in `Fedora <https://apps.fedoraproject.org/notifications/>`_.
 Documentation
 -------------
 
-Documentation is available in the docs/ directory or `online <https://fedora-infra.github.io/fmn/>`_
+Documentation is available in the docs/ directory or `online <https://fmn.readthedocs.io/en/latest/>`_.
 
 You need sphinx, sqlalchemy_schemadisplay, and graphviz to build the
 documentation.
@@ -23,5 +27,5 @@ documentation.
 Contributing
 ------------
 
-Consult the `contribution guide <https://fedora-infra.github.io/fmn/contributing.html>`_
+Consult the `contribution guide <https://fmn.readthedocs.io/en/latest/contributing.html>`_
 in our documentation!


### PR DESCRIPTION
Docs are now hosted on readthedocs.org.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>