### PR TITLE
Remove the empty line from dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,6 @@ flake8
 html5lib
 mock
 nose
-
 # Docs requirements
 sphinx
 sqlalchemy_schemadisplay


### PR DESCRIPTION
The little parsing function in setup.py doesn't handle newlines very
well, and distutil gets unhappy if a requirement is an empty string.
This removes the empty line.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>

PS: I'm really sorry for the flurry of tiny PRs