### PR TITLE
Unify the various preference loading/updating functions

### DIFF
--- a/fmn/lib/models.py
+++ b/fmn/lib/models.py
@@ -59,6 +59,16 @@ Session = scoped_session(sessionmaker(bind=engine))
 
 
 class FMNBase(object):
+    """
+    Base class for the SQLAlchemy model base class.
+
+    Attributes:
+        query (sqlalchemy.orm.query.Query): a class property which produces a
+            Query object against the class and the current Session when called.
+    """
+
+    query = Session.query_property()
+
     def notify(self, openid, context, changed):
         obj = type(self).__name__.lower()
         topic = obj + ".update"

--- a/fmn/tests/__init__.py
+++ b/fmn/tests/__init__.py
@@ -21,6 +21,8 @@ class Base(unittest.TestCase):
         fmn.lib.models.engine = create_engine(DB_PATH, echo=False)
         fmn.lib.models.Session = scoped_session(sessionmaker(bind=fmn.lib.models.engine))
         fmn.lib.models.BASE.metadata.create_all(fmn.lib.models.engine)
+        # Be sure to use the new session on the query property
+        fmn.lib.models.BASE.query = fmn.lib.models.Session.query_property()
         self.sess = fmn.lib.models.Session
 
         self.config = {

--- a/fmn/tests/lib/test_models.py
+++ b/fmn/tests/lib/test_models.py
@@ -20,6 +20,7 @@
 
 import unittest
 
+from sqlalchemy.orm.query import Query
 import mock
 
 import fmn.lib.models
@@ -43,6 +44,11 @@ class TestFMNBase(unittest.TestCase):
             topic='base.update',
             msg={'openid': 'jcline', 'context': 'email', 'changed': 'change'},
         )
+
+    def test_has_query_property(self):
+        """Assert that models inheriting from the base class have a query propery"""
+        pref = fmn.lib.models.Preference()
+        self.assertTrue(isinstance(pref.query, Query))
 
 
 class TestBasics(fmn.tests.Base):

--- a/fmn/tests/test_defaults.py
+++ b/fmn/tests/test_defaults.py
@@ -24,18 +24,16 @@ class TestDefaults(fmn.tests.Base):
 
     def test_defaults_with_detail_value(self):
         self.create_data()
-        preferences = fmn.lib.load_preferences(
-            self.sess, self.config, self.valid_paths)
-        pref = preferences[0]
+        preferences = fmn.lib.load_preferences()
+        pref = preferences['ralph.id.fedoraproject.org_email']
         self.assertEqual(pref['user']['openid'], 'ralph.id.fedoraproject.org')
         self.assertEqual(pref['detail_values'], ['shmalf@fedoraproject.org'])
         self.assertEqual(pref['enabled'], True)
 
     def test_defaults_without_detail_value(self):
         self.create_data()
-        preferences = fmn.lib.load_preferences(
-            self.sess, self.config, self.valid_paths)
-        pref = preferences[1]
+        preferences = fmn.lib.load_preferences()
+        pref = preferences['toshio.id.fedoraproject.org_email']
         self.assertEqual(pref['user']['openid'], 'toshio.id.fedoraproject.org')
         self.assertEqual(pref['detail_values'], [])
         self.assertEqual(pref['enabled'], False)


### PR DESCRIPTION
This is made up of two commits.

The first commit adds a query property to the base SQLAlchemy model.
This allows for the ``ModelClass.query(...)`` pattern rather than
passing the session object around. The query property uses the scoped
session.

The second commit (which relies on the first) unifies the various preference
loading/updating functions Previously there were _three_ different functions
to load preferences and _two_ functions update them. The also used different
(undocumented) formats. This gets rid of two of those loading functions and 
moves the update function into the same module as the last loading function.