### PR TITLE
Start creating a scoped session object in the models module

### DIFF
--- a/fmn/lib/db.py
+++ b/fmn/lib/db.py
@@ -20,50 +20,68 @@ This module provides a command to configure a database for FMN.
 """
 from __future__ import print_function, unicode_literals
 
-import sys
+import argparse
 
-import fedmsg.config
-import fmn.lib.models
+from fmn.lib import models
+
 
 def main():
     """
     The entry point for the database commands.
     """
-    config = fedmsg.config.load_config()
-    uri = config.get('fmn.sqlalchemy.uri')
-    if not uri:
-        raise ValueError("fmn.sqlalchemy.uri must be present")
+    parser = argparse.ArgumentParser(description='FMN database manager')
+    parser.add_argument(
+        '--create',
+        '-c',
+        dest='create',
+        action='store_true',
+        help='Create the database tables'
+    )
+    parser.add_argument(
+        '--with-dev-data',
+        '-d',
+        dest='dev',
+        action='store_true',
+        help='Add some development sample data'
+    )
+    args = parser.parse_args()
 
-    if '-h' in sys.argv or '--help'in sys.argv:
-        print(sys.argv[0] + " [--with-dev-data]")
-        sys.exit(0)
+    if args.create:
+        models.BASE.metadata.create_all(models.engine)
 
-    session = fmn.lib.models.init(uri, debug=True, create=True)
+    if args.dev:
+        dev_data()
 
-    if '--with-dev-data' in sys.argv:
-        context1 = fmn.lib.models.Context.create(
-            session, name="irc", description="Internet Relay Chat",
-            detail_name="irc nick", icon="user",
-            placeholder="z3r0_c00l",
-        )
-        context2 = fmn.lib.models.Context.create(
-            session, name="email", description="Electronic Mail",
-            detail_name="email address", icon="envelope",
-            placeholder="jane@fedoraproject.org",
-        )
-        context3 = fmn.lib.models.Context.create(
-            session, name="android", description="Google Cloud Messaging",
-            detail_name="registration id", icon="phone",
-            placeholder="laksdjfasdlfkj183097falkfj109f"
-        )
-        context4 = fmn.lib.models.Context.create(
-            session, name="desktop", description="fedmsg-notify",
-            detail_name="None", icon="console",
-            placeholder="There's no need to put a value here"
-        )
-        context5 = fmn.lib.models.Context.create(
-            session, name="sse", description="server sent events",
-            detail_name="None", icon="console",
-            placeholder="There's no need to put a value here"
-        )
-        session.commit()
+
+def dev_data():
+    """
+    Populate the database with some development data
+    """
+    session = models.Session()
+    models.Context.create(
+        session, name="irc", description="Internet Relay Chat",
+        detail_name="irc nick", icon="user",
+        placeholder="z3r0_c00l",
+    )
+    models.Context.create(
+        session, name="email", description="Electronic Mail",
+        detail_name="email address", icon="envelope",
+        placeholder="jane@fedoraproject.org",
+    )
+    models.Context.create(
+        session, name="android", description="Google Cloud Messaging",
+        detail_name="registration id", icon="phone",
+        placeholder="laksdjfasdlfkj183097falkfj109f"
+    )
+    models.Context.create(
+        session, name="desktop", description="fedmsg-notify",
+        detail_name="None", icon="console",
+        placeholder="There's no need to put a value here"
+    )
+    models.Context.create(
+        session, name="sse", description="server sent events",
+        detail_name="None", icon="console",
+        placeholder="There's no need to put a value here"
+    )
+    session.commit()
+    models.Session.remove()

--- a/fmn/tests/lib/test_db.py
+++ b/fmn/tests/lib/test_db.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of the FMN project.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+"""Unit tests for the :mod:`fmn.lib.db` module."""
+
+import unittest
+
+import mock
+
+from fmn.lib import db, models
+from fmn.tests import Base as BaseTestCase
+
+
+class MainTests(BaseTestCase):
+    """Tests for the DB CLI entry point"""
+
+    @mock.patch('sys.argv', ['fmn-createdb'])
+    @mock.patch('fmn.lib.db.dev_data')
+    @mock.patch('fmn.lib.db.models.BASE.metadata.create_all')
+    def test_main_no_create_no_dev_data(self, mock_create, mock_dev_data):
+        """Assert nothing happens without some arguments"""
+        db.main()
+        self.assertEqual(0, mock_create.call_count)
+        self.assertEqual(0, mock_dev_data.call_count)
+
+    @mock.patch('sys.argv', 'fmn-createdb --with-dev-data'.split())
+    @mock.patch('fmn.lib.db.models.BASE.metadata.create_all')
+    def test_main_no_create_dev_data(self, mock_create):
+        """Assert --with-dev-data adds data"""
+        contexts = models.Session.query(models.Context).all()
+        self.assertEqual(0, len(contexts))
+        db.main()
+        self.assertEqual(0, mock_create.call_count)
+        contexts = models.Session.query(models.Context).all()
+        self.assertEqual(5, len(contexts))
+
+    @mock.patch('sys.argv', 'fmn-createdb --create --with-dev-data'.split())
+    @mock.patch('fmn.lib.db.models.BASE.metadata.create_all')
+    def test_main_create_dev_data(self, mock_create):
+        """Assert -c -d creates a db and adds data"""
+        contexts = models.Session.query(models.Context).all()
+        self.assertEqual(0, len(contexts))
+        db.main()
+        mock_create.assert_called_once_with(models.engine)
+        contexts = models.Session.query(models.Context).all()
+        self.assertEqual(5, len(contexts))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/fmn/tests/lib/test_models.py
+++ b/fmn/tests/lib/test_models.py
@@ -1,5 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of the FMN project.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+"""Unit tests for the :mod:`fmn.lib.models` module."""
+
+import unittest
+
+import mock
+
 import fmn.lib.models
 import fmn.tests
+
+
+class TestFMNBase(unittest.TestCase):
+
+    def test_scoped_session(self):
+        """Assert the module creates a scoped session"""
+        session1 = fmn.lib.models.Session()
+        session2 = fmn.lib.models.Session()
+
+        self.assertTrue(session1 is session2)
+
+    @mock.patch('fmn.lib.models.fedmsg.publish')
+    def test_base_has_notify(self, mock_publish):
+        """Assert the model base class has a notify method"""
+        fmn.lib.models.BASE.notify(fmn.lib.models.BASE(), 'jcline', 'email', 'change')
+        mock_publish.assert_called_once_with(
+            topic='base.update',
+            msg={'openid': 'jcline', 'context': 'email', 'changed': 'change'},
+        )
 
 
 class TestBasics(fmn.tests.Base):


### PR DESCRIPTION
Since we load the configuration at module import time anyway, there's no
reason we can't create the database engine at import time as well. The
engine only connects to the database when connect is explicitly called
or something that requires a connection is called[0]. Furthermore, we
can also create the scoped session object.

This adds the ability to create the database to the fmn-createdb script
and stops that from calling ``fmn.lib.models.init``. That function has
been deprecated.

[0] http://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine

Signed-off-by: Jeremy Cline <jeremy@jcline.org>