### PR TITLE
Add requirements file to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,7 @@ include COPYING
 include COPYING.LESSER
 include createdb.py
 include README.rst
+include requirements.txt
+include dev-requirements.txt
 recursive-include alembic *
 recursive-include systemd *


### PR DESCRIPTION
Since the requirements files are read in the setup.py, they need to be
accessible for an sdist to be installed. This includes them in the
manifest.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>