### PR TITLE
Update the generic rule for packages to use namespaces

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ flake8
 html5lib
 mock
 nose
+vcrpy
 # Docs requirements
 sphinx
 sqlalchemy_schemadisplay

--- a/fmn/rules/generic.py
+++ b/fmn/rules/generic.py
@@ -94,7 +94,11 @@ def user_package_filter(config, message, fasnick=None, *args, **kw):
             return False
         usr_packages = fmn.rules.utils.get_packages_of_user(
             config, fasnick, all_acls)
-        return usr_packages.intersection(msg_packages)
+        for namespace, packages in usr_packages.items():
+            namespaced_msg_packages = fmn.rules.utils.msg2packages(
+                message, namespace=namespace, **config)
+            if packages.intersection(namespaced_msg_packages):
+                return True
 
     return False
 
@@ -118,7 +122,11 @@ def user_package_commit_filter(config, message, fasnick=None, *args, **kw):
             return False
         usr_packages = fmn.rules.utils.get_packages_of_user(
             config, fasnick, only_commit)
-        return usr_packages.intersection(msg_packages)
+        for namespace, packages in usr_packages.items():
+            namespaced_msg_packages = fmn.rules.utils.msg2packages(
+                message, namespace=namespace, **config)
+            if packages.intersection(namespaced_msg_packages):
+                return True
 
     return False
 
@@ -143,7 +151,11 @@ def user_package_watch_filter(config, message, fasnick=None, *args, **kw):
             return False
         usr_packages = fmn.rules.utils.get_packages_of_user(
             config, fasnick, only_watchcommits)
-        return usr_packages.intersection(msg_packages)
+        for namespace, packages in usr_packages.items():
+            namespaced_msg_packages = fmn.rules.utils.msg2packages(
+                message, namespace=namespace, **config)
+            if packages.intersection(namespaced_msg_packages):
+                return True
 
     return False
 

--- a/fmn/rules/generic.py
+++ b/fmn/rules/generic.py
@@ -52,6 +52,26 @@ def _get_users_of_group(config, group):
     return fmn.rules.utils.get_user_of_group(config, fas, group)
 
 
+def _user_package_intersection(fasnick, message, config, acls):
+    """
+    Returns true if the user has one of the packages mentioned in the message.
+
+    Args:
+        fasnick (str): The user's FAS name.
+        message (dict): The fedmsg that might mention packages.
+        config (dict): The fedmsg configuration dictionary.
+        acls (list): A list of acls use to determine if the user is related to
+            the package (e.g. "watch" "commit", etc).
+    """
+    usr_packages = fmn.rules.utils.get_packages_of_user(
+        config, fasnick, acls)
+    for namespace, packages in usr_packages.items():
+        namespaced_msg_packages = fmn.rules.utils.msg2packages(
+            message, namespace=namespace, **config)
+        if packages.intersection(namespaced_msg_packages):
+            return True
+
+
 @hint(callable=_get_users_of_group)
 def fas_group_member_filter(config, message, group=None, *args, **kw):
     """ Messages regarding any member of a FAS group
@@ -82,24 +102,9 @@ def user_package_filter(config, message, fasnick=None, *args, **kw):
     This rule includes messages that relate to packages where the
     specified user has *either* commit ACLs or the watchcommits flag.
     """
-
     fasnick = kw.get('fasnick', fasnick)
     if fasnick:
-        msg_packages = fmn.rules.utils.msg2packages(message, **config)
-        if not msg_packages:
-            # If the message has no packages associated with it, there's no
-            # way that "one of them" is going to happen to belong to this user,
-            # so let's not waste our time doing the somewhat expensive call out
-            # to pkgdb on the next line to check.
-            return False
-        usr_packages = fmn.rules.utils.get_packages_of_user(
-            config, fasnick, all_acls)
-        for namespace, packages in usr_packages.items():
-            namespaced_msg_packages = fmn.rules.utils.msg2packages(
-                message, namespace=namespace, **config)
-            if packages.intersection(namespaced_msg_packages):
-                return True
-
+        return _user_package_intersection(fasnick, message, config, all_acls)
     return False
 
 only_commit = ['point of contact', 'co-maintained']
@@ -113,21 +118,7 @@ def user_package_commit_filter(config, message, fasnick=None, *args, **kw):
 
     fasnick = kw.get('fasnick', fasnick)
     if fasnick:
-        msg_packages = fmn.rules.utils.msg2packages(message, **config)
-        if not msg_packages:
-            # If the message has no packages associated with it, there's no
-            # way that "one of them" is going to happen to belong to this user,
-            # so let's not waste our time doing the somewhat expensive call out
-            # to pkgdb on the next line to check.
-            return False
-        usr_packages = fmn.rules.utils.get_packages_of_user(
-            config, fasnick, only_commit)
-        for namespace, packages in usr_packages.items():
-            namespaced_msg_packages = fmn.rules.utils.msg2packages(
-                message, namespace=namespace, **config)
-            if packages.intersection(namespaced_msg_packages):
-                return True
-
+        return _user_package_intersection(fasnick, message, config, only_commit)
     return False
 
 
@@ -142,21 +133,7 @@ def user_package_watch_filter(config, message, fasnick=None, *args, **kw):
 
     fasnick = kw.get('fasnick', fasnick)
     if fasnick:
-        msg_packages = fmn.rules.utils.msg2packages(message, **config)
-        if not msg_packages:
-            # If the message has no packages associated with it, there's no
-            # way that "one of them" is going to happen to belong to this user,
-            # so let's not waste our time doing the somewhat expensive call out
-            # to pkgdb on the next line to check.
-            return False
-        usr_packages = fmn.rules.utils.get_packages_of_user(
-            config, fasnick, only_watchcommits)
-        for namespace, packages in usr_packages.items():
-            namespaced_msg_packages = fmn.rules.utils.msg2packages(
-                message, namespace=namespace, **config)
-            if packages.intersection(namespaced_msg_packages):
-                return True
-
+        return _user_package_intersection(fasnick, message, config, only_watchcommits)
     return False
 
 

--- a/fmn/rules/utils.py
+++ b/fmn/rules/utils.py
@@ -264,6 +264,7 @@ def msg2packages(msg, **config):
     if not _cache.is_configured:
         _cache.configure(**config['fmn.rules.cache'])
 
-    key = "|".join(['packages', msg['msg_id']]).encode('utf-8')
+    namespace = config.get('namespace', u'')
+    key = u'|'.join([u'packages', namespace, msg['msg_id']]).encode('utf-8')
     creator = lambda: fedmsg.meta.msg2packages(msg, **config)
     return _cache.get_or_create(key, creator)

--- a/fmn/rules/utils.py
+++ b/fmn/rules/utils.py
@@ -1,5 +1,6 @@
 """ Fedora Notifications pkgdb client """
 
+from collections import defaultdict
 import logging
 import time
 
@@ -134,7 +135,7 @@ def get_packages_of_user(config, username, flags):
     if not _cache.is_configured:
         _cache.configure(**config['fmn.rules.cache'])
 
-    packages = []
+    packages = defaultdict(set)
 
     groups = get_groups_of_user(config, get_fas(config), username)
     owners = [username] + ['group::' + group for group in groups]
@@ -143,9 +144,10 @@ def get_packages_of_user(config, username, flags):
         key = cache_key_generator(get_packages_of_user, owner)
         creator = lambda: _get_pkgdb2_packages_for(config, owner, flags)
         subset = _cache.get_or_create(key, creator)
-        packages.extend(subset)
+        for namespace in subset:
+            packages[namespace].update(subset[namespace])
 
-    return set(packages)
+    return dict(packages)
 
 
 def cache_key_generator(fn, arg):
@@ -161,6 +163,16 @@ def invalidate_cache_for(config, fn, arg):
 
 
 def _get_pkgdb2_packages_for(config, username, flags):
+    """
+    Get the packages a user is associated with from pkgdb2.
+
+    Args:
+        config (dict): The application configuration.
+        username (str): The FAS username to fetch the packages for.
+        flags (list): The type of relationship the user should have to the
+            package (e.g. "watch", "point of contact", etc.). See the pkgdb2
+            API for details.
+    """
     log.debug("Requesting pkgdb2 packages for user %r" % username)
     start = time.time()
 
@@ -173,14 +185,17 @@ def _get_pkgdb2_packages_for(config, username, flags):
 
     if not req.status_code == 200:
         log.debug('URL %s returned code %s', req.url, req.status_code)
-        return set()
+        return {}
 
     data = req.json()
 
+    packages = defaultdict(set)
+
     packages_of_interest = sum([data[flag] for flag in flags], [])
-    packages_of_interest = set([p['name'] for p in packages_of_interest])
+    for package in packages_of_interest:
+        packages[package.get('namespace', 'rpms')].add(package['name'])
     log.debug("done talking with pkgdb2 for now.  %0.2fs", time.time() - start)
-    return packages_of_interest
+    return dict(packages)
 
 
 def get_user_of_group(config, fas, groupname):

--- a/fmn/tests/__init__.py
+++ b/fmn/tests/__init__.py
@@ -3,6 +3,7 @@ import os
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
+import vcr
 
 import fmn.lib.models
 
@@ -24,6 +25,11 @@ class Base(unittest.TestCase):
         # Be sure to use the new session on the query property
         fmn.lib.models.BASE.query = fmn.lib.models.Session.query_property()
         self.sess = fmn.lib.models.Session
+
+        cwd = os.path.dirname(os.path.realpath(__file__))
+        context_manager = vcr.use_cassette(os.path.join(cwd, 'fixtures/', self.id()))
+        self.vcr = context_manager.__enter__()
+        self.addCleanup(context_manager.__exit__)
 
         self.config = {
             'fmn.backends': ['irc', 'email', 'android'],

--- a/fmn/tests/fixtures/fmn.tests.rules.test_generic.UserPackageFilterTests.test_different_namespaces
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_generic.UserPackageFilterTests.test_different_namespaces
@@ -1,0 +1,5256 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.12.5]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/packager/package/remi
+  response:
+    body: {string: !!python/unicode "{\n  \"co-maintained\": [\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"A\
+        \ simple, modern and intuitive unit testing framework for PHP!\\n\\nIt has\
+        \ been designed from the start with the following ideas in mind :\\n* Can\
+        \ be implemented rapidly ;\\n* Simplify test development ;\\n* Allow for writing\
+        \ reliable, readable, and clear unit tests ;\\n\\nTo accomplish that, it massively\
+        \ uses capabilities provided by PHP 5.3,\\nto give the developer a whole new\
+        \ way of writing unit tests.\\nAlso, thanks to its fluid interface, it allows\
+        \ for writing unit tests in\\na fashion close to natural language.\\nIt also\
+        \ makes it easier to implement stubbing within tests, thanks to\\nintelligent\
+        \ uses of anonymous functions and closures.\\natoum natively, and by default,\
+        \ performs the execution of each unit test\\nwithin a separate PHP process,\
+        \ to warrant isolation.\\nOf course, it can be used seamlessly for continuous\
+        \ integration, and given its\\ndesign, it can be made to cope with specific\
+        \ needs extremely easily.\\natoum also accomplishes all of this without affecting\
+        \ performance, since it\\nhas been developed to boast a reduced memory footprint\
+        \ while allowing for\\nhastened test execution.\\nIt can also generate unit\
+        \ test execution reports in the Xunit format,\\nwhich makes it compatible\
+        \ with continuous integration tools such as Jenkins.\\natoum also generates\
+        \ code coverage reports, in order to make it possible\\nto supervise unit\
+        \ tests.\\n\\nOptional dependency:\\n- php-pecl-xdebug for code coverage reports\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"atoum\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"PHP Unit Testing framework\"\
+        ,\n      \"upstream_url\": \"http://atoum.org\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"The\
+        \ gd graphics library allows your code to quickly draw images\\ncomplete with\
+        \ lines, arcs, text, multiple colors, cut and paste from\\nother images, and\
+        \ flood fills, and to write out the result as a PNG or\\nJPEG file. This is\
+        \ particularly useful in Web applications, where PNG\\nand JPEG are two of\
+        \ the formats accepted for inline images by most\\nbrowsers. Note that gd\
+        \ is not a paint program.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"gd\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        A graphics library for quick creation of PNG or JPEG images\",\n      \"upstream_url\"\
+        : \"http://libgd.github.io/\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"Libmcrypt is a thread-safe\
+        \ library providing a uniform interface\\nto access several block and stream\
+        \ encryption algorithms.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"libmcrypt\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Encryption algorithms library\",\n      \"upstream_url\": \"http://mcrypt.sourceforge.net/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"libzip is a C library for reading, creating, and\
+        \ modifying zip archives. Files\\ncan be added from data buffers, files, or\
+        \ compressed data copied directly from\\nother zip archives. Changes made\
+        \ without closing the archive can be reverted.\\nThe API is documented by\
+        \ man pages.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"libzip\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"C library for\
+        \ reading, creating, and modifying zip archives\",\n      \"upstream_url\"\
+        : \"http://www.nih.at/libzip/index.html\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Net::CUPS\
+        \ is an interface to the Common Unix Printing System API.  If you feel\\nan\
+        \ urge to control CUPS servers via Perl, this is a good way to do it :)\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": \"nobuild\",\n   \
+        \   \"name\": \"perl-Net-CUPS\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/232747\",\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Perl bindings to the CUPS C API Interface\"\
+        ,\n      \"upstream_url\": \"http://search.cpan.org/dist/Net-CUPS/\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A PHP implementation for validating JSON structures\
+        \ against a given schema.\\n\\n\\n\\n\\nThis package provides the library\
+        \ version 1.\\nThe php-justinrainbow-json-schema package provides the library\
+        \ version 2\\nand the validate-json command.\\n\\nSee http://json-schema.org\
+        \ for more details.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"php-JsonSchema\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"PHP implementation of JSON schema\",\n      \"upstream_url\"\
+        : \"https://github.com/justinrainbow/json-schema\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Full Featured Email Transfer Class for PHP. PHPMailer features:\\n\\n\
+        \    * Supports emails digitally signed with S/MIME encryption!\\n    * Supports\
+        \ emails with multiple TOs, CCs, BCCs and REPLY-TOs\\n    * Works on any platform.\\\
+        n    * Supports Text & HTML emails.\\n    * Embedded image support.\\n   \
+        \ * Multipart/alternative emails for mail clients that do not read\\n    \
+        \  HTML email.\\n    * Flexible debugging.\\n    * Custom mail headers.\\\
+        n    * Redundant SMTP servers.\\n    * Support for 8bit, base64, binary, and\
+        \ quoted-printable encoding.\\n    * Word wrap.\\n    * Multiple fs, string,\
+        \ and binary attachments (those from database,\\n      string, etc).\\n  \
+        \  * SMTP authentication.\\n    * Tested on multiple SMTP servers: Sendmail,\
+        \ qmail, Postfix, Gmail,\\n      Imail, Exchange, etc.\\n    * Good documentation,\
+        \ many examples included in download.\\n    * It's swift, small, and simple.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-PHPMailer\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"PHP email transport\
+        \ class with a lot of features\",\n      \"upstream_url\": \"https://github.com/PHPMailer/PHPMailer\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A PHP parser written in PHP to simplify static analysis\
+        \ and code manipulation.\\n\\n\\n\\n\\nThis package provides the library version\
+        \ 1.\\nThe php-nikic-php-parser package provides the library version 2\\nand\
+        \ the  php-parse command.\\n\\nAutoloader: '/usr/share/php/PhpParser/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"php-PHPParser\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A PHP parser\
+        \ written in PHP\",\n      \"upstream_url\": \"https://github.com/nikic/PHP-Parser\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package holds all interfaces/classes/traits\
+        \ related to PSR-3 [1].\\n\\nNote that this is not a logger of its own. It\
+        \ is merely an interface that\\ndescribes a logger. See the specification\
+        \ for more details.\\n\\n[1] http://www.php-fig.org/psr/psr-3/\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"php-PsrLog\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Common interface for logging libraries\"\
+        ,\n      \"upstream_url\": \"http://www.php-fig.org/psr/psr-3/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Extending the art & spirit of PHP, Zend Framework is\
+        \ based on simplicity,\\nobject-oriented best practices, corporate friendly\
+        \ licensing, and a rigorously\\ntested agile code base. Zend Framework is\
+        \ focused on building more secure,\\nreliable, and modern Web 2.0 applications\
+        \ & web services, and consuming widely\\navailable APIs from leading vendors\
+        \ like Google, Amazon, Yahoo!, Flickr, as\\nwell as API providers and catalogers\
+        \ like StrikeIron and ProgrammableWeb.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-ZendFramework\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Leading open-source PHP framework\"\
+        ,\n      \"upstream_url\": \"http://framework.zend.com/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Zend Framework 2 is an open source framework for developing web applications\\\
+        nand services using PHP 5.3+. Zend Framework 2 uses 100% object-oriented code\\\
+        nand utilizes most of the new features of PHP 5.3, namely namespaces, late\\\
+        nstatic binding, lambda functions and closures.\\n\\nZend Framework 2 evolved\
+        \ from Zend Framework 1, a successful PHP framework\\nwith over 15 million\
+        \ downloads.\\n\\nNote: This meta package installs all base Zend Framework\
+        \ component packages\\n(Authentication, Barcode, Cache, Captcha, Code, Config,\
+        \ Console, Crypt, Db,\\nDebug, Di, Dom, Escaper, EventManager, Feed, File,\
+        \ Filter, Form, Http, I18n,\\nInputFilter, Json, Ldap, Loader, Log, Mail,\
+        \ Math, Memory, Mime, ModuleManager,\\nMvc, Navigation, Paginator, Permissions-Acl,\
+        \ Permissions-Rbac, ProgressBar,\\nSerializer, Server, ServiceManager, Session,\
+        \ Soap, Stdlib, Tag, Test, Text,\\nUri, Validator, Version, View, XmlRpc)\
+        \ except the optional Cache-apc and\\nCache-memcached packages.\",\n     \
+        \ \"koschei_monitor\": false,\n      \"monitor\": \"nobuild\",\n      \"name\"\
+        : \"php-ZendFramework2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework\
+        \ 2\",\n      \"upstream_url\": \"http://framework.zend.com\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"This package adds the pear.horde.org channel which allows\
+        \ PEAR packages\\nfrom this channel to be installed.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-channel-horde\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Adds pear.horde.org channel to PEAR\"\
+        ,\n      \"upstream_url\": \"http://pear.horde.org/\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This package adds the PHP Depend PEAR channe which allows\\nPEAR packages\
+        \ from this channel to be installed.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-channel-pdepend\",\n   \
+        \   \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PHP Depend PEAR channel\",\n      \"\
+        upstream_url\": \"http://www.pdepend.org/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ package adds the PHP Mess Detector PEAR channel which allows\\nPEAR packages\
+        \ from this channel to be installed.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-channel-phpmd\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PHP Mess Detector PEAR channel\",\n\
+        \      \"upstream_url\": \"http://www.phpmd.org/\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1451927659.0,\n      \"description\"\
+        : \"container-interop tries to identify and standardize features in container\\\
+        nobjects (service locators, dependency injection containers, etc.) to achieve\\\
+        ninteropererability.\\n\\nThrough discussions and trials, we try to create\
+        \ a standard, made of common\\ninterfaces but also recommendations.\\n\\nIf\
+        \ PHP projects that provide container implementations begin to adopt these\\\
+        ncommon standards, then PHP applications and projects that use containers\
+        \ can\\ndepend on the common interfaces instead of specific implementations.\
+        \ This\\nfacilitates a high-level of interoperability and flexibility that\
+        \ allows users\\nto consume any container implementation that can be adapted\
+        \ to these interfaces.\\n\\nThe work done in this project is not officially\
+        \ endorsed by the PHP-FIG [1],\\nbut it is being worked on by members of PHP-FIG\
+        \ and other good developers. We\\nadhere to the spirit and ideals of PHP-FIG,\
+        \ and hope this project will pave the\\nway for one or more future PSRs.\\\
+        n\\nAutoloader: /usr/share/php/Interop/Container/autoload.php\\n\\n[1] http://www.php-fig.org/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": \"nobuild\",\n   \
+        \   \"name\": \"php-container-interop\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/1295255\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Promoting the interoperability\
+        \ of container objects (DIC, SL, etc.)\",\n      \"upstream_url\": \"https://github.com/container-interop/container-interop\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Mockery is a simple but flexible PHP mock object\
+        \ framework for use in unit\\ntesting. It is inspired by Ruby's flexmock and\
+        \ Java's Mockito, borrowing\\nelements from both of their APIs.\\n\\nTo use\
+        \ this library, you just have to add, in your project:\\n  require_once '/usr/share/php/Mockery/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"php-deepend-Mockery\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Mockery is\
+        \ a simple but flexible PHP mock object framework\",\n      \"upstream_url\"\
+        : \"https://github.com/padraic/mockery\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"PHP is an\
+        \ HTML-embedded scripting language.\\n\\nThis package contains various additional\
+        \ modules for PHP, which\\nhave not been included in the basic PHP package\
+        \ for Fedora Core.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-extras\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Additional PHP modules from the standard PHP distribution\",\n      \"\
+        upstream_url\": \"http://www.php.net/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1476966055.0,\n      \"description\": \"Static PSR-4\
+        \ [1], PSR-0 [2], and classmap autoloader.  Includes loader for\\nrequired\
+        \ and optional dependencies.\\n\\n[1] http://www.php-fig.org/psr/psr-4/\\\
+        n[2] http://www.php-fig.org/psr/psr-0/\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": \"nobuild\",\n      \"name\": \"php-fedora-autoloader\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1386735\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fedora Autoloader\"\
+        ,\n      \"upstream_url\": \"https://github.com/php-fedora/autoloader\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"JSON Lint for PHP.\\n\\nThis library is a port of\
+        \ the JavaScript jsonlint\\n(https://github.com/zaach/jsonlint) library.\\\
+        n\\nBin: /usr/bin/jsonlint-php [1]\\nAutoloader: /usr/share/php/Seld/JsonLint/autoload.php\\\
+        n\\n[1] Package python2-demjson installs /usr/bin/jsonlint so this package's\
+        \ bin\\n    script has been renamed to /usr/bin/jsonlint-php\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": \"nobuild\",\n      \"name\"\
+        : \"php-jsonlint\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"JSON Lint for\
+        \ PHP\",\n      \"upstream_url\": \"https://github.com/Seldaek/jsonlint\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1415189375.0,\n\
+        \      \"description\": \"A set of code generator utilities built on top of\
+        \ PHP-Parsers that ease its use\\nwhen combined with Reflection.\\n\\nAutoloader:\
+        \ /usr/share/php/CodeGenerationUtils/autoload.php\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"php-ocramius-code-generator-utils\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1157700\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A set of code generator\
+        \ utilities built on top of PHP-Parsers\",\n      \"upstream_url\": \"https://github.com/Ocramius/CodeGenerationUtils\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1417005299.0,\n\
+        \      \"description\": \"GeneratedHydrator is a library about high performance\
+        \ transition of data from\\narrays to objects and from objects to arrays.\\\
+        n\\nAutoloader: /usr/share/php/GeneratedHydrator/autoload.php\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"php-ocramius-generated-hydrator\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1157708\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An object hydrator\"\
+        ,\n      \"upstream_url\": \"https://github.com/Ocramius/GeneratedHydrator\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHP_Depend is an adaption of the established Java\
+        \ development tool JDepend.\\nThis tool shows you the quality of your design\
+        \ in the terms of extensibility,\\nreusability and maintainability.\",\n \
+        \     \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pdepend-PHP-Depend\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"PHP_Depend\
+        \ design quality metrics for PHP package\",\n      \"upstream_url\": \"http://pdepend.org/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"DB is a database abstraction layer providing:\\\
+        n* an OO-style query API\\n* portability features that make programs written\
+        \ for one DBMS work with\\n  other DBMS's\\n* a DSN (data source name) format\
+        \ for specifying database servers\\n* prepare/execute (bind) emulation for\
+        \ databases that don't support it natively\\n* a result object for each query\
+        \ response\\n* portable error codes\\n* sequence emulation\\n* sequential\
+        \ and non-sequential row fetching as well as bulk fetching\\n* formats fetched\
+        \ rows as associative arrays, ordered arrays or objects\\n* row limit support\\\
+        n* transactions support\\n* table information interface\\n* DocBook and phpDocumentor\
+        \ API documentation\\n\\nDB layers itself on top of PHP's existing database\
+        \ extensions.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"php-pear-DB\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        PEAR: Database Abstraction Layer\",\n      \"upstream_url\": \"http://pear.php.net/package/DB\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This command is an improved implementation of the\
+        \ standard PEAR \\\"makerpm\\\"\\ncommand, and contains several enhancements\
+        \ that make it far more flexible.\\nSimilar functions for other external packaging\
+        \ mechanisms may be added at\\na later date.\\n\\nThis package generate spec\
+        \ file closed to fedora PHP Guidelines:\\nhttp://fedoraproject.org/wiki/Packaging:PHP\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pear-PEAR-Command-Packaging\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Create RPM spec files from PEAR modules\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/PEAR_Command_Packaging\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"APC is a free, open, and robust framework for caching and optimizing PHP\\\
+        nintermediate code.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pecl-apc\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"APC caches and optimizes PHP intermediate code\",\n      \"upstream_url\"\
+        : \"http://pecl.php.net/package/APC\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"PECL cairo\
+        \ is the official Cairo Graphics Library binding. It provides an\\nobject\
+        \ oriented and procedural interface for the cairo library. Support is\\ncurrently\
+        \ provided for 1.4 to 1.8 versions of the library\\n(1.10 is partially supported).\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pecl-cairo\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"PECL package\
+        \ for drawing using cairo via PHP scripts\",\n      \"upstream_url\": \"http://www.cairographics.org/cairo-php/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This extension uses libgearman library to provide\
+        \ API for\\ncommunicating with gearmand, and writing clients and workers\\\
+        n\\nDocumentation: http://php.net/gearman\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pecl-gearman\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"PHP wrapper to libgearman\",\n      \"upstream_url\"\
+        : \"https://github.com/wcgallego/pecl-gearman\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"OAuth\
+        \ is an authorization protocol built on top of HTTP which allows\\napplications\
+        \ to securely access data without having to store\\nuser names and passwords.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"php-pecl-oauth\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"PHP OAuth consumer\
+        \ extension\",\n      \"upstream_url\": \"http://pecl.php.net/package/oauth\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This extension provides PHP bindings for libsphinxclient,\\\
+        nclient library for Sphinx the SQL full-text search engine.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-pecl-sphinx\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PECL extension for Sphinx SQL full-text\
+        \ search engine\",\n      \"upstream_url\": \"http://pecl.php.net/package/sphinx\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Bindings to the functions of libssh2 which implements\
+        \ the SSH2 protocol.\\nlibssh2 is available from http://www.sourceforge.net/projects/libssh2\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pecl-ssh2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Bindings for\
+        \ the libssh2 library\",\n      \"upstream_url\": \"http://pecl.php.net/package/ssh2\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is the project site of PHPMD. It is a spin-off\
+        \ project of PHP Depend\\nand aims to be a PHP equivalent of the well known\
+        \ Java tool PMD. PHPMD can\\nbe seen as an user friendly front-end application\
+        \ for the raw metrics\\nstream measured by PHP Depend.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"php-phpmd-PHP-PMD\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PHPMD - PHP Mess Detector\",\n     \
+        \ \"upstream_url\": \"http://phpmd.org/\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1441668211.0,\n      \"description\": \"MIT-licensed\
+        \ pure-PHP implementations of an arbitrary-precision integer\\narithmetic\
+        \ library, fully PKCS#1 (v2.1) compliant RSA, DES, 3DES, RC4,\\nRijndael,\
+        \ AES, Blowfish, Twofish, SSH-1, SSH-2, SFTP, and X.509\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"php-phpseclib\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1258111\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"PHP Secure Communications\
+        \ Library\",\n      \"upstream_url\": \"https://github.com/phpseclib/phpseclib\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Bytekit is a PHP extension that provides userspace\
+        \ access to the opcodes\\ngenerated by PHP's compiler.\\n\\nbytekit-cli is\
+        \ a command-line tool that leverages Bytekit to perform common code\\nanalysis\
+        \ tasks.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"php-phpunit-bytekit\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"A command-line tool built on the PHP Bytekit extension\",\n      \"upstream_url\"\
+        : \"https://github.com/sebastianbergmann/bytekit-cli\"\n    },\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"phpcpd is a Copy/Paste Detector (CPD) for PHP code.\\n\\nThe goal of phpcpd\
+        \ is not not to replace more sophisticated tools such as phpcs,\\npdepend,\
+        \ or phpmd, but rather to provide an alternative to them when you just\\nneed\
+        \ to get a quick overview of duplicated code in a project.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"php-phpunit-phpcpd\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Copy/Paste Detector (CPD) for PHP code\"\
+        ,\n      \"upstream_url\": \"https://github.com/sebastianbergmann/phpcpd\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"phploc is a tool for quickly measuring the size\
+        \ of a PHP project.\\n\\nThe goal of phploc is not not to replace more sophisticated\
+        \ tools such as phpcs,\\npdepend, or phpmd, but rather to provide an alternative\
+        \ to them when you just\\nneed to get a quick understanding of a project's\
+        \ size.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n \
+        \     \"name\": \"php-phpunit-phploc\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"A tool for quickly measuring the size of a PHP project\",\n      \"upstream_url\"\
+        : \"https://github.com/sebastianbergmann/phploc\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"SabreDAV VObject plugin.\",\n      \"koschei_monitor\": false,\n     \
+        \ \"monitor\": false,\n      \"name\": \"php-sabredav-Sabre_VObject\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An intuitive reader for iCalendar and\
+        \ vCard objects\",\n      \"upstream_url\": \"http://sabre.io/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"\\nSwift Mailer integrates into any web app written\
+        \ in PHP 5, offering a\\nflexible and elegant object-oriented approach to\
+        \ sending emails with\\na multitude of features.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"php-swift-Swift\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Free Feature-rich PHP Mailer\",\n  \
+        \    \"upstream_url\": \"http://www.swiftmailer.org/\"\n    },\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"PHP framework for web projects\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"php-symfony\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"PHP framework for web projects\",\n      \"upstream_url\"\
+        : \"http://symfony.com\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\"\
+        : 1400070978.0,\n      \"description\": \"Contains data of the ICU library.\\\
+        n\\nYou should not directly use this component. Use it through the API of\
+        \ the\\nSymfony Intl component instead.\\n\\nNOTE: This package requires the\
+        \ Symfony Intl package (>= 2.3, < 3.0)\\n      but does not explicitly require\
+        \ it to prevent a circular dependency.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"php-symfony-icu\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Symfony Icu Component\",\n      \"upstream_url\"\
+        : \"https://github.com/symfony/Icu\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1464125957.0,\n      \"description\": \"Symfony\
+        \ Security Component - ACL (Access Control List).\\n\\nAutoloader: /usr/share/php/Symfony/Component/Security/Acl/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"php-symfony-security-acl\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1336872\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Symfony Security Component - ACL (Access\
+        \ Control List)\",\n      \"upstream_url\": \"https://github.com/symfony/security-acl\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490726864.0,\n\
+        \      \"description\": \"Symfony PHP framework (version 3).\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": \"nobuild\",\n      \"name\"\
+        : \"php-symfony3\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1431298\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Symfony PHP framework (version 3)\",\n      \"upstream_url\"\
+        : \"http://symfony.com\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\"\
+        : 1409054578.0,\n      \"description\": \"The flexible, fast, and secure template\
+        \ engine for PHP.\\n\\n* Fast: Twig compiles templates down to plain optimized\
+        \ PHP code. The\\n  overhead compared to regular PHP code was reduced to the\
+        \ very minimum.\\n\\n* Secure: Twig has a sandbox mode to evaluate untrusted\
+        \ template code. This\\n  allows Twig to be used as a template language for\
+        \ applications where users\\n  may modify the template design.\\n\\n* Flexible:\
+        \ Twig is powered by a flexible lexer and parser. This allows the\\n  developer\
+        \ to define its own custom tags and filters, and create its own\\n  DSL.\\\
+        n\\nAutoloader: /usr/share/php/Twig/autoload.php\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": \"nobuild\",\n      \"name\": \"php-twig\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1118528\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"The flexible, fast,\
+        \ and secure template engine for PHP\",\n      \"upstream_url\": \"http://twig.sensiolabs.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"phpMyAdmin is a tool written in PHP intended to\
+        \ handle the administration of\\nMySQL over the World Wide Web. Most frequently\
+        \ used operations are supported\\nby the user interface (managing databases,\
+        \ tables, fields, relations, indexes,\\nusers, permissions), while you still\
+        \ have the ability to directly execute any\\nSQL statement.\\n\\nFeatures\
+        \ include an intuitive web interface, support for most MySQL features\\n(browse\
+        \ and drop databases, tables, views, fields and indexes, create, copy,\\ndrop,\
+        \ rename and alter databases, tables, fields and indexes, maintenance\\nserver,\
+        \ databases and tables, with proposals on server configuration, execute,\\\
+        nedit and bookmark any SQL-statement, even batch-queries, manage MySQL users\\\
+        nand privileges, manage stored procedures and triggers), import data from\
+        \ CSV\\nand SQL, export data to various formats: CSV, SQL, XML, PDF, OpenDocument\
+        \ Text\\nand Spreadsheet, Word, Excel, LATEX and others, administering multiple\
+        \ servers,\\ncreating PDF graphics of your database layout, creating complex\
+        \ queries using\\nQuery-by-example (QBE), searching globally in a database\
+        \ or a subset of it,\\ntransforming stored data into any format using a set\
+        \ of predefined functions,\\nlike displaying BLOB-data as image or download-link\
+        \ and much more...\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"phpMyAdmin\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Handle the administration of MySQL over the World Wide Web\",\n      \"\
+        upstream_url\": \"https://www.phpmyadmin.net/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1411069262.0,\n      \"description\": \"phpMyAdmin\
+        \ is a tool written in PHP intended to handle the administration of\\nMySQL\
+        \ over the World Wide Web. Most frequently used operations are supported\\\
+        nby the user interface (managing databases, tables, fields, relations, indexes,\\\
+        nusers, permissions), while you still have the ability to directly execute\
+        \ any\\nSQL statement.\\n\\nFeatures include an intuitive web interface, support\
+        \ for most MySQL features\\n(browse and drop databases, tables, views, fields\
+        \ and indexes, create, copy,\\ndrop, rename and alter databases, tables, fields\
+        \ and indexes, maintenance\\nserver, databases and tables, with proposals\
+        \ on server configuration, execute,\\nedit and bookmark any SQL-statement,\
+        \ even batch-queries, manage MySQL users\\nand privileges, manage stored procedures\
+        \ and triggers), import data from CSV\\nand SQL, export data to various formats:\
+        \ CSV, SQL, XML, PDF, OpenDocument Text\\nand Spreadsheet, Word, Excel, LATEX\
+        \ and others, administering multiple servers,\\ncreating PDF graphics of your\
+        \ database layout, creating complex queries using\\nQuery-by-example (QBE),\
+        \ searching globally in a database or a subset of it,\\ntransforming stored\
+        \ data into any format using a set of predefined functions,\\nlike displaying\
+        \ BLOB-data as image or download-link and much more...\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"phpMyAdmin4\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1121355\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Handle the administration\
+        \ of MySQL over the World Wide Web\",\n      \"upstream_url\": \"https://www.phpmyadmin.net/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The uw-imap package provides UW server daemons for\
+        \ both the IMAP (Internet\\nMessage Access Protocol) and POP (Post Office\
+        \ Protocol) mail access\\nprotocols.  The POP protocol uses a \\\"post office\\\
+        \" machine to collect\\nmail for users and allows users to download their\
+        \ mail to their local\\nmachine for reading. The IMAP protocol allows a user\
+        \ to read mail on a\\nremote machine without downloading it to their local\
+        \ machine.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"uw-imap\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"UW Server daemons\
+        \ for IMAP and POP network mail protocols\",\n      \"upstream_url\": \"http://www.washington.edu/imap/\"\
+        \n    }\n  ],\n  \"output\": \"ok\",\n  \"point of contact\": [\n    {\n \
+        \     \"acls\": [],\n      \"creation_date\": 1460670291.0,\n      \"description\"\
+        : \"Smart and Readable Documentation for your PHP project.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"apigen\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1277504\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"PHP source code API\
+        \ generator\",\n      \"upstream_url\": \"http://www.apigen.org/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"A simple, modern and intuitive unit testing framework\
+        \ for PHP!\\n\\nIt has been designed from the start with the following ideas\
+        \ in mind :\\n* Can be implemented rapidly ;\\n* Simplify test development\
+        \ ;\\n* Allow for writing reliable, readable, and clear unit tests ;\\n\\\
+        nTo accomplish that, it massively uses capabilities provided by PHP 5.3,\\\
+        nto give the developer a whole new way of writing unit tests.\\nAlso, thanks\
+        \ to its fluid interface, it allows for writing unit tests in\\na fashion\
+        \ close to natural language.\\nIt also makes it easier to implement stubbing\
+        \ within tests, thanks to\\nintelligent uses of anonymous functions and closures.\\\
+        natoum natively, and by default, performs the execution of each unit test\\\
+        nwithin a separate PHP process, to warrant isolation.\\nOf course, it can\
+        \ be used seamlessly for continuous integration, and given its\\ndesign, it\
+        \ can be made to cope with specific needs extremely easily.\\natoum also accomplishes\
+        \ all of this without affecting performance, since it\\nhas been developed\
+        \ to boast a reduced memory footprint while allowing for\\nhastened test execution.\\\
+        nIt can also generate unit test execution reports in the Xunit format,\\nwhich\
+        \ makes it compatible with continuous integration tools such as Jenkins.\\\
+        natoum also generates code coverage reports, in order to make it possible\\\
+        nto supervise unit tests.\\n\\nOptional dependency:\\n- php-pecl-xdebug for\
+        \ code coverage reports\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"atoum\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"PHP Unit Testing framework\",\n      \"upstream_url\": \"http://atoum.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1434981816.0,\n\
+        \      \"description\": \"Composer helps you declare, manage and install dependencies\
+        \ of PHP projects,\\nensuring you have the right stack everywhere.\\n\\nDocumentation:\
+        \ https://getcomposer.org/doc/\",\n      \"koschei_monitor\": true,\n    \
+        \  \"monitor\": true,\n      \"name\": \"composer\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1225134\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Dependency Manager\
+        \ for PHP\",\n      \"upstream_url\": \"https://getcomposer.org/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"This is a XML diff and merge package. It consists of\
+        \ a shared library and\\ntwo utilities: dm and dm-merge.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"diffmark\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"XML diff and merge\",\n      \"upstream_url\"\
+        : \"http://www.mangrove.cz/diffmark/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1410178944.0,\n      \"description\": \"FastLZ is\
+        \ a lossless data compression library designed for real-time\\ncompression\
+        \ and decompression. It favors speed over compression ratio.\\nDecompression\
+        \ requires no memory. Decompression algorithm is very simple,\\nand thus extremely\
+        \ fast.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"fastlz\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1138898\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Portable real-time compression library\",\n      \"\
+        upstream_url\": \"http://fastlz.org/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"GLPI is\
+        \ the Information Resource-Manager with an additional Administration-\\nInterface.\
+        \ You can use it to build up a database with an inventory for your\\ncompany\
+        \ (computer, software, printers...). It has enhanced functions to make\\nthe\
+        \ daily life for the administrators easier, like a job-tracking-system with\\\
+        nmail-notification and methods to build a database with basic information\\\
+        nabout your network-topology.\",\n      \"koschei_monitor\": true,\n     \
+        \ \"monitor\": false,\n      \"name\": \"glpi\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n  \
+        \    \"summary\": \"Free IT asset management software\",\n      \"upstream_url\"\
+        : \"http://www.glpi-project.org/\"\n    },\n    {\n      \"acls\": [],\n \
+        \     \"creation_date\": 1400070978.0,\n      \"description\": \"Jukebox for\
+        \ large collections of music files\\nUses gstreamer, mpg321/ogg123/flac123\
+        \  or mplayer for playback\\nMain features :\\n- customizable window layouts\\\
+        n- artist/album lock : easily restrict playlist to current artist/album\\\
+        n- easy access to related songs (same artist/album/title)\\n- simple mass-tagging\
+        \ and mass-renaming\\n- support multiple genres for each song\\n- customizable\
+        \ labels can be set for each song\\n- filters with unlimited nesting of conditions\\\
+        n- customizable weighted random mode\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"gmusicbrowser\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Jukebox for large collections of music files\",\n  \
+        \    \"upstream_url\": \"http://gmusicbrowser.org/\"\n    },\n    {\n    \
+        \  \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"libmemcached is a C/C++ client library and tools for the memcached server\\\
+        n(http://memcached.org/). It has been designed to be light on memory\\nusage,\
+        \ and provide full access to server side methods.\\n\\nIt also implements\
+        \ several command line tools:\\n\\nmemaslap    Load testing and benchmarking\
+        \ a server\\nmemcapable  Checking a Memcached server capibilities and compatibility\\\
+        nmemcat      Copy the value of a key to standard output\\nmemcp       Copy\
+        \ data to a server\\nmemdump     Dumping your server\\nmemerror    Translate\
+        \ an error code to a string\\nmemexist    Check for the existance of a key\\\
+        nmemflush    Flush the contents of your servers\\nmemparse    Parse an option\
+        \ string\\nmemping     Test to see if a server is available.\\nmemrm     \
+        \  Remove a key(s) from the server\\nmemslap     Generate testing loads on\
+        \ a memcached cluster\\nmemstat     Dump the stats of your servers to standard\
+        \ output\\nmemtouch    Touches a key\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"libmemcached\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Client library and command line tools for memcached\
+        \ server\",\n      \"upstream_url\": \"http://libmemcached.org/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"This is a C-language AMQP client library for use with\
+        \ AMQP servers\\nspeaking protocol versions 0-9-1.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"librabbitmq\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Client library for AMQP\",\n      \"\
+        upstream_url\": \"https://github.com/alanxz/rabbitmq-c\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Sodium is a new, easy-to-use software library for encryption, decryption,\\\
+        nsignatures, password hashing and more. It is a portable, cross-compilable,\\\
+        ninstallable, packageable fork of NaCl, with a compatible API, and an extended\\\
+        nAPI to improve usability even further. Its goal is to provide all of the\
+        \ core\\noperations needed to build higher-level cryptographic tools. The\
+        \ design\\nchoices emphasize security, and \\\"magic constants\\\" have clear\
+        \ rationales.\\n\\nThe same cannot be said of NIST curves, where the specific\
+        \ origins of certain\\nconstants are not described by the standards. And despite\
+        \ the emphasis on\\nhigher security, primitives are faster across-the-board\
+        \ than most\\nimplementations of the NIST standards.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"libsodium\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"The Sodium crypto library\",\n      \"upstream_url\"\
+        : \"http://libsodium.org/\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1463495018.0,\n      \"description\": \"mongo-c-driver is\
+        \ a client library written in C for MongoDB.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"mongo-c-driver\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1312939\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Client library written\
+        \ in C for MongoDB\",\n      \"upstream_url\": \"https://github.com/mongodb/mongo-c-driver\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"MySQL Connector/C++ is a MySQL database connector\
+        \ for C++.\\n\\nThe MySQL Driver for C++ mimics the JDBC 4.0 API.\\nHowever,\
+        \ Connector/C++ does not implement all of the JDBC 4.0 API.\\n\\nThe Connector/C++\
+        \ preview features the following classes:\\n* Connection\\n* DatabaseMetaData\\\
+        n* Driver\\n* PreparedStatement\\n* ResultSet\\n* ResultSetMetaData\\n* Savepoint\\\
+        n* Statement\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"mysql-connector-c++\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"MySQL database connector for C++\",\n      \"upstream_url\": \"http://dev.mysql.com/downloads/connector/cpp/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1426785953.0,\n\
+        \      \"description\": \"GStreamer1 implements a framework that allows for\
+        \ processing and encoding\\nof multimedia sources in a manner similar to a\
+        \ shell pipeline.\\n\\nThis package provides the perl language bindings.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"perl-GStreamer1\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1203610\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Bindings for GStreamer 1.x\",\n      \"upstream_url\"\
+        : \"http://search.cpan.org/dist/GStreamer1/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1410783618.0,\n      \"description\": \"Perl\
+        \ extension for libappindicator.\",\n      \"koschei_monitor\": true,\n  \
+        \    \"monitor\": false,\n      \"name\": \"perl-Gtk2-AppIndicator\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1138980\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Perl extension for\
+        \ libappindicator\",\n      \"upstream_url\": \"http://search.cpan.org/dist/Gtk2-AppIndicator/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"WebKit is a web content engine, derived from KHTML\
+        \ and KJS from KDE, and\\nused primarily in Apple's Safari browser. It is\
+        \ made to be embedded in\\nother applications, such as mail readers, or web\
+        \ browsers.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"perl-Gtk2-WebKit\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/728296\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Web content engine library for Gtk2\"\
+        ,\n      \"upstream_url\": \"http://search.cpan.org/dist/Gtk2-WebKit/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHP is an HTML-embedded scripting language. PHP\
+        \ attempts to make it\\neasy for developers to write dynamically generated\
+        \ web pages. PHP also\\noffers built-in database integration for several commercial\
+        \ and\\nnon-commercial database management systems, so writing a\\ndatabase-enabled\
+        \ webpage with PHP is fairly simple. The most common\\nuse of PHP coding is\
+        \ probably as a replacement for CGI scripts.\\n\\nThe php package contains\
+        \ the module (often referred to as mod_php)\\nwhich adds support for the PHP\
+        \ language to Apache HTTP Server.\",\n      \"koschei_monitor\": true,\n \
+        \     \"monitor\": false,\n      \"name\": \"php\",\n      \"namespace\":\
+        \ \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"PHP scripting language for creating dynamic web sites\"\
+        ,\n      \"upstream_url\": \"http://www.php.net/\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"PHP CSS Parser: a Parser for CSS Files written in PHP.\\nAllows extraction\
+        \ of CSS files into a data structure, manipulation\\nof said structure and\
+        \ output as (optimized) CSS.\\n\\nAutoloader: /usr/share/php/Sabberworm/CSS/autoload.php\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-PHP-CSS-Parser\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        A Parser for CSS Files\",\n      \"upstream_url\": \"https://github.com/sabberworm/PHP-CSS-Parser\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Full Featured Email Transfer Class for PHP. PHPMailer\
+        \ features:\\n\\n    * Supports emails digitally signed with S/MIME encryption!\\\
+        n    * Supports emails with multiple TOs, CCs, BCCs and REPLY-TOs\\n    *\
+        \ Works on any platform.\\n    * Supports Text & HTML emails.\\n    * Embedded\
+        \ image support.\\n    * Multipart/alternative emails for mail clients that\
+        \ do not read\\n      HTML email.\\n    * Flexible debugging.\\n    * Custom\
+        \ mail headers.\\n    * Redundant SMTP servers.\\n    * Support for 8bit,\
+        \ base64, binary, and quoted-printable encoding.\\n    * Word wrap.\\n   \
+        \ * Multiple fs, string, and binary attachments (those from database,\\n \
+        \     string, etc).\\n    * SMTP authentication.\\n    * Tested on multiple\
+        \ SMTP servers: Sendmail, qmail, Postfix, Gmail,\\n      Imail, Exchange,\
+        \ etc.\\n    * Good documentation, many examples included in download.\\n\
+        \    * It's swift, small, and simple.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-PHPMailer\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"PHP email transport class with a lot of features\",\n\
+        \      \"upstream_url\": \"https://github.com/PHPMailer/PHPMailer\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1469711854.0,\n    \
+        \  \"description\": \"The Mongo PHP Adapter is a userland library designed\
+        \ to act as an\\nadapter between applications relying on ext-mongo and the\
+        \ new driver\\n(ext-mongodb).\\n\\nIt provides the API of ext-mongo built\
+        \ on top of mongo-php-library,\\nthus being compatible with PHP 7.\\n\\nAutoloader:\
+        \ /usr/share/php/Alcaeus/MongoDbAdapter/autoload.php\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-alcaeus-mongo-php-adapter\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1347147\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Mongo PHP Adapter\"\
+        ,\n      \"upstream_url\": \"https://github.com/alcaeus/mongo-php-adapter\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1432234921.0,\n\
+        \      \"description\": \"This library emulates the PHP reflection model using\
+        \ the tokenized PHP source.\\n\\nAutoloader: /usr/share/php/TokenReflection/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"php-andrewsville-php-token-reflection\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1207591\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Library emulating the PHP internal\
+        \ reflection\",\n      \"upstream_url\": \"https://github.com/Andrewsville/PHP-Token-Reflection\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1447683066.0,\n\
+        \      \"description\": \"Twitter Bootstrap Theme for Apigen.\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\": \"php-apigen-theme-bootstrap\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1277497\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Twitter Bootstrap\
+        \ Theme for Apigen\",\n      \"upstream_url\": \"http://www.apigen.org/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1447683614.0,\n\
+        \      \"description\": \"Default Theme for Apigen.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"php-apigen-theme-default\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1277499\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Default Theme for\
+        \ Apigen\",\n      \"upstream_url\": \"http://www.apigen.org/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1480342702.0,\n    \
+        \  \"description\": \"This extension exposes the abstract syntax tree generated\
+        \ by PHP 7.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-ast\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1398355\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Abstract Syntax Tree\",\n      \"upstream_url\": \"\
+        https://github.com/nikic/php-ast\"\n    },\n    {\n      \"acls\": [],\n \
+        \     \"creation_date\": 1468942019.0,\n      \"description\": \"A serializable\
+        \ dependency injection container with constructor and setter\\ninjection,\
+        \ interface and trait awareness, configuration inheritance, and\\nmuch more.\\\
+        n\\nAutoloader: /usr/share/php/Aura/Di/autoload.php\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-aura-di\",\n   \
+        \   \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352466\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A serializable dependency\
+        \ injection container\",\n      \"upstream_url\": \"https://github.com/auraphp/Aura.Di\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468942320.0,\n\
+        \      \"description\": \"Powerful, flexible web routing for PSR-7 requests.\\\
+        n\\nAutoloader: /usr/share/php/Aura/Router/autoload.php\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-aura-router\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352468\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Powerful, flexible\
+        \ web routing for PSR-7 requests\",\n      \"upstream_url\": \"https://github.com/auraphp/Aura.Router\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHP_CompatInfo will parse a file/folder/array to\
+        \ find out the minimum\\nversion and extensions required for it to run. CLI\
+        \ version has many reports\\n(extension, interface, class, function, constant)\
+        \ to display and ability to\\nshow content of dictionary references.\\n\\\
+        nDocumentation: http://php5.laurent-laville.org/compatinfo/manual/current/en/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-bartlett-PHP-CompatInfo\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Find out version and the extensions required for a piece of code to run\"\
+        ,\n      \"upstream_url\": \"http://php5.laurent-laville.org/compatinfo/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHP_Reflect adds the ability to reverse-engineer\
+        \ classes, interfaces,\\nfunctions, constants and more, by connecting php\
+        \ callbacks to other tokens.\\n\\nDocumentation: http://php5.laurent-laville.org/reflect/manual/current/en/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-bartlett-PHP-Reflect\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Adds the ability to reverse-engineer PHP\",\n      \"upstream_url\": \"http://php5.laurent-laville.org/reflect/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1451329134.0,\n\
+        \      \"description\": \"Reference Database to be used with php-compatinfo\
+        \ library.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-bartlett-php-compatinfo-db\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1290302\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Reference Database\
+        \ to be used with php-compatinfo library\",\n      \"upstream_url\": \"https://github.com/llaville/php-compatinfo-db\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1432298906.0,\n\
+        \      \"description\": \"This tool wil generate UML class diagrams with all\
+        \ class,\\ninterface and trait definitions in your PHP project.\\n\\n* reverse-engine\
+        \ interchangeable (currently support Bartlett\\\\Reflect\\n  and Andrewsville\\\
+        \\TokenReflection)\\n* UML syntax processor interchangeable (currently support\
+        \ Graphviz\\n  and PlantUML)\\n* generates a class and its direct dependencies\\\
+        n* generates a namespace with all objects\\n* generates a full package with\
+        \ all namespaces and objects\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": true,\n      \"name\": \"php-bartlett-umlwriter\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1205346\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Create UML class\
+        \ diagrams from your PHP source\",\n      \"upstream_url\": \"http://php5.laurent-laville.org/umlwriter/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package adds the bartlett channel which allows\
+        \ PEAR packages\\nfrom this channel to be installed.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-channel-bartlett\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Adds bartlett channel to PEAR\",\n \
+        \     \"upstream_url\": \"http://bartlett.laurent-laville.org/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"This package adds the pear.nrk.io channel which allows\
+        \ PEAR packages\\nfrom this channel to be installed.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-channel-nrk\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Adds pear.nrk.io channel to PEAR\",\n\
+        \      \"upstream_url\": \"http://pear.nrk.io/\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This package adds the phing channel which allows\\nPEAR packages from\
+        \ this channel to be installed.\",\n      \"koschei_monitor\": false,\n  \
+        \    \"monitor\": false,\n      \"name\": \"php-channel-phing\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Adds phing channel to PEAR\",\n      \"\
+        upstream_url\": \"http://phing.info/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"This package\
+        \ adds the phpunit channel which allows PEAR packages\\nfrom this channel\
+        \ to be installed.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-channel-phpunit\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n  \
+        \    \"summary\": \"Adds phpunit channel to PEAR\",\n      \"upstream_url\"\
+        : \"http://pear.phpunit.de\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"This package adds\
+        \ the symfony channel which allows\\nPEAR packages from this channel to be\
+        \ installed.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-channel-symfony\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Adds symfony project channel to PEAR\",\n      \"upstream_url\": \"http://www.symfony-project.com/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package adds the pear.netpirates.net (theseer)\
+        \ channel which allows\\nPEAR packages from this channel to be installed.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-channel-theseer\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Adds theseer channel to PEAR\",\n      \"upstream_url\": \"http://pear.netpirates.net/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1463494945.0,\n\
+        \      \"description\": \"Small utility library that lets you find a path\
+        \ to the system CA bundle.\\n\\nAutoloader: /usr/share/php/Composer/CaBundle/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-composer-ca-bundle\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1331937\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Lets you find a path to the system CA\",\n      \"\
+        upstream_url\": \"https://github.com/composer/ca-bundle\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1444584165.0,\n      \"description\"\
+        : \"Semver library that offers utilities, version constraint parsing\\nand\
+        \ validation.\\n\\nOriginally written as part of composer/composer, now extracted\
+        \ and\\nmade available as a stand-alone library.\\n\\nTo use this library,\
+        \ you just have to add, in your project:\\n  require_once '/usr/share/php/Composer/Semver/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-composer-semver\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1268683\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Semver library that offers utilities, version constraint\
+        \ parsing and validation\",\n      \"upstream_url\": \"https://github.com/composer/semver\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1437659201.0,\n\
+        \      \"description\": \"SPDX licenses list and validation library.\\n\\\
+        nOriginally written as part of composer/composer,\\nnow extracted and made\
+        \ available as a stand-alone library.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"php-composer-spdx-licenses\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1244102\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"SPDX licenses list\
+        \ and validation library\",\n      \"upstream_url\": \"https://github.com/composer/spdx-licenses\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480342890.0,\n\
+        \      \"description\": \"The PHP Coding Standards Fixer tool fixes most issues\
+        \ in your code when you\\nwant to follow the PHP coding standards as defined\
+        \ in the PSR-1 and PSR-2\\ndocuments and many more.\\n\\nIf you are already\
+        \ using a linter to identify coding standards problems in\\nyour code, you\
+        \ know that fixing them by hand is tedious, especially on large\\nprojects.\
+        \ This tool does not only detect them, but also fixes them for you.\",\n \
+        \     \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-cs-fixer\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1391951\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A tool to automatically fix PHP code style\",\n  \
+        \    \"upstream_url\": \"https://github.com/FriendsOfPHP/PHP-CS-Fixer\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1409239897.0,\n\
+        \      \"description\": \"This library provides a way of avoiding usage of\
+        \ constructors when\\ninstantiating PHP classes.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-doctrine-instantiator\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1134003\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Instantiate objects\
+        \ in PHP without invoking their constructors\",\n      \"upstream_url\": \"\
+        https://github.com/doctrine/instantiator\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"XML\
+        \ transition from PHP4 domxml to PHP5 dom module.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-domxml-php4-php5\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"XML transition from PHP4 domxml to PHP5\
+        \ dom module\",\n      \"upstream_url\": \"http://alexandre.alapetite.fr/doc-alex/domxml-php4-php5/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The Graph component enables you to create line,\
+        \ pie and bar charts.\\nThe output driver mechanism allows you to create different\
+        \ image types\\nfrom each chart, and the available renderers make the chart\
+        \ output\\ncustomizable from simple two-dimensional charts to beautiful\\\
+        nthree-dimensional data projections.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-ezc-Graph\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"A component for creating pie charts, line graphs and\
+        \ other kinds of diagrams\",\n      \"upstream_url\": \"http://ezcomponents.org/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1481808040.0,\n\
+        \      \"description\": \"This library holds utility classes and constants\
+        \ to facilitate common\\noperations of PSR-7; the primary purpose is to provide\
+        \ constants for\\nreferring to request methods, response status codes and\
+        \ messages, and\\npotentially common headers.\\n\\nAutoloader: /usr/share/php/Fig/Http/Message/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-fig-http-message-util\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1404577\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"PSR Http Message Util\",\n      \"upstream_url\"\
+        : \"https://github.com/php-fig/http-message-util\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1480686373.0,\n      \"description\"\
+        : \"Provides additional asserts to be used in PHPUnit tests.\\nThe asserts\
+        \ are provided using Traits so no changes are needed\\nin the hierarchy of\
+        \ test classes.\\n\\nAutoloader: /usr/share/php/GeckoPackages/PHPUnit/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-gecko-packages-gecko-php-unit\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/1400626\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Additional PHPUnit tests\",\n\
+        \      \"upstream_url\": \"https://github.com/GeckoPackages/GeckoPHPUnit\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483018542.0,\n\
+        \      \"description\": \"PHP module for GEOS.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-geos\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1405298\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"PHP module for GEOS\"\
+        ,\n      \"upstream_url\": \"http://trac.osgeo.org/geos\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"getID3() is a PHP script that extracts useful information\\n(such as ID3\
+        \ tags, bitrate, playtime, etc.) from MP3s &\\nother multimedia file formats\
+        \ (Ogg, WMA, WMV, ASF, WAV, AVI,\\nAAC, VQF, FLAC, MusePack, Real, QuickTime,\
+        \ Monkey's Audio, MIDI and more).\\n\\nAutoloader: /usr/share/php/getid3/autoload.php\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-getid3\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"The PHP media\
+        \ file parser\",\n      \"upstream_url\": \"http://www.getid3.org/\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1446684827.0,\n\
+        \      \"description\": \"Hamcrest is a matching library originally written\
+        \ for Java,\\nbut subsequently ported to many other languages.\\n\\nphp-hamcrest\
+        \ is the official PHP port of Hamcrest and essentially follows\\na literal\
+        \ translation of the original Java API for Hamcrest,\\nwith a few Exceptions,\
+        \ mostly down to PHP language barriers.\\n\\nTo use this library, you just\
+        \ have to add, in your project:\\n  require_once '/usr/share/php/Hamcrest/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-hamcrest\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1271954\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"PHP port of Hamcrest Matchers\",\n      \"upstream_url\"\
+        : \"https://github.com/hamcrest/hamcrest-php\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"An\
+        \ interface to deal with reminders, alarms and notifications through a\\nstandardized\
+        \ API. The following notification methods are currently\\navailable: standard\
+        \ Horde notifications, pop-ups, emails.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Alarm\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Alarm Libraries\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"Classes for parsing\
+        \ command line arguments with various actions, providing\\nhelp, grouping\
+        \ options, and more.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Argv\",\n      \"namespace\":\
+        \ \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde command-line argument parsing package\",\n   \
+        \   \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"The\
+        \ Horde_Auth package provides a common interface into the various\\nbackends\
+        \ for the Horde authentication system.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Auth\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Authentication API\",\n      \"\
+        upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Autoload\
+        \ implementation and class loading manager for Horde.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Autoloader\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Autoloader\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"The Horde_Browser\
+        \ class provides an API for getting information about the\\ncurrent user's\
+        \ browser and its capabilities.\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": false,\n      \"name\": \"php-horde-Horde-Browser\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Browser API\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"This package provides\
+        \ a simple, functional caching API, with the option to\\nstore the cached\
+        \ data on the filesystem, in one of the PHP opcode cache\\nsystems (APC, eAcclerator,\
+        \ XCache, or Zend Performance Suite's content\\ncache), memcached, or an SQL\
+        \ table.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-Cache\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Horde Caching API\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Horde_Cli:: API for basic command-line functionality/checks\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Cli\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Horde Command\
+        \ Line Interface API\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"An API for various compression techniques.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Compress\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Horde Compression API\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides compression suitable for packing strings\
+        \ on-the-fly in PHP code\\n(as opposed to more resource-intensive compression\
+        \ algorithms such as\\nDEFLATE).\",\n      \"koschei_monitor\": true,\n  \
+        \    \"monitor\": false,\n      \"name\": \"php-horde-Horde-Compress-Fast\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Fast Compression Library\",\n      \"\
+        upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"A\
+        \ programmatic way of building constraints that evaluate to true or false.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Constraint\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Horde Constraint library\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package provides the controller part of an\
+        \ MVC system for Horde.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Controller\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde Controller libraries\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"These classes provide\
+        \ the core functionality of the Horde Application\\nFramework.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Core\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Core Framework libraries\",\n\
+        \      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"The Horde_Crypt package class provides an API for various cryptographic\\\
+        nsystems.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-Crypt\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Horde Cryptography API\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides blowfish encryption/decryption for PHP\
+        \ string data.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-Crypt-Blowfish\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Blowfish Encryption Library\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"This package provides\
+        \ access to the Sabberworm CSS Parser from within the\\nHorde framework.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Css-Parser\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Horde CSS Parser\",\n      \"upstream_url\": \"http://pear.horde.org\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1405954861.0,\n\
+        \      \"description\": \"Abstracted interface to various CSS minification\
+        \ backends.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-CssMinify\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1117438\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"CSS Minification\",\n      \"\
+        upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"A\
+        \ data import and export API, with backends for:\\n* CSV\\n* TSV\\n* iCalendar\\\
+        n* vCard\\n* vNote\\n* vTodo\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": false,\n      \"name\": \"php-horde-Horde-Data\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde Data API\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Package for creating and manipulating dates.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Date\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Horde Date\
+        \ package\",\n      \"upstream_url\": \"http://pear.horde.org\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Library for natural-language date parsing, with support\
+        \ for multiple\\nlanguages and locales\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Date-Parser\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Date Parser\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"This package contains\
+        \ all Horde-specific wrapper classes for the Sabre DAV\\nlibrary.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Dav\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Horde library\
+        \ for WebDAV, CalDAV, CardDAV\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Horde database/SQL abstraction layer\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Db\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Database Libraries\",\n      \"\
+        upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"The\
+        \ Horde_Editor package provides an API to generate the code necessary for\\\
+        nembedding javascript RTE editors in a web page.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Editor\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Editor API\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"Lightweight API for\
+        \ ElasticSearch (http://www.elasticsearch.org/).\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-ElasticSearch\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde ElasticSearch client\",\n    \
+        \  \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ class provides the default exception handlers for the Horde\\nApplication\
+        \ Framework.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-Exception\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Horde Exception Handler\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Support for working with feed formats such as RSS\
+        \ and Atom.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-Feed\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Horde Feed libraries\",\n      \"upstream_url\": \"http://pear.horde.org/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The Horde_Form package provides form rendering,\
+        \ validation, and other\\nfunctionality for the Horde Application Framework.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Form\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Horde Form\
+        \ API\",\n      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Package for managing and accessing the Horde groups system.\",\n     \
+        \ \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"\
+        php-horde-Horde-Group\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Horde User\
+        \ Groups System\",\n      \"upstream_url\": \"http://pear.horde.org\"\n  \
+        \  },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides an abstract API to access various hash\
+        \ table implementations.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-HashTable\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde Hash Table Interface\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"The Horde_History\
+        \ API provides a way to track changes on arbitrary pieces\\nof data in Horde\
+        \ applications.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-History\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"API for tracking the history of an object\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"This package provides\
+        \ a set of classes for making HTTP requests.\\n\\nOptional dependency: php-pecl-http\
+        \ or php-pecl-http1\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Http\",\n      \"namespace\":\
+        \ \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde HTTP libraries\",\n      \"upstream_url\": \"\
+        http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\"\
+        : 1400070978.0,\n      \"description\": \"An API for dealing with iCalendar\
+        \ data.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-Icalendar\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"iCalendar API\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1420638760.0,\n\
+        \      \"description\": \"Normalized access to various backends providing\
+        \ IDNA (Internationalized\\nDomain Names in Applications) support.\",\n  \
+        \    \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Idna\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1179711\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"IDNA backend normalization package\",\n      \"upstream_url\"\
+        : \"http://www.horde.org/\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"An Image utility\
+        \ API, with backends for:\\n* GD\\n* GIF\\n* PNG\\n* SVG\\n* SWF\\n* ImageMagick\
+        \ convert command line tool\\n* Imagick Extension\\n\\nOptional dependency:\
+        \ php-pecl-imagick\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Image\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde Image API\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"An abstracted API interface to various IMAP4rev1\
+        \ (RFC 3501) backend\\ndrivers.\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": false,\n      \"name\": \"php-horde-Horde-Imap-Client\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde IMAP abstraction interface\",\n\
+        \      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Provides an API into an IMSP server for address books and options.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Imsp\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"IMSP API\"\
+        ,\n      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n    \
+        \  \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"A dependency injection container for Horde.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Injector\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde dependency injection container\"\
+        ,\n      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n    \
+        \  \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This package to generates MIME encapsuled responses to iCalendar\\ninvitations.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Itip\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"iTip invitation\
+        \ response handling\",\n      \"upstream_url\": \"http://pear.horde.org\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1405954889.0,\n\
+        \      \"description\": \"Abstracted interface to various javascript minification\
+        \ backends.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-JavascriptMinify\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1117444\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Javascript Minification\"\
+        ,\n      \"upstream_url\": \"http://pear.horde.org/\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This package allows to convert Kolab data objects from XML to data arrays.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Kolab-Format\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"A package for reading/writing Kolab data formats\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org/\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"This package reads/writes\
+        \ entries in the Kolab user database stored in LDAP.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Kolab-Server\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A package for manipulating the Kolab\
+        \ user database\",\n      \"upstream_url\": \"http://pear.horde.org/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package stores Kolab specific user data in\
+        \ the session.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-Kolab-Session\",\n      \"namespace\":\
+        \ \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"A package managing an active Kolab session\",\n    \
+        \  \"upstream_url\": \"http://pear.horde.org/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Storing\
+        \ user data in an IMAP account belonging to the user is one of the\\nKolab\
+        \ server core concepts. This package provides all the necessary means\\nto\
+        \ deal with this type of data storage effectively.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Kolab-Storage\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A package for handling Kolab data stored\
+        \ on an IMAP server\",\n      \"upstream_url\": \"http://pear.horde.org\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A set of classes for connecting to LDAP servers\
+        \ and working with directory\\nobjects.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Ldap\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde LDAP libraries\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"The Horde_ListHeaders\
+        \ library parses Mailing List Headers as defined\\nin RFC 2369 & RFC 2919.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-ListHeaders\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Horde List Headers Parsing Library\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The Horde_Lock library provides the Horde resource\
+        \ locking system.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Lock\",\n      \"namespace\":\
+        \ \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde Resource Locking System\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"Horde Logging package\
+        \ with configurable handlers, filters, and formatting.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Log\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Logging library\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"The Horde_LoginTasks\
+        \ library provides a set of methods for dealing with\\ntasks run upon login\
+        \ to Horde applications.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-LoginTasks\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde Login Tasks System\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"The Horde_Mail library\
+        \ is a fork of the PEAR Mail library that provides\\nadditional functionality,\
+        \ including (but not limited to):\\n* Allows a stream to be passed in.\\n*\
+        \ Allows raw headertext to be used in the outgoing messages (required for\\\
+        nthings like message redirection pursuant to RFC 5322 [3.6.6]).\\n* Native\
+        \ PHP 5 code.\\n* PHPUnit test suite.\\n* Provides more comprehensive sendmail\
+        \ error messages.\\n* Uses Exceptions instead of PEAR_Errors.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Mail\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Mail Library\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1405973467.0,\n      \"description\": \"Attempts to automatically\
+        \ determine configuration options for various\\nremote mail services (IMAP/POP3/SMTP).\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Mail-Autoconfig\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/1117476\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Mail Autoconfiguration\",\n  \
+        \    \"upstream_url\": \"http://pear.horde.org/\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Provides various utility classes for dealing with Microsoft MAPI structured\\\
+        ndata.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n \
+        \     \"name\": \"php-horde-Horde-Mapi\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"MAPI utility library\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides an API to access a memcache installation.\\\
+        n\\nYou need to also install php-pecl-memcache or php-pecl-memcached.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Memcache\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Horde Memcache API\",\n      \"upstream_url\": \"http://pear.horde.org\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides methods for dealing with MIME (RFC 2045)\
+        \ and related e-mail (RFC\\n822/2822/5322) standards.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Mime\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde MIME Library\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"Provides rendering\
+        \ drivers for MIME data.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Mime-Viewer\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde MIME Viewer Library\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"Provides an API to\
+        \ ensure that the PECL Mongo extension can be used\\nconsistently across various\
+        \ Horde packages.\\n\\nTu use this module, you also need to install\\n  -\
+        \ php-pecl-mongo (PHP 5 only)\\nor\\n  - php-pecl-mongodb (PHP 5 or 7)\\n\
+        \  - php-alcaeus-mongo-php-adapter\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Mongo\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Mongo Configuration\",\n     \
+        \ \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Common\
+        \ methods for handling language data, timezones, and hostname->country\\nlookups.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Nls\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Native Language\
+        \ Support (NLS)\",\n      \"upstream_url\": \"http://pear.horde.org\"\n  \
+        \  },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A library implementing a subject-observer pattern\
+        \ for raising and showing\\nmessages of different types and to different listeners.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Notification\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Horde Notification System\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"An OAuth consumer (http://oauth.net) and OAuth infrastructure,\
+        \ and in the\\nfuture will provide an OAuth server.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Oauth\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde OAuth client/server\",\n     \
+        \ \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1405956782.0,\n      \"description\": \"Library\
+        \ to interact with Open-Xchange servers.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-horde-Horde-OpenXchange\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1118273\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Open-Xchange Connector\"\
+        ,\n      \"upstream_url\": \"http://pear.horde.org/\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"A replacement for serialize()/json_encode() that will automatically use\
+        \ the\\nmost efficient serialization available based on the input.\\n\\nThe\
+        \ serialization extensions you may want to install are:\\n- php-json\\n- php-pecl-igbinary\\\
+        n- php-pecl-msgpack\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Pack\",\n      \"namespace\":\
+        \ \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde Pack Utility\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1414411642.0,\n\
+        \      \"description\": \"PDF generation using only PHP, without requiring\
+        \ any external libraries.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Pdf\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1141526\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Horde PDF library\"\
+        ,\n      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n    \
+        \  \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"The Perms package provides an interface to the Horde permissions system.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Perms\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Horde Permissions\
+        \ System\",\n      \"upstream_url\": \"http://pear.horde.org\"\n    },\n \
+        \   {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n     \
+        \ \"description\": \"The Horde_Prefs package provides a common abstracted\
+        \ interface into the\\nvarious preferences storage mediums. It also includes\
+        \ all of the functions\\nfor retrieving, storing, and checking preference\
+        \ values.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-Prefs\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Horde Preferences API\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Queue layer with various storage backends and runners\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Queue\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Horde Queue\"\
+        ,\n      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n    \
+        \  \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Lightweight ORM layer\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Rdo\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n  \
+        \    \"summary\": \"Rampage Data Objects\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package provides a method for PEAR to install\
+        \ Horde components into\\nthe base Horde installation.\\n\\nSystem default\
+        \ Horde installation directory is /usr/share/horde.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Role\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PEAR installer role used to install\
+        \ Horde components\",\n      \"upstream_url\": \"http://pear.horde.org\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Classes for mapping URLs into the controllers and\
+        \ actions of an MVC system.\\nIt is a port of a Python library, Routes, by\
+        \ Ben Bangert\\n(http://routes.groovie.org).\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Routes\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Routes URL mapping system\",\n\
+        \      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"A common abstracted interface to various remote methods of accessing Horde\\\
+        nfunctionality.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-Rpc\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Horde RPC API\",\n      \"upstream_url\": \"http://pear.horde.org\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Packaged version of the PHP Scribe client.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Scribe\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Scribe\",\n\
+        \      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"An API for encrypting and decrypting small pieces of data with the use\
+        \ of a\\nshared key.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Secret\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Secret Encryption API\",\n      \"upstream_url\": \"\
+        http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\"\
+        : 1400070978.0,\n      \"description\": \"The Horde_Serialize library provides\
+        \ various methods of encapsulating data.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Serialize\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Data Encapulation API\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1405973532.0,\n      \"description\": \"A library for accessing\
+        \ the Avatar services at gravatar.com.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Service-Gravatar\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1118289\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"API accessor for\
+        \ gravatar.com\",\n      \"upstream_url\": \"http://pear.horde.org/\"\n  \
+        \  },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Set of classes that provide an abstraction to various\
+        \ online weather\\nservice providers. Includes drivers for WeatherUnderground,\\\
+        nWorldWeatherOnline, and Google Weather.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Service-Weather\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Weather Provider\",\n      \"\
+        upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Horde_SessionHandler\
+        \ defines an API for implementing custom session\\nhandlers for PHP.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-SessionHandler\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Horde Session Handler API\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Horde_Share provides an interface to all shared\
+        \ resources a user\\nowns or has access to.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Share\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Shared Permissions System\",\n\
+        \      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Provides interfaces for connecting to a SMTP (RFC 5321) server to send\\\
+        ne-mail messages..\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Smtp\",\n      \"namespace\":\
+        \ \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde SMTP Client\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides abstract class for use in creating PHP\
+        \ network socket clients.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Socket-Client\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde Socket Client\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Unified spellchecking API.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-SpellChecker\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Spellcheck API\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"An object-oriented\
+        \ interface to assist in creating and storing PHP stream\\nresources, and\
+        \ to provide utility methods to access and manipulate the\\nstream contents.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Stream\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Horde stream\
+        \ handler\",\n      \"upstream_url\": \"http://pear.horde.org\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"A collection of various stream filters.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Stream-Filter\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Stream filters\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"This package provides\
+        \ various stream wrappers.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": false,\n      \"name\": \"php-horde-Horde-Stream-Wrapper\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Stream wrappers\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1434981694.0,\n      \"description\": \"Horde wrapper around\
+        \ the znerol/php-stringprep package.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"php-horde-Horde-Stringprep\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1222799\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Preparation of Internationalized\
+        \ Strings (\\\"stringprep\\\")\",\n      \"upstream_url\": \"http://www.horde.org/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Support classes not tied to Horde but is used by\
+        \ it. These classes can be\\nused outside of Horde as well.\\n\\nOptional\
+        \ dependencies:\\n- uuid-php or php-pecl-uuid\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Support\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde support package\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"Classes for implementing\
+        \ a SyncML server.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-SyncMl\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde_SyncMl provides an API for processing SyncML requests\"\
+        ,\n      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n    \
+        \  \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Horde Template system. Adapted from bTemplate, by Brian Lozier\\n<brian@massassi.net>.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Template\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Horde Template System\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Horde-specific PHPUnit base classes.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Test\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde testing base classes\",\n    \
+        \  \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ package provides a text-based diff engine and renderers for multiple\\ndiff\
+        \ output formats.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Text-Diff\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Engine for performing and rendering text diffs\",\n\
+        \      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Common methods for fitering and converting text.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Text-Filter\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Text Filter API\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org/\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"The Horde_Text_Filter_Csstidy::\
+        \ class provides the PHP-based library needed\\nto perform optimization/compression\
+        \ on CSS code. It is provided in a\\nseparate package as the code is under\
+        \ the GPLv2 license instead of the\\nLGPLv2 license used for the Text_Filter\
+        \ class.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-Text-Filter-Csstidy\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde Text Filter API\",\n      \"upstream_url\": \"\
+        http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\"\
+        : 1400070978.0,\n      \"description\": \"The Horde_Text_Flowed:: class provides\
+        \ common methods for manipulating text\\nusing the encoding described in RFC\
+        \ 3676 ('flowed' text).\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Text-Flowed\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde API for flowed text as per RFC 3676\",\n     \
+        \ \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Packaged\
+        \ version of the PHP Thrift client\\n\\nOptional extension : php-pecl-apcu\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Thrift\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Thrift\",\n\
+        \      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Library for parsing timezone databases and generating VTIMEZONE iCalendar\\\
+        ncomponents.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-Timezone\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Timezone library\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The Horde_Token:: class provides a common abstracted\
+        \ interface into the\\nvarious token generation mediums. It also includes\
+        \ all of the functions for\\nretrieving, storing, and checking tokens.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-Horde-Token\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Horde Token\
+        \ API\",\n      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Translation wrappers.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Translation\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Horde translation library\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"This package provides\
+        \ a tree view of hierarchical information. It allows\\nfor expanding/collapsing\
+        \ of branches and maintains their state.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Tree\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Tree API\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"This class represents\
+        \ a single URL and provides methods for manipulating\\nURLs.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Url\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Url class\",\n      \"upstream_url\"\
+        : \"http://pear.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"These classes provide\
+        \ functionality useful for all kind of applications.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Util\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Utility Libraries\",\n      \"\
+        upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ package provides a Virtual File System API, with backends for:\\n\\n* SQL\\\
+        n* FTP\\n* Local filesystems\\n* Hybrid SQL and filesystem\\n* Samba\\n* SSH2/SFTP\\\
+        n* IMAP (Kolab)\\n\\nReading, writing and listing of files are all supported,\
+        \ and there are both\\nobject-based and array-based interfaces to directory\
+        \ listings.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-horde-Horde-Vfs\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Virtual File System API\",\n      \"upstream_url\": \"http://pear.horde.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A simple View pattern implementation.\",\n     \
+        \ \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"\
+        php-horde-Horde-View\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Horde View\
+        \ API\",\n      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This package provides an element object that can be used to provide\\\
+        nSimpleXML-like functionality over a DOM object. The main advantage over\\\
+        nusing SimpleXML is the ability to add multiple levels of new elements in\
+        \ a\\nsingle call, without introducing \\\"ghost\\\" objects.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-horde-Horde-Xml-Element\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Horde Xml Element object\",\n      \"\
+        upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ package provides encoding and decoding of WBXML (Wireless Binary XML)\\\
+        ndocuments. WBXML is used in SyncML for transferring smaller amounts of data\\\
+        nwith wireless devices.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-horde-Horde-Xml-Wbxml\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Provides an API for encoding and decoding WBXML documents\"\
+        ,\n      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n    \
+        \  \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This application provides tagging support for the other Horde applications.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-content\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Tagging application\"\
+        ,\n      \"upstream_url\": \"http://pear.horde.org\"\n    },\n    {\n    \
+        \  \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"The Horde Application Framework is a flexible, modular, general-purpose\
+        \ web\\napplication framework written in PHP. It provides an extensive array\
+        \ of\\ncomponents that are targeted at the common problems and tasks involved\
+        \ in\\ndeveloping modern web applications. It is the basis for a large number\
+        \ of\\nproduction-level web applications, notably the Horde Groupware suites.\
+        \ For\\nmore information on Horde or the Horde Groupware suites, visit\\nhttp://www.horde.org.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-horde\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Horde Application\
+        \ Framework\",\n      \"upstream_url\": \"http://www.horde.org/apps/horde\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1418046961.0,\n\
+        \      \"description\": \"PHP extension that implements the LZ4 compression\
+        \ algorithm,\\nan extremely fast lossless compression algorithm.\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\":\
+        \ \"php-horde-horde-lz4\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1141903\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Horde LZ4 Compression Extension\",\n      \"upstream_url\"\
+        : \"http://www.horde.org\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\"\
+        : 1400070978.0,\n      \"description\": \"IMP, the Internet Mail Program,\
+        \ is one of the most popular and widely\\ndeployed open source webmail applications\
+        \ in the world. It allows\\nuniversal, web-based access to IMAP and POP3 mail\
+        \ servers and provides\\nAjax, mobile and traditional interfaces with a rich\
+        \ range of features\\nnormally found only in desktop email clients.\",\n \
+        \     \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-imp\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A web based\
+        \ webmail system\",\n      \"upstream_url\": \"http://www.horde.org/apps/imp\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400266848.0,\n\
+        \      \"description\": \"Ingo is an email-filter management application.\
+        \ It is fully\\ninternationalized, integrated with Horde and the IMP Webmail\
+        \ client, and\\nsupports both server-side (Sieve, Procmail, Maildrop) and\
+        \ client-side\\n(IMAP) message filtering.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-horde-ingo\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1087737\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An email filter rules\
+        \ manager\",\n      \"upstream_url\": \"http://www.horde.org/apps/ingo\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400501119.0,\n\
+        \      \"description\": \"Kronolith is the Horde calendar application. It\
+        \ provides web-based\\ncalendars backed by a SQL database or a Kolab server.\
+        \ Supported features\\ninclude Ajax and mobile interfaces, shared calendars,\
+        \ remote calendars,\\ninvitation management (iCalendar/iTip), free/busy management,\
+        \ resource\\nmanagement, alarms, recurring events, and a sophisticated day/week\
+        \ view\\nwhich handles arbitrary numbers of overlapping events.\",\n     \
+        \ \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"\
+        php-horde-kronolith\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1087772\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A web based calendar\",\n      \"upstream_url\": \"\
+        http://www.horde.org/apps/kronolith\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1418046619.0,\n      \"description\": \"The Mnemo\
+        \ Note Manager is the Horde notes/memos application. It allows\\nusers to\
+        \ keep web-based notes and freeform text. Notes may be shared with\\nother\
+        \ users via shared notepads. It requires the Horde Application\\nFramework\
+        \ and an SQL database or Kolab server for backend storage.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-horde-mnemo\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1141528\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A web based notes\
+        \ manager\",\n      \"upstream_url\": \"http://www.horde.org/apps/mnemo\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400266870.0,\n\
+        \      \"description\": \"Nag is a web-based application built upon the Horde\
+        \ Application Framework\\nwhich provides a simple, clean interface for managing\
+        \ online task lists\\n(i.e., todo lists). It also includes strong integration\
+        \ with the other\\nHorde applications and allows users to share task lists\
+        \ or enable\\nlight-weight project management.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-horde-nag\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1087740\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A web based task\
+        \ list manager\",\n      \"upstream_url\": \"http://www.horde.org/apps/nag\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1418046936.0,\n\
+        \      \"description\": \"An application to change any user passwords stored\
+        \ in various backends like\\nSQL, LDAP, Kolab, passwd files etc.\",\n    \
+        \  \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-passwd\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1141529\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Horde password changing application\",\n      \"upstream_url\"\
+        : \"http://www.horde.org/apps/passwd\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400266905.0,\n      \"description\": \"Turba is\
+        \ the Horde contact management application. Leveraging the Horde\\nframework\
+        \ to provide seamless integration with IMP and other Horde\\napplications,\
+        \ it supports storing contacts in SQL, LDAP, Kolab, and IMSP\\naddress books.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-horde-turba\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1087742\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A web based address book\",\n      \"upstream_url\"\
+        : \"http://www.horde.org/apps/turba\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1406039678.0,\n      \"description\": \"Wicked is\
+        \ a wiki application for Horde.\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": false,\n      \"name\": \"php-horde-wicked\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1087769\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Wiki application\"\
+        ,\n      \"upstream_url\": \"http://www.horde.org/apps/wicked\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"PHP code to purify and filter HTML\\n\\n* make HTML\
+        \ markup in text secure and standard-compliant\\n* process text for use in\
+        \ HTML, XHTML or XML documents\\n* restrict HTML elements, attributes or URL\
+        \ protocols\\n  using black or white-lists\\n* balance tags, check element\
+        \ nesting, transform deprecated\\n  attributes and tags, make relative URLs\
+        \ absolute, etc.\\n* fast, highly customizable, well-documented\\n* single,\
+        \ 48 kb file\\n* simple HTML Tidy alternative\\n* free and licensed under\
+        \ LGPL v3 and GPL v2+\\n* use to filter, secure and sanitize HTML in blog\
+        \ comments or\\n  forum posts, generate XML-compatible feed items from web-page\\\
+        n  excerpts, convert HTML to XHTML, pretty-print HTML, scrape\\n  web-pages,\
+        \ reduce spam, remove XSS code, etc.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-htmLawed\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"PHP code to purify and filter HTML\",\n      \"upstream_url\"\
+        : \"http://www.bioinformatics.org/phplabware/internal_utilities/htmLawed/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480344524.0,\n\
+        \      \"description\": \"PSR-15 interfaces for HTTP middleware.\\n\\nAutoloader:\
+        \ /usr/share/php/Interop/Http/Middleware/autoload.php\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-http-interop-http-middleware\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1393934\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Common interface\
+        \ for HTTP middleware\",\n      \"upstream_url\": \"https://github.com/http-interop/http-middleware\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1464624504.0,\n\
+        \      \"description\": \"Find URLs in HTML that are not already links, and\
+        \ make them into links.\\n\\nAutoloader: /usr/share/php/php-iamcal-lib-autolink/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-iamcal-lib-autolink\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1330429\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Adds anchors to urls in a text\",\n      \"upstream_url\"\
+        : \"https://github.com/iamcal/lib_autolink\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1442772616.0,\n      \"description\": \"PHP\
+        \ wrapper for smbclient and libsmbclient-php\\n\\n* Reuses a single smbclient\
+        \ instance for multiple requests\\n* Doesn't leak the password to the process\
+        \ list\\n* Simple 1-on-1 mapping of SMB commands\\n* A stream-based api to\
+        \ remove the need for temporary files\\n* Support for using libsmbclient directly\
+        \ trough libsmbclient-php\\n\\nTo use this library, you just have to add,\
+        \ in your project:\\n  require-once '/usr/share/php/Icewind/SMB/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-icewind-smb\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1259172\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"php wrapper for smbclient and libsmbclient-php\",\n\
+        \      \"upstream_url\": \"https://github.com/icewind1991/SMB\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1441400182.0,\n    \
+        \  \"description\": \"Generic stream wrappers for php.\\n\\nTo use this library,\
+        \ you just have to add, in your project:\\n  require-once '/usr/share/php/Icewind/Streams/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-icewind-streams\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1258955\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A set of generic stream wrappers\",\n      \"upstream_url\"\
+        : \"https://github.com/icewind1991/Streams\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1453299374.0,\n      \"description\": \"Parses\
+        \ variables and converts them to string so that they can be logged.\\n\\nBased\
+        \ on the Monolog formatter/normalizer.\\n\\nAutoloader: /usr/share/php/InterfaSys/LogNormalizer/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-interfasys-lognormalizer\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": \"https://bugzilla.redhat.com/1298649\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Parses variables and converts them to\
+        \ string\",\n      \"upstream_url\": \"https://github.com/interfasys/lognormalizer\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1414411560.0,\n\
+        \      \"description\": \"A library for generating random numbers and strings\
+        \ of various strengths.\\n\\nThis library is useful in security contexts.\\\
+        n\\nAutoloader: /usr/share/php/RandomLib/autoload.php\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-ircmaxell-random-lib\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1129714\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A Library For Generating\
+        \ Secure Random Numbers\",\n      \"upstream_url\": \"https://github.com/ircmaxell/RandomLib\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1409239860.0,\n\
+        \      \"description\": \"This is a base set of libraries used in other projects.\\\
+        nThis isn't useful on its own...\\n\\nOptional dependency: php-gmp or php-bcmath\\\
+        n\\nAutoloader: /usr/share/php/SecurityLib/autoload.php\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-ircmaxell-security-lib\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1129700\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A Base Security Library\"\
+        ,\n      \"upstream_url\": \"https://github.com/ircmaxell/SecurityLib\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1441400166.0,\n\
+        \      \"description\": \"Even though serializing closures is \\\"not allowed\\\
+        \" by PHP,\\nthe SuperClosure library makes it possible\\n\\nTo use this library,\
+        \ you just have to add, in your project:\\n  require-once '/usr/share/php/SuperClosure/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-jeremeamia-superclosure\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1258899\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Serialize Closure objects, including\
+        \ their context and binding\",\n      \"upstream_url\": \"https://github.com/jeremeamia/super_closure\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"php-json is an extremely fast PHP C extension for\
+        \ JSON (JavaScript Object\\nNotation) serialisation.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-json\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An extremely fast PHP extension for\
+        \ JSON\",\n      \"upstream_url\": null\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1464624684.0,\n      \"description\": \"A PHP Implementation\
+        \ for validating JSON Structures against a given Schema.\\n\\nThis package\
+        \ provides the library version 2.\\n\\nSee http://json-schema.org/\\n\\nAutoloader:\
+        \ /usr/share/php/JsonSchema2/autoload.php\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-justinrainbow-json-schema\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1327511\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A library to validate\
+        \ a json schema\",\n      \"upstream_url\": \"https://github.com/justinrainbow/json-schema\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1481807974.0,\n\
+        \      \"description\": \"A PHP Implementation for validating JSON Structures\
+        \ against a given Schema.\\n\\nThis package provides the library version 4.\\\
+        n\\nSee http://json-schema.org/\\n\\nAutoloader: /usr/share/php/JsonSchema4/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-justinrainbow-json-schema4\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/1403724\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A library to validate a json schema\"\
+        ,\n      \"upstream_url\": \"https://github.com/justinrainbow/json-schema\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490186863.0,\n\
+        \      \"description\": \"A PHP Implementation for validating JSON Structures\
+        \ against a given Schema.\\n\\nThis package provides the library version 5.\\\
+        n\\nSee http://json-schema.org/\\n\\nAutoloader: /usr/share/php/JsonSchema5/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-justinrainbow-json-schema5\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/1428926\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A library to validate a json schema\"\
+        ,\n      \"upstream_url\": \"https://github.com/justinrainbow/json-schema\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1457712793.0,\n\
+        \      \"description\": \"This extension is here to provide robust events\
+        \ system for Nette Framework.\\n\\nTo use this library, you just have to add,\
+        \ in your project:\\n  require_once '/usr/share/php/Kdyby/Events/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-kdyby-events\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277493\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Events for Nette Framework\",\n      \"upstream_url\"\
+        : \"https://github.com/kdyby/events\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1424786464.0,\n      \"description\": \"A successor\
+        \ of the PEAR:Net_LDAP2 module providing advanced functionality\\nfor accessing\
+        \ LDAP directories.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"php-kolab-net-ldap3\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1195058\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Advanced functionality\
+        \ for accessing LDAP directories\",\n      \"upstream_url\": \"http://git.kolab.org/pear/Net_LDAP3/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1446757581.0,\n\
+        \      \"description\": \"FSHL is a free, open source, universal, fast syntax\
+        \ highlighter written in PHP.\\nA very fast parser performs syntax highlighting\
+        \ for few languages and produces\\na HTML output.\\n\\nTo use this library,\
+        \ you just have to add, in your project:\\n  require_once '/usr/share/php/FSHL/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"php-kukulich-fshl\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277487\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"FSHL: fast syntax highlighter\",\n      \"upstream_url\"\
+        : \"http://fshl.kukulich.cz/\"\n    },\n    {\n      \"acls\": [],\n     \
+        \ \"creation_date\": 1447079622.0,\n      \"description\": \"Latte is a template\
+        \ engine for PHP which eases your work and ensures the\\noutput is protected\
+        \ against vulnerabilities, such as XSS.\\n\\nLatte is fast: it compiles templates\
+        \ to plain optimized PHP code.\\n\\nLatte is secure: it is the first PHP engine\
+        \ introducing content-aware escaping.\\n\\nLatte speaks your language: it\
+        \ has intuitive syntax and helps you to build\\nbetter websites easily.\\\
+        n\\nTo use this library, you just have to add, in your project:\\n  require_once\
+        \ '/usr/share/php/Latte/autoload.php';\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"php-latte\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1277407\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Latte: the amazing\
+        \ template engine for PHP\",\n      \"upstream_url\": \"https://github.com/nette/latte\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453299195.0,\n\
+        \      \"description\": \"Flysystem is a filesystem abstraction which allows\
+        \ you to easily swap out\\na local filesystem for a remote one.\\n\\nAutoloader:\
+        \ /usr/share/php/League/Flysystem/autoload.php\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-league-flysystem\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1298475\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Filesystem abstraction:\
+        \ Many filesystems, one API\",\n      \"upstream_url\": \"https://github.com/thephpleague/flysystem\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460041611.0,\n\
+        \      \"description\": \"Plates is a native PHP template system that's fast,\
+        \ easy to use and easy\\nto extend. It's inspired by the excellent Twig template\
+        \ engine and strives\\nto bring modern template language functionality to\
+        \ native PHP templates.\\nPlates is designed for developers who prefer to\
+        \ use native PHP templates\\nover compiled template languages, such as Twig\
+        \ or Smarty.\\n\\nAutoloader: /usr/share/php/League/Plates/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-league-plates\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1324861\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Native PHP template system\",\n      \"upstream_url\"\
+        : \"https://github.com/thephpleague/plates\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1464971774.0,\n      \"description\": \"This\
+        \ is a pure ID3 parser based upon getID3.\\nIt supports the following ID3\
+        \ versions inside MP3 files:\\n\\n* ID3v1 (v1.0 & v1.1)\\n* ID3v2 (v2.2, v2.3\
+        \ & v2.4)\\n\\nAutoloader: /usr/share/php/ID3Parser/autoload.php\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\":\
+        \ \"php-lukasreschke-id3parser\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1341283\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"ID3 parser library\",\n      \"upstream_url\"\
+        : \"https://github.com/LukasReschke/ID3Parser\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ is a PHP implementation of John Gruber's Markdown.\\nIt is almost completely\
+        \ compliant with the reference implementation.\\n\\nThis packages provides\
+        \ the classic version 1.0.2 and the new\\nlibrary version 1.7.0.\\n\\nAutoloader:\
+        \ /usr/share/php/Michelf/markdown-autoload.php\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-markdown\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Markdown implementation in PHP\",\n\
+        \      \"upstream_url\": \"https://michelf.ca/projects/php-markdown/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453299592.0,\n\
+        \      \"description\": \"Simple Class to create zip files on the fly and\
+        \ stream directly to the\\nHTTP client as the content is added (without using\
+        \ temporary files).\\n\\nAutoloader: /usr/share/php/ZipStreamer/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-mcnetic-zipstreamer\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1296901\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Stream zip files without i/o overhead\",\n      \"\
+        upstream_url\": \"https://github.com/McNetic/PHPZipStreamer\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1402520672.0,\n      \"\
+        description\": \"vfsStream is a PHP stream wrapper for a virtual file system\
+        \ that may be\\nhelpful in unit tests to mock the real file system.\\n\\nIt\
+        \ can be used with any unit test framework, like PHPUnit or SimpleTest.\\\
+        n\\nTo use this library, you just have to add, in your project:\\n  require_once\
+        \ '/usr/share/php/org/bovigo/vfs/autoload.php';\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-mikey179-vfsstream\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1097327\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"PHP stream wrapper\
+        \ for a virtual file system\",\n      \"upstream_url\": \"https://github.com/mikey179/vfsStream\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1456152783.0,\n\
+        \      \"description\": \"PHP-Mock can mock built-in PHP functions (e.g. time()).\\\
+        nPHP-Mock relies on PHP's namespace fallback policy.\\nNo further extension\
+        \ is needed.\\n\\nAutoloader: /usr/share/php/phpmock/autoload.php\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-mock\",\n      \"namespace\": \"rpms\",\n      \"review_url\": \"\
+        https://bugzilla.redhat.com/1306968\",\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"PHP-Mock can mock built-in PHP functions\",\n      \"\
+        upstream_url\": \"https://github.com/php-mock/php-mock\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1457713072.0,\n      \"description\"\
+        : \"This is a support package for PHP-Mock integration into other frameworks.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-mock-integration\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1306971\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Integration package for PHP-Mock\",\n      \"upstream_url\"\
+        : \"https://github.com/php-mock/php-mock-integration\"\n    },\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1460552791.0,\n      \"description\"\
+        : \"Mock built-in PHP functions (e.g. time()) with PHPUnit.\\nThis package\
+        \ relies on PHP's namespace fallback policy.\\nNo further extension is needed.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-mock-phpunit\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1306972\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Mock built-in PHP functions with PHPUnit.\",\n   \
+        \   \"upstream_url\": \"https://github.com/php-mock/php-mock-phpunit\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1469625368.0,\n\
+        \      \"description\": \"This library provides a high-level abstraction around\
+        \ the lower-level drivers\\nfor PHP and HHVM (i.e. the mongodb extension).\\\
+        n\\nWhile the extension provides a limited API for executing commands, queries,\\\
+        nand write operations, this library implements an API similar to that of the\\\
+        nlegacy PHP driver. It contains abstractions for client, database, and\\ncollection\
+        \ objects, and provides methods for CRUD operations and common\\ncommands\
+        \ (e.g. index and collection management).\\n\\nAutoloader: /usr/share/php/MongoDB/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-mongodb\",\n      \"namespace\": \"rpms\",\n      \"review_url\":\
+        \ \"https://bugzilla.redhat.com/1276834\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"MongoDB driver library\",\n      \"upstream_url\"\
+        : \"https://github.com/mongodb/mongo-php-library\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1436069184.0,\n      \"description\"\
+        : \"DeepCopy helps you create deep copies (clones) of your objects.\\nIt is\
+        \ designed to handle cycles in the association graph.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"php-myclabs-deep-copy\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1239222\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Create deep copies\
+        \ (clones) of your objects\",\n      \"upstream_url\": \"https://github.com/myclabs/DeepCopy\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1456152185.0,\n\
+        \      \"description\": \"Nette Framework is a popular tool for PHP web development\\\
+        nIt is designed to be as usable and as friendly as possible.\\nIt focuses\
+        \ on security and performance and is definitely one\\nof the safest PHP frameworks.\\\
+        n\\nNette Framework speaks your language and helps you to easily build better\
+        \ websites.\\nCache accelerates your application by storing data, once hardly\
+        \ retrieved,\\nfor future use.\\n\\nTo use this library, you just have to\
+        \ add, in your project:\\n  require_once '/usr/share/php/Nette/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette\",\n      \"namespace\": \"rpms\",\n      \"review_url\": \"\
+        https://bugzilla.redhat.com/1277484\",\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Nette Framework\",\n      \"upstream_url\": \"https://github.com/nette/nette\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1451328933.0,\n\
+        \      \"description\": \"Model-View-Controller is a software architecture\
+        \ that was created to\\nsatisfy the need to separate utility code (controller)\
+        \ from application\\nlogic code (model) and from code for displaying data\
+        \ (view) in applications\\nwith graphical user interface. With this approach\
+        \ we make the application\\nbetter understandable, simplify future development\
+        \ and enable testing each\\nunit of the application separately.\\n\\nTo use\
+        \ this library, you just have to add, in your project:\\n  require_once '/usr/share/php/Nette/Application/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette-application\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277470\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Nette Application MVC Component\",\n      \"upstream_url\"\
+        : \"https://github.com/nette/application\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1453298659.0,\n      \"description\": \"Loads\
+        \ Nette Framework and all libraries.\\n\\nClass Configurator creates so called\
+        \ DI container\\nand handles application initialization.\\n\\nTo use this\
+        \ library, you just have to add, in your project:\\n  require_once '/usr/share/php/Nette/Bootstrap/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette-bootstrap\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277476\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Nette Bootstrap\",\n      \"upstream_url\": \"https://github.com/nette/bootstrap\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1448810491.0,\n\
+        \      \"description\": \"Cache accelerates your application by storing data,\
+        \ once hardly retrieved,\\nfor future use.\\n\\nTo use this library, you just\
+        \ have to add, in your project:\\n  require_once '/usr/share/php/Nette/Caching/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette-caching\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277409\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Nette Caching Component\",\n      \"upstream_url\"\
+        : \"https://github.com/nette/caching\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1447683694.0,\n      \"description\": \"Components\
+        \ are the foundation of reusable code. They make your work easier\\nand allow\
+        \ you to profit from community work. Components are wonderful.\\nNette Framework\
+        \ introduces several classes and interfaces for all these\\ntypes of components.\\\
+        n\\nObject inheritance allows us to have a hierarchic structure of classes\
+        \ like\\nin real world. We can create new classes by extending. These extended\
+        \ classes\\nare descendants of the original class and inherit its parameters\
+        \ and methods.\\nExtended class can add its own parameters and methods to\
+        \ the inherited ones.\\n\\nTo use this library, you just have to add, in your\
+        \ project:\\n  require_once '/usr/share/php/Nette/ComponentModel/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette-component-model\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1277395\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Nette Component Model\",\n      \"upstream_url\"\
+        : \"https://github.com/nette/component-model\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1449066194.0,\n      \"description\": \"Nette\
+        \ provides a powerful layer for accessing your database easily.\\n\\n- composes\
+        \ SQL queries with ease\\n- easily fetches data\\n- uses efficient queries\
+        \ and does not transmit unnecessary data\\n\\nThe Nette\\\\Database\\\\Connection\
+        \ class is a wrapper around the PDO\\nand represents a connection to the database.\
+        \ The core functionality\\nis provided by Nette\\\\Database\\\\Context. Nette\\\
+        \\Database\\\\Table layer\\nprovides an enhanced layer for table querying.\\\
+        n\\nTo use this library, you just have to add, in your project:\\n  require_once\
+        \ '/usr/share/php/Nette/Database/autoload.php';\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-nette-database\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1277474\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Nette Database Component\"\
+        ,\n      \"upstream_url\": \"https://github.com/nette/database\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1454689387.0,\n    \
+        \  \"description\": \"APIs and features removed from Nette Framework.\\n\\\
+        nTo use this library, you just have to add, in your project:\\n  require_once\
+        \ '/usr/share/php/Nette/Deprecated/autoload.php';\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-nette-deprecated\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1277478\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"APIs and features\
+        \ removed from Nette Framework\",\n      \"upstream_url\": \"https://github.com/nette/deprecated\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1448749408.0,\n\
+        \      \"description\": \"Purpose of the Dependecy Injection (DI) is to free\
+        \ classes from the\\nresponsibility for obtaining objects that they need for\
+        \ its operation\\n(these objects are called services). To pass them these\
+        \ services on their\\ninstantiation instead.\\n\\nNette DI is one of the most\
+        \ interesting part of framework.\\nIt is compiled DI container, extremely\
+        \ fast and easy to configure.\\n\\nTo use this library, you just have to add,\
+        \ in your project:\\n  require_once '/usr/share/php/Nette/DI/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette-di\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277397\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Nette Dependency Injection Component\",\n      \"\
+        upstream_url\": \"https://github.com/nette/di\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1447682810.0,\n      \"description\": \"Class\
+        \ Nette\\\\Utils\\\\Finder makes browsing the directory structure really easy.\\\
+        n\\nTo use this library, you just have to add, in your project:\\n  require_once\
+        \ '/usr/share/php/Nette/Finder/autoload.php';\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-nette-finder\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1277384\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Nette Finder: Files\
+        \ Searching\",\n      \"upstream_url\": \"https://github.com/nette/finder\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1449066131.0,\n\
+        \      \"description\": \"Nette\\\\Forms greatly facilitates creating and\
+        \ processing web forms.\\nWhat it can really do?\\n- validate sent data both\
+        \ client-side (JavaScript) and server-side\\n- provide high level of security\\\
+        n- multiple render modes\\n- translations, i18n\\n\\nTo use this library,\
+        \ you just have to add, in your project:\\n  require_once '/usr/share/php/Nette/Forms/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette-forms\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277465\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Nette Forms: greatly facilitates web forms\",\n  \
+        \    \"upstream_url\": \"https://github.com/nette/forms\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1448810608.0,\n      \"description\"\
+        : \"HTTP request and response are encapsulated in Nette\\\\Http\\\\Request\
+        \ and\\nNette\\\\Http\\\\Response objects which offer comfortable API and\
+        \ also act\\nas sanitization filter.\\n\\nTo use this library, you just have\
+        \ to add, in your project:\\n  require_once '/usr/share/php/Nette/Http/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette-http\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277415\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Nette HTTP Component\",\n      \"upstream_url\": \"\
+        https://github.com/nette/http\"\n    },\n    {\n      \"acls\": [],\n    \
+        \  \"creation_date\": 1451328802.0,\n      \"description\": \"Almost every\
+        \ web application needs to send e-mails, whether newsletters\\nor order confirmations.\
+        \ That's why Nette Framework provides necessary tools.\\n\\nTo use this library,\
+        \ you just have to add, in your project:\\n  require_once '/usr/share/php/Nette/Mail/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette-mail\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277434\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Nette Mail: Sending E-mails\",\n      \"upstream_url\"\
+        : \"https://github.com/nette/mail\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1447094537.0,\n      \"description\": \"Nette NEON:\
+        \ parser and generator for Nette Object Notation.\\n\\nTo use this library,\
+        \ you just have to add, in your project:\\n  require_once '/usr/share/php/Nette/Neon/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette-neon\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277376\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Nette NEON: parser and generator for Nette Object\
+        \ Notation\",\n      \"upstream_url\": \"https://github.com/nette/neon\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1447683756.0,\n\
+        \      \"description\": \"Generate PHP code with a simple programmatical API.\\\
+        n\\nTo use this library, you just have to add, in your project:\\n  require_once\
+        \ '/usr/share/php/Nette/PhpGenerator/autoload.php';\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-nette-php-generator\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1277388\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Nette PHP Generator\"\
+        ,\n      \"upstream_url\": \"https://github.com/nette/php-generator\"\n  \
+        \  },\n    {\n      \"acls\": [],\n      \"creation_date\": 1449065890.0,\n\
+        \      \"description\": \"If you need to find every information about any\
+        \ class, reflection is the\\nright tool to do it. You can easily find out\
+        \ which methods does any class\\nhave, what parameters do those methods accept,\
+        \ etc.\\n\\nNette\\\\Object simplifies access to class' self-reflection with\
+        \ method\\ngetReflection(), returning a Nette\\\\Reflection\\\\ClassType object.\\\
+        n\\nTo use this library, you just have to add, in your project:\\n  require_once\
+        \ '/usr/share/php/Nette/Reflection/autoload.php';\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-nette-reflection\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1277413\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Nette PHP Reflection\
+        \ Component\",\n      \"upstream_url\": \"https://github.com/nette/reflection\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1449066071.0,\n\
+        \      \"description\": \"RobotLoader is a tool that gives you comfort of\
+        \ automated class loading\\nfor your entire application including third-party\
+        \ libraries.\\n\\n- get rid of all require\\n- only necessary scripts are\
+        \ loaded\\n- requires no strict file naming conventions\\n- allows more classes\
+        \ in single file\\n\\nTo use this library, you just have to add, in your project:\\\
+        n  require_once '/usr/share/php/Nette/RobotLoader/autoload.php';\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\":\
+        \ \"php-nette-robot-loader\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277437\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Nette RobotLoader: comfortable autoloading\",\n  \
+        \    \"upstream_url\": \"https://github.com/nette/robot-loader\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1447087092.0,\n    \
+        \  \"description\": \"The Nette\\\\Utils\\\\SafeStram protocol for file manipulation\
+        \ guarantees\\natomicity and isolation of every file operation.\\n\\nTo use\
+        \ this library, you just have to add, in your project:\\n  require_once '/usr/share/php/Nette/SafeStream/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette-safe-stream\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277441\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Nette SafeStream: Atomic Operations\",\n      \"upstream_url\"\
+        : \"https://github.com/nette/safe-stream\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1449065998.0,\n      \"description\": \"Nette\
+        \ Security: Access Control\\n- user login and logout\\n- verifying user privileges\\\
+        n- securing against vulnerabilities\\n- how to create custom authenticators\
+        \ and authorizators\\n- Access Control List\\n\\nTo use this library, you\
+        \ just have to add, in your project:\\n  require_once '/usr/share/php/Nette/Security/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette-security\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277418\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Nette Security: Access Control Component\",\n    \
+        \  \"upstream_url\": \"https://github.com/nette/security\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1446684997.0,\n      \"description\"\
+        : \"Nette Tester is a productive and enjoyable unit testing framework.\\nIt's\
+        \ used by the Nette Framework and is capable of testing any PHP code.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette-tester\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277375\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"An easy-to-use PHP unit testing framework\",\n   \
+        \   \"upstream_url\": \"https://github.com/nette/tester\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1447079160.0,\n      \"description\"\
+        : \"Tokenizer is a tool that uses regular expressions to split given\\nstring\
+        \ into tokens. What the hell is that good for, you might ask?\\nWell, you\
+        \ can create your own languages! Tokenizer is used in Latte for example.\\\
+        n\\nTo use this library, you just have to add, in your project:\\n  require_once\
+        \ '/usr/share/php/Nette/Tokenizer/autoload.php';\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-nette-tokenizer\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1277379\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Nette Tokenizer\"\
+        ,\n      \"upstream_url\": \"https://github.com/nette/tokenizer\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1447079697.0,\n    \
+        \  \"description\": \"Nette Utility Classes.\\n\\nTo use this library, you\
+        \ just have to add, in your project:\\n  require_once '/usr/share/php/Nette/Utils/autoload.php';';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-nette-utils\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1277377\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Nette Utility Classes\",\n      \"upstream_url\":\
+        \ \"https://github.com/nette/utils\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1463495098.0,\n      \"description\": \"This is\
+        \ a PHP 5.2 to PHP 7.0 parser written in PHP.\\nIts purpose is to simplify\
+        \ static code analysis and manipulation.\\n\\n\\n\\nThis package provides\
+        \ the library version 2.\\n\\nThe php-nikic-php-parser3 packages provides\
+        \ the library version 3.\\nThe php-PHPParser package provides the library\
+        \ version 1.\\n\\nDocumentation: https://github.com/nikic/PHP-Parser/tree/2.x/doc\\\
+        n\\nAutoloader: /usr/share/php/PhpParser2/autoload.php\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-nikic-php-parser\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1327566\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A PHP parser written\
+        \ in PHP\",\n      \"upstream_url\": \"https://github.com/nikic/PHP-Parser\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1481807828.0,\n\
+        \      \"description\": \"This is a PHP 5.2 to PHP 7.1 parser written in PHP.\\\
+        nIts purpose is to simplify static code analysis and manipulation.\\n\\nThis\
+        \ package provides the library version 3 and the php-parse3 command.\\n\\\
+        nDocumentation: https://github.com/nikic/PHP-Parser/tree/master/doc\\n\\nAutoloader:\
+        \ /usr/share/php/PhpParser3/autoload.php\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-nikic-php-parser3\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1402446\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A PHP parser written\
+        \ in PHP\",\n      \"upstream_url\": \"https://github.com/nikic/PHP-Parser\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Flexible and feature-complete PHP client library\
+        \ for Redis.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-nrk-Predis\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"PHP client library for Redis\",\n      \"upstream_url\": \"http://pear.nrk.io\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"An open protocol to allow API authentication in\
+        \ a simple and standard\\nmethod from desktop and web applications.\",\n \
+        \     \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-oauth\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"PHP Authentication\
+        \ library for desktop to web applications\",\n      \"upstream_url\": \"http://code.google.com/p/oauth/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1405947254.0,\n\
+        \      \"description\": \"This library provides a way of avoiding usage of\
+        \ constructors when\\ninstantiating PHP classes.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-ocramius-instantiator\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1120563\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Instantiate objects\
+        \ in PHP without invoking their constructors\",\n      \"upstream_url\": \"\
+        https://github.com/Ocramius/Instantiator\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1405947148.0,\n      \"description\": \"This\
+        \ small library aims at providing a very simple and efficient map\\nof lazy-instantiating\
+        \ objects.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-ocramius-lazy-map\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1120543\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Lazy instantiation logic for\
+        \ a map of objects\",\n      \"upstream_url\": \"https://github.com/Ocramius/LazyMap\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453299011.0,\n\
+        \      \"description\": \"A library for dynamically streaming dynamic tar\
+        \ files without\\nthe need to have the complete file stored on the server.\\\
+        n\\nAutoloader: /usr/share/php/ownCloud/TarStreamer/autoload.php\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\":\
+        \ \"php-owncloud-tarstreamer\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1296939\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Streaming dynamic tar files\",\n   \
+        \   \"upstream_url\": \"https://github.com/owncloud/TarStreamer\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"PEAR is a framework and distribution system for reusable\
+        \ PHP\\ncomponents.  This package contains the basic PEAR components.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"php-pear\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"PHP Extension and Application\
+        \ Repository framework\",\n      \"upstream_url\": \"http://pear.php.net/package/PEAR\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The PEAR::Auth package provides methods for creating\
+        \ an authentication\\nsystem using PHP.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-Auth\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Authentication provider for PHP\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/Auth\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"This package\
+        \ provides wrapper-classes for the RADIUS PECL.\\nThere are different Classes\
+        \ for the different authentication methods.\\nIf you are using CHAP-MD5 or\
+        \ MS-CHAP you need also the Crypt_CHAP package.\\nIf you are using MS-CHAP\
+        \ you need also the mcrypt extension.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-Auth-RADIUS\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Wrapper Classes for the RADIUS PECL\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Auth_RADIUS\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides code to generate responses to common SASL\
+        \ mechanisms, including:\\no Digest-MD5\\no CramMD5\\no Plain\\no Anonymous\\\
+        no Login (Pseudo mechanism)\",\n      \"koschei_monitor\": false,\n      \"\
+        monitor\": false,\n      \"name\": \"php-pear-Auth-SASL\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Abstraction of various SASL mechanism responses\",\n\
+        \      \"upstream_url\": \"http://pear.php.net/package/Auth_SASL\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Framework to benchmark PHP scripts or function calls.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pear-Benchmark\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Framework to benchmark PHP scripts or function calls\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/Benchmark\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ package is a PEAR library for using a Central Authentication Service.\\\
+        n\\nAutoloader '%{pear_phpdir}/CAS/Autoload.php';\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-CAS\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Central Authentication Service client\
+        \ library in php\",\n      \"upstream_url\": \"https://wiki.jasig.org/display/CASC/phpCAS\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"With the PEAR Cache you can cache the result of\
+        \ certain function\\ncalls, as well as the output of a whole script run or\
+        \ share data\\nbetween applications.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-Cache\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Framework for caching of arbitrary data\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Cache\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"This package is a little cache system optimized for\
+        \ file containers. It is\\nfast and safe (because it uses file locking and/or\
+        \ anti-corruption tests).\",\n      \"koschei_monitor\": false,\n      \"\
+        monitor\": false,\n      \"name\": \"php-pear-Cache-Lite\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Fast and Safe little cache system for PHP\",\n     \
+        \ \"upstream_url\": \"http://pear.php.net/package/Cache_Lite\"\n    },\n \
+        \   {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n     \
+        \ \"description\": \"The Console_Color class makes it easy to use ANSI color\
+        \ codes from CLI-based\\napplications written in PHP.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"php-pear-Console-Color\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Easily use ANSI console colors from\
+        \ PHP applications\",\n      \"upstream_url\": \"http://pear.php.net/package/Console_Color\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Console_CommandLine is a full featured package for\
+        \ managing command-line\\noptions and arguments highly inspired from python\
+        \ optparse module, it allows\\nthe developer to easily build complex command\
+        \ line interfaces.\\n\\nMain features:\\n* handles sub commands (i.e. $ my-script.php\
+        \ -q sub-command -f file),\\n* can be completely built from an XML definition\
+        \ file,\\n* generate --help and --version options automatically,\\n* can be\
+        \ completely customized,\\n* built-in support for i18n,\\n* and much more...\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pear-Console-CommandLine\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"A full featured command line options and arguments parser\",\n      \"\
+        upstream_url\": \"http://pear.php.net/package/Console_CommandLine\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"The Console_Getargs package implements a Command Line\
+        \ arguments and\\nparameters parser for your CLI applications. It performs\
+        \ some basic\\narguments validation and automatically creates a formatted\
+        \ help text,\\nbased on the given configuration.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-Console-Getargs\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Command-line arguments and parameters\
+        \ parser\",\n      \"upstream_url\": \"http://pear.php.net/package/Console_Getargs\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The class allows you to display progress bars in\
+        \ your terminal. You can use\\nthis for displaying the status of downloads\
+        \ or other tasks that take some\\ntime.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-Console-ProgressBar\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"This class provides you with an easy-to-use\
+        \ interface to progress bars\",\n      \"upstream_url\": \"http://pear.php.net/package/Console_ProgressBar\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides methods such as addRow(), insertRow(),\
+        \ addCol() etc. to build\\nconsole tables with or without headers and with\
+        \ user defined table rules\\nand padding.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-Console-Table\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Class that makes it easy to build console\
+        \ style tables\",\n      \"upstream_url\": \"http://pear.php.net/package/Console_Table\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package provides Classes for generating CHAP\
+        \ packets.\\nCurrently these types of CHAP are supported:\\n- CHAP-MD5,\\\
+        n- MS-CHAPv1,\\n- MS-CHAPv2.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": false,\n      \"name\": \"php-pear-Crypt-CHAP\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Class to generate CHAP packets\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/Crypt_CHAP\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"DataObject\
+        \ performs 2 tasks:\\n1. Builds SQL statements based on the objects vars and\
+        \ the builder methods.\\n2. acts as a datastore for a table row.\\n\\nThe\
+        \ core class is designed to be extended for each of your tables so that you\\\
+        nput the data logic inside the data classes. Included is a Generator to make\\\
+        nyour configuration files and your base classes.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-DB-DataObject\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An SQL Builder, Object Interface to\
+        \ Database Tables\",\n      \"upstream_url\": \"http://pear.php.net/package/DB_DataObject\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"DB_DataObject_FormBuilder will aid you in rapid\
+        \ application development using\\nthe packages DB_DataObject and HTML_QuickForm.\
+        \ For having a quick but working\\nprototype of your application, simply model\
+        \ the database, run DataObject's\\ncreateTable script over it and write a\
+        \ script that passes one of the resulting\\nobjects to the FormBuilder class.\
+        \ The FormBuilder will automatically generate\\na simple but working HTML_QuickForm\
+        \ object that you can use to test your\\napplication. It also provides a processing\
+        \ method that will automatically\\ndetect if an insert() or update() command\
+        \ has to be executed after the form\\nhas been submitted. If you have set\
+        \ up DataObject's links.ini file correctly,\\nit will also automatically detect\
+        \ if a table field is a foreign key and will\\npopulate a selectbox with the\
+        \ linked table's entries. There are many optional\\nparameters that you can\
+        \ place in your DataObjects.ini or in the properties of\\nyour derived classes,\
+        \ that you can use to fine-tune the form-generation,\\ngradually turning the\
+        \ prototypes into fully-featured forms, and you can take\\ncontrol at any\
+        \ stage of the process.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pear-DB-DataObject-FormBuilder\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Automatically build HTML_QuickForm objects\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/DB_DataObject_FormBuilder\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package is an OO-abstraction to the SQL-Query\
+        \ language, it provides\\nmethods such as setWhere, setOrder, setGroup, setJoin,\
+        \ etc. to easily\\nbuild queries.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-DB-QueryTool\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An OO-interface for easily retrieving\
+        \ and modifying data in a DB\",\n      \"upstream_url\": \"http://pear.php.net/package/DB_QueryTool\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Generic classes for representation and manipulation\
+        \ of dates, times and time\\nzones without the need of timestamps, which is\
+        \ a huge limitation for php\\nprograms. Includes time zone data, time zone\
+        \ conversions and many date/time\\nconversions.  It does not rely on 32-bit\
+        \ system date stamps, so you can display\\ncalendars and compare dates that\
+        \ date pre 1970 and post 2038. This package also\\nprovides a class to convert\
+        \ date strings between Gregorian and Human calendar\\nformats.\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\": \"php-pear-Date\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Date and Time Zone Classes\",\n    \
+        \  \"upstream_url\": \"http://pear.php.net/package/Date\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Date_Holidays helps you calculating the dates and titles of holidays and\\\
+        nother special celebrations. The calculation is driver-based so it is easy\\\
+        nto add new drivers that calculate a country's holidays. The methods of the\\\
+        nclass can be used to get a holiday's date and title in various languages.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pear-Date-Holidays\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Driver based class to calculate holidays\",\n      \"upstream_url\": \"\
+        http://pear.php.net/package/Date_Holidays\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Date_Holidays\
+        \ helps you calculate the dates and titles of holidays and other\\nspecial\
+        \ celebrations.  This is the driver for calculating holidays in USA.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pear-Date-Holidays-USA\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Driver based class to calculate holidays in USA\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/Date_Holidays_USA\"\n    },\n    {\n     \
+        \ \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"The Event_Dispatcher acts as a notification dispatch table.\\nIt is used\
+        \ to notify other objects of interesting things. This\\ninformation is encapsulated\
+        \ in Event_Notification objects. Client\\nobjects register themselves with\
+        \ the Event_Dispatcher as observers of\\nspecific notifications posted by\
+        \ other objects. When an event occurs,\\nan object posts an appropriate notification\
+        \ to the Event_Dispatcher.\\nThe Event_Dispatcher dispatches a message to\
+        \ each registered\\nobserver, passing the notification as the sole argument.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pear-Event-Dispatcher\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Dispatch notifications using PHP callbacks\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/Event_Dispatcher\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Provides easy access to read/write to files along with some common routines\\\
+        nto deal with paths.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pear-File\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Common file and directory routines\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/File\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"Read and\
+        \ write of CSV files as well as discovering the format the CSV file\\nis in.\\\
+        n\\nSupports headers and is excel compatible, i.e. =\\\"0004\\\" outputs as\
+        \ 0004\\n(only read wise)\\n\\nFor more information on CSV: http://rfc.net/rfc4180.html\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pear-File-CSV\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Read and write\
+        \ of CSV files\",\n      \"upstream_url\": \"http://pear.php.net/package/File_CSV\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"File_Find, created as a replacement for its Perl\
+        \ counterpart, also named\\nFile_Find, is a directory searcher, which handles,\
+        \ globbing, recursive\\ndirectory searching, as well as a slew of other cool\
+        \ features.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-File-Find\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Class which facilitates the search of filesystems\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/File_Find\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"File_Fstab\
+        \ is an easy-to-use package which can read & write UNIX fstab\\nfiles. It\
+        \ presents a pleasant object-oriented interface to the fstab.\\nFeatures:\\\
+        n* Supports blockdev, label, and UUID specification of mount device.\\n* Extendable\
+        \ to parse non-standard fstab formats by defining a new Entry\\nclass for\
+        \ that format.\\n* Easily examine and set mount options for an entry.\\n*\
+        \ Stable, functional interface.\\n* Fully documented with PHPDoc.\",\n   \
+        \   \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pear-File-Fstab\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Read and write\
+        \ fstab files\",\n      \"upstream_url\": \"http://pear.php.net/package/File_Fstab\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides methods to manipulate and authenticate\
+        \ against standard Unix,\\nSMB server, AuthUser (.htpasswd), AuthDigest (.htdigest),\
+        \ CVS pserver\\nand custom formatted password files.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-File-Passwd\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Manipulate many kinds of password files\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/File_Passwd\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"With this package, you can maintain smbpasswd-files,\
+        \ usually used by SAMBA.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pear-File-SMBPasswd\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Class for managing SAMBA style password files\",\n \
+        \     \"upstream_url\": \"http://pear.php.net/package/File_SMBPasswd\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Common file and directory utility functions. Path\
+        \ handling, temp dir/file,\\nsorting of files, listDirs, isIncludable and\
+        \ more.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-File-Util\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Common file and directory utility functions\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/File_Util\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"The\
+        \ PEAR::HTML_Common package provides methods for html code display and\\nattributes\
+        \ handling.\\n* Methods to set, remove, update html attributes.\\n* Handles\
+        \ comments in HTML code.\\n* Handles layout, tabs, line endings for nicer\
+        \ HTML code.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-HTML-Common\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Base class for other HTML classes\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/HTML_Common\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"The\
+        \ HTML_QuickForm package provides methods to dynamically create, validate\\\
+        nand render HTML forms.\\n\\nFeatures:\\n* More than 20 ready-to-use form\
+        \ elements.\\n* XHTML compliant generated code.\\n* Numerous mixable and extendable\
+        \ validation rules.\\n* Automatic server-side validation and filtering.\\\
+        n* On request JavaScript code generation for client-side validation.\\n* File\
+        \ uploads support.\\n* Total customization of form rendering.\\n* Support\
+        \ for external template engines (ITX, Sigma, Flexy, Smarty).\\n* Pluggable\
+        \ elements, rules and renderers extensions.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-HTML-QuickForm\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Class for creating, validating, processing\
+        \ HTML forms\",\n      \"upstream_url\": \"http://pear.php.net/package/HTML_QuickForm\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"An HTML_QuickForm meta-element which holds multiple\
+        \ HTML_QuickForm elements in\\nan HTML_Table. The elements in the table should\
+        \ behave exactly like normal\\nelements in a form, such as freezing and getting\
+        \ defaults and submitted values\\ncorrectly.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-HTML-QuickForm-ElementGrid\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Meta-element which holds any other element\
+        \ in a grid\",\n      \"upstream_url\": \"http://pear.php.net/package/HTML_QuickForm_ElementGrid\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The HTML_QuickForm_advmultiselect package adds an\
+        \ element to the\\nHTML_QuickForm package that is two select boxes next to\
+        \ each other\\nemulating a multi-select.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-HTML-QuickForm-advmultiselect\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Element for HTML_QuickForm that emulate\
+        \ a multi-select\",\n      \"upstream_url\": \"http://pear.php.net/package/HTML_QuickForm_advmultiselect\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The PEAR::HTML_Table package provides methods for\
+        \ easy and efficient design\\nof HTML tables.\\n- Lots of customization options.\\\
+        n- Tables can be modified at any time.\\n- The logic is the same as standard\
+        \ HTML editors.\\n- Handles col and row spans.\\n- PHP code is shorter, easier\
+        \ to read and to maintain.\\n- Tables options can be reused.\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\": \"php-pear-HTML-Table\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Class to easily design HTML tables\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/HTML_Table\"\n  \
+        \  },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The HTTP class is a class with static methods for\
+        \ doing\\nmiscellaneous HTTP related stuff like date formatting,\\nlanguage\
+        \ negotiation or HTTP redirection.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-HTTP\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Miscellaneous HTTP utilities\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/HTTP\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"The HTTP_Client\
+        \ class wraps around HTTP_Request and provides a higher level\\ninterface\
+        \ for performing multiple HTTP requests.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-HTTP-Client\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Easy way to perform multiple HTTP requests\
+        \ and process their results\",\n      \"upstream_url\": \"http://pear.php.net/package/HTTP_Client\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Allows the use of the consumer and provider angles\
+        \ of the OAuth spec.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pear-HTTP-OAuth\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n  \
+        \    \"summary\": \"Implementation of the OAuth spec\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/HTTP_OAuth\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Supports\
+        \ GET/POST/HEAD/TRACE/PUT/DELETE, Basic authentication, Proxy,\\nProxy Authentication,\
+        \ SSL, file uploads etc.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pear-HTTP-Request\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Provides an easy way to perform HTTP requests\",\n \
+        \     \"upstream_url\": \"http://pear.php.net/package/HTTP_Request\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHP5 rewrite of HTTP_Request package. Provides cleaner\
+        \ API and pluggable\\nAdapters. Currently available are:\\n  * Socket adapter,\
+        \ based on old HTTP_Request code,\\n  * Curl adapter, wraps around PHP's cURL\
+        \ extension,\\n  * Mock adapter, to use for testing packages dependent on\
+        \ HTTP_Request2.\\nSupports POST requests with data and file uploads, basic\
+        \ and digest\\nauthentication, cookies, proxies, gzip and deflate encodings,\
+        \ monitoring\\nthe request progress with Observers...\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-HTTP-Request2\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Provides an easy way to perform HTTP\
+        \ requests\",\n      \"upstream_url\": \"http://pear.php.net/package/HTTP_Request2\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This class provides an advanced file uploader system\
+        \ for file uploads made\\nfrom html forms. Features:\\n* Can handle from one\
+        \ file to multiple files.\\n* Safe file copying from tmp dir.\\n* Easy detecting\
+        \ mechanism of valid upload, missing upload or error.\\n* Gives extensive\
+        \ information about the uploaded file.\\n* Rename uploaded files in different\
+        \ ways: as it is, safe or unique\\n* Validate allowed file extensions\\n*\
+        \ Multiple languages error messages support (es, en, de, fr, it, nl, pt_BR)\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pear-HTTP-Upload\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Secure managment of files submitted via HTML Forms\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/HTTP_Upload\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"A\
+        \ package providing a common interface to image drawing, making\\nimage source\
+        \ code independent on the library used.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-Image-Canvas\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Common interface to image drawing\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Image_Canvas\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Manage and handles color data and conversions.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pear-Image-Color\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Manage and handles color data and conversions\",\n      \"upstream_url\":\
+        \ \"http://pear.php.net/package/Image_Color\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Image_Graph\
+        \ provides a set of classes that creates graphs/plots/charts based on\\n(numerical)\
+        \ data.\\n\\nMany different plot types are supported: Bar, line, area, step,\
+        \ impulse,\\nscatter, radar, pie, map, candlestick, band, box & whisker and\
+        \ smoothed line,\\narea and radar plots.\\n\\nThe graph is highly customizable,\
+        \ making it possible to get the exact look and\\nfeel that is required.\\\
+        n\\nThe output is controlled by a Image_Canvas, which facilitates easy output\
+        \ to\\nmany different output formats, amongst others, GD (PNG, JPEG, GIF,\
+        \ WBMP),\\nPDF (using PDFLib), Scalable Vector Graphics (SVG).\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\": \"php-pear-Image-Graph\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Displays numerical data as a graph/chart/plot\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Image_Graph\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The GraphViz class allows for the creation of and\
+        \ the work with directed and\\nundirected graphs and their visualization with\
+        \ AT&T's GraphViz tools.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pear-Image-GraphViz\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Interface to AT&T's GraphViz tools\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/Image_GraphViz\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Image_Text provides a comfortable interface to text manipulations in GD\\\
+        nimages. Beside common Freetype2 functionality it offers to handle texts\\\
+        nin a graphic- or office-tool like way. For example it allows alignment of\\\
+        ntexts inside a text box, rotation (around the top left corner of a text\\\
+        nbox or it's center point) and the automatic measurement of the optimal\\\
+        nfont size for a given text box.\",\n      \"koschei_monitor\": false,\n \
+        \     \"monitor\": false,\n      \"name\": \"php-pear-Image-Text\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Advanced text manipulations in images\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Image_Text\"\n  \
+        \  },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The Log framework provides an abstracted logging\
+        \ system.\\nIt supports logging to console, file, syslog, SQL, Sqlite, mail,\
+        \ and mcal\\ntargets.  It also provides a subject - observer mechanism.\\\
+        n\\nphp-pear-Log can optionally use package \\\"php-pear-DB\\\" (version >=\
+        \ 1.3)\\nand \\\"php-pear-MDB2\\\" (version >= 2.0.0RC1).\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-Log\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Abstracted logging facility for PHP\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Log\"\n    },\n \
+        \   {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n     \
+        \ \"description\": \"PEAR::MDB2 is a merge of the PEAR::DB and Metabase php\
+        \ database abstraction\\nlayers.\\n\\nIt provides a common API for all supported\
+        \ RDBMS. The main difference to most\\nother DB abstraction packages is that\
+        \ MDB2 goes much further to ensure\\nportability.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-MDB2\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Database Abstraction Layer\",\n    \
+        \  \"upstream_url\": \"http://pear.php.net/package/MDB2\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This is the MySQL MDB2 driver.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-MDB2-Driver-mysql\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"MySQL MDB2 driver\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/MDB2_Driver_mysql\"\n    },\n    {\n     \
+        \ \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This is the MySQL Improved MDB2 driver.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-pear-MDB2-Driver-mysqli\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"MySQL Improved MDB2 driver\",\n    \
+        \  \"upstream_url\": \"http://pear.php.net/package/MDB2_Driver_mysqli\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is the PostgreSQL MDB2 driver.\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\": \"php-pear-MDB2-Driver-pgsql\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PostgreSQL MDB2 driver\",\n      \"\
+        upstream_url\": \"http://pear.php.net/package/MDB2_Driver_pgsql\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"PEAR's Mail package defines an interface for implementing\
+        \ mailers under the\\nPEAR hierarchy.  It also provides supporting functions\
+        \ useful to multiple\\nmailer backends.  Currently supported backends include:\
+        \ PHP's native\\nmail() function, sendmail, and SMTP.  This package also provides\
+        \ a RFC822\\nemail address list validation utility class.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-Mail\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Class that provides multiple interfaces\
+        \ for sending emails\",\n      \"upstream_url\": \"http://pear.php.net/package/Mail\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Mail_Mime provides classes to deal with the creation\
+        \ and manipulation\\nof MIME messages. It allows people to create e-mail messages\
+        \ consisting of:\\n* Text Parts\\n* HTML Parts\\n* Inline HTML Images\\n*\
+        \ Attachments\\n* Attached messages\\n\\nIt supports big messages, base64\
+        \ and quoted-printable encoding and\\nnon-ASCII characters in file names,\
+        \ subjects, recipients, etc. encoded\\nusing RFC2047 and/or RFC2231.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pear-Mail-Mime\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Classes to\
+        \ create MIME messages\",\n      \"upstream_url\": \"http://pear.php.net/package/Mail_Mime\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides a class to deal with the decoding and interpreting\
+        \ of mime messages.\\nThis package used to be part of the Mail_Mime package,\
+        \ but has been split off.\\n\\nTo run post-installation tests, execute:\\\
+        npear run-tests -p Mail_mimeDecode\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-Mail-mimeDecode\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Class to decode mime messages\",\n \
+        \     \"upstream_url\": \"http://pear.php.net/package/Mail_mimeDecode\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Package to calculate statistical parameters of numerical\
+        \ arrays\\nof data. The data can be in a simple numerical array, or in a\\\
+        ncumulative numerical array. A cumulative array, has the value\\nas the index\
+        \ and the number of repeats as the value for the\\narray item, e.g. $data\
+        \ = array(3=>4, 2.3=>5, 1.25=>6, 0.5=>3).\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-Math-Stats\",\n   \
+        \   \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Classes to calculate statistical parameters\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Math_Stats\"\n  \
+        \  },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides an Object-Oriented interface to PHP's curl\
+        \ extension.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-Net-Curl\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"OO interface to PHP's cURL extension\",\n      \"upstream_url\": \"http://pear.php.net/package/Net_Curl\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is the initial independent release of the Net_DIME\
+        \ package.\\nProvides an implementation of \\\"Direct Internet Message Encapsulation\\\
+        \" (DIME)\\nas defined at http://search.ietf.org/internet-drafts/draft-nielsen-dime-02.txt\\\
+        n\\nNote : this specification has been superseded by the SOAP Message Transmission\\\
+        nOptimization Mechanism (MTOM) specification.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-Net-DIME\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Implements Direct Internet Message Encapsulation\
+        \ (DIME)\",\n      \"upstream_url\": \"http://pear.php.net/package/Net_DIME\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A resolver library used to communicate with a name\
+        \ server to perform DNS\\nqueries, zone transfers, dynamic DNS updates, etc.\
+        \ Creates an object\\nhierarchy from a DNS server response, which allows you\
+        \ to view all of\\nthe information given by the DNS server. It bypasses the\
+        \ system\\nresolver library and communicates directly with the server.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pear-Net-DNS\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Resolver library\
+        \ used to communicate with a DNS server\",\n      \"upstream_url\": \"http://pear.php.net/package/Net_DNS\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Net_DNS2 - Native PHP5 DNS Resolver and Updater\\\
+        n\\nThe main features for this package include:\\n* Increased performance;\
+        \ most requests are 2-10x faster than Net_DNS\\n* Near drop-in replacement\
+        \ for Net_DNS\\n* Uses PHP5 style classes and exceptions\\n* Support for IPv4\
+        \ and IPv6, TCP and UDP sockets.\\n* Includes a separate, more intuitive Updater\
+        \ class for handling dynamic update\\n* Support zone signing using TSIG and\
+        \ SIG(0) for updates and zone transfers\\n* Includes a local cache using shared\
+        \ memory or flat file to improve performance\\n* includes many more RR's,\
+        \ including DNSSEC RR's.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pear-Net-DNS2\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n  \
+        \    \"summary\": \"PHP Resolver library used to communicate with a DNS server\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Net_DNS2\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Net_FTP allows you to communicate with FTP servers in\
+        \ a more comfortable\\nway than the native FTP functions of PHP do. The class\
+        \ implements everything\\nnativly supported by PHP and additionally features\
+        \ like recursive up- and\\ndownloading, dircreation and chmodding. It although\
+        \ implements an observer\\npattern to allow for example the view of a progress\
+        \ bar.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-Net-FTP\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Provides an OO interface to the PHP FTP functions plus some additions\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Net_FTP\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Provides an implementation of the IMAP4Rev1 protocol\
+        \ using PEAR's\\nNet_Socket and the optional Auth_SASL class.\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\": \"php-pear-Net-IMAP\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Provides an implementation of the IMAP\
+        \ protocol\",\n      \"upstream_url\": \"http://pear.php.net/package/Net_IMAP\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Class used for calculating IPv4 (AF_INET family)\
+        \ address information\\nsuch as network as network address, broadcast address,\
+        \ and IP address\\nvalidity.\",\n      \"koschei_monitor\": false,\n     \
+        \ \"monitor\": false,\n      \"name\": \"php-pear-Net-IPv4\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"IPv4 network calculations and validation\",\n      \"\
+        upstream_url\": \"http://pear.php.net/package/Net_IPv4\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1424772665.0,\n      \"description\"\
+        : \"Net_LDAP2 is the successor of Net_LDAP (which is a clone of Perls Net::LDAP)\\\
+        nobject interface to directory servers. It does contain most of Net::LDAPs\\\
+        nfeatures but has some own too.\\n\\nWith Net_LDAP2 you have:\\n* A simple\
+        \ object-oriented interface to connections,\\n  searches entries and filters.\\\
+        n* Support for TLS and LDAP v3.\\n* Simple modification, deletion and creation\
+        \ of LDAP entries.\\n* Support for schema handling.\\n\\nNet_LDAP2 layers\
+        \ itself on top of PHP's existing ldap extensions.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"php-pear-Net-LDAP2\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1195054\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Object oriented interface\
+        \ for searching and manipulating LDAP-entries\",\n      \"upstream_url\":\
+        \ \"http://pear.php.net/package/Net_LDAP2\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Provides\
+        \ a POP3 class to access POP3 server. Support all POP3 commands\\nincluding\
+        \ UIDL listings, APOP authentication, DIGEST-MD5 and CRAM-MD5 using\\noptional\
+        \ Auth_SASL package.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pear-Net-POP3\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n  \
+        \    \"summary\": \"Provides a POP3 class to access POP3 server\",\n     \
+        \ \"upstream_url\": \"http://pear.php.net/package/Net_POP3\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"OS independent wrapper class for executing ping calls.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pear-Net-Ping\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Execute ping\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Net_Ping\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Provides an implementation of the SMTP protocol using\
+        \ PEAR's Net_Socket class.\\n\\nphp-pear-Net-SMTP can optionally use package\
+        \ \\\"php-pear-Auth-SASL\\\".\",\n      \"koschei_monitor\": false,\n    \
+        \  \"monitor\": false,\n      \"name\": \"php-pear-Net-SMTP\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Provides an implementation of the SMTP protocol\",\n\
+        \      \"upstream_url\": \"http://pear.php.net/package/Net_SMTP\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"This package provides an API to talk to servers implementing\
+        \ the\\nmanagesieve protocol. It can be used to install and remove sieve\\\
+        nscripts, mark them active etc.\",\n      \"koschei_monitor\": false,\n  \
+        \    \"monitor\": false,\n      \"name\": \"php-pear-Net-Sieve\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Handles talking to a sieve server\",\n \
+        \     \"upstream_url\": \"http://pear.php.net/package/Net_Sieve\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Net_Socket is a class interface to TCP sockets.  It\
+        \ provides blocking\\nand non-blocking operation, with different reading and\
+        \ writing modes\\n(byte-wise, block-wise, line-wise and special formats like\
+        \ network\\nbyte-order ip addresses).\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-Net-Socket\",\n   \
+        \   \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Network Socket Interface\",\n      \"\
+        upstream_url\": \"http://pear.php.net/package/Net_Socket\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"OS independent wrapper class for executing traceroute calls.\",\n    \
+        \  \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pear-Net-Traceroute\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Execute traceroute\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Net_Traceroute\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides easy parsing of URLs and their constituent\
+        \ parts.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-Net-URL\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Easy parsing of URLs\",\n      \"upstream_url\": \"http://pear.php.net/package/Net_URL\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Net_URL_Mapper provides a simple and flexible way\
+        \ to build nice URLs for your\\nweb applications.\\n\\nThe URL syntax is similar\
+        \ to what can be found in Ruby on Rails or Python\\nRoutes module and as such,\
+        \ this package can be compared to what they call a\\nrouter. Still, Net_URL_Mapper\
+        \ does not perform the dispatching like these\\nframeworks and therefore can\
+        \ be used with your own router.\",\n      \"koschei_monitor\": false,\n  \
+        \    \"monitor\": false,\n      \"name\": \"php-pear-Net-URL-Mapper\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Simple and flexible way to build nice\
+        \ URLs for web applications\",\n      \"upstream_url\": \"http://pear.php.net/package/Net_URL_Mapper\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides parsing of URLs into their constituent\
+        \ parts (scheme, host, path\\netc.), URL generation, and resolving of relative\
+        \ URLs.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-Net-URL2\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Class for parsing and handling URL\",\n      \"upstream_url\": \"http://pear.php.net/package/Net_URL2\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The Net_UserAgent object does a number of tests\
+        \ on an HTTP user\\nagent string. The results of these tests are available\
+        \ via methods of\\nthe object.\",\n      \"koschei_monitor\": false,\n   \
+        \   \"monitor\": false,\n      \"name\": \"php-pear-Net-UserAgent-Detect\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Extract information from an HTTP user\
+        \ agent\",\n      \"upstream_url\": \"http://pear.php.net/package/Net_UserAgent_Detect\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Numbers_Roman provides static methods for converting\
+        \ to and from Roman\\nnumerals. It supports Roman numerals in both uppercase\
+        \ and lowercase\\nstyles and conversion for and to numbers up to 5 999 999.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pear-Numbers-Roman\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Provides methods for converting to and from Roman Numerals\",\n      \"\
+        upstream_url\": \"http://pear.php.net/package/Numbers_Roman\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"With Numbers_Words class you can convert numbers written\
+        \ in Arabic digits to\\nwords in several languages.  You can convert an integer\
+        \ between -infinity and\\ninfinity.  If your system does not support such\
+        \ long numbers you can call\\nNumbers_Words::toWords() with just a string.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pear-Numbers-Words\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Methods for spelling numerals in words\",\n      \"upstream_url\": \"\
+        http://pear.php.net/package/Numbers_Words\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"PHP_CodeSniffer\
+        \ provides functionality to verify that code conforms to\\ncertain standards,\
+        \ such as PEAR, or user-defined.\",\n      \"koschei_monitor\": true,\n  \
+        \    \"monitor\": false,\n      \"name\": \"php-pear-PHP-CodeSniffer\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PHP coding standards enforcement tool\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/PHP_CodeSniffer\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHP_Compat provides missing functionality for older\
+        \ versions of PHP.\\nThis include fonctions and constants.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-PHP-Compat\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Provides missing functionality for older\
+        \ versions of PHP\",\n      \"upstream_url\": \"http://pear.php.net/package/PHP_Compat\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHP_CompatInfo will parse a file/folder/script/array\
+        \ to find out the\\nminimum version and extensions required for it to run.\
+        \ Features advanced\\ndebug output which shows which functions require which\
+        \ version and CLI\\noutput script\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-PHP-CompatInfo\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Find out version and extensions required\
+        \ for a piece of code to run\",\n      \"upstream_url\": \"http://pear.php.net/package/PHP_CompatInfo\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHPUnit is a family of PEAR packages that supports\
+        \ the development of\\nobject-oriented PHP applications using the concepts\
+        \ and methods of Agile\\nSoftware Development, Extreme Programming, Test-Driven\
+        \ Development and\\nDesign-by-Contract Development by providing an elegant\
+        \ and robust framework\\nfor the creation, execution and analysis of Unit\
+        \ Tests.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-PHPUnit\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Regression testing framework for unit tests\",\n      \"upstream_url\"\
+        : \"http://www.phpunit.de\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"It takes an array\
+        \ of data as input and pages it according to various\\nparameters. It also\
+        \ builds links within a specified range, and allows\\ncomplete customization\
+        \ of the output (it even works with front controllers\\nand mod_rewrite).\
+        \ Two operating modes available: \\\"Jumping\\\" and \\\"Sliding\\\"\\nwindow\
+        \ style.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-Pager\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Data paging class\",\n      \"upstream_url\": \"http://pear.php.net/package/Pager\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Payment_Process is a gateway-independent framework\
+        \ for processing credit\\ncards, e-checks and eventually other forms of payments\
+        \ as well.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-Payment-Process\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Unified payment processor\",\n      \"upstream_url\": \"http://pear.php.net/package/Payment_Process\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Implementation of Simple Object Access Protocol\
+        \ (SOAP) protocol and services.\",\n      \"koschei_monitor\": false,\n  \
+        \    \"monitor\": false,\n      \"name\": \"php-pear-SOAP\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Simple Object Access Protocol (SOAP) Client/Server for\
+        \ PHP\",\n      \"upstream_url\": \"http://pear.php.net/package/SOAP\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"An interface for communicating with Twitter's public\
+        \ API.\\nSend status updates, fetch information, add friends, etc.\",\n  \
+        \    \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pear-Services-Twitter\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        PHP interface to Twitter's API\",\n      \"upstream_url\": \"http://pear.php.net/package/Services_Twitter\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Services_Weather searches for given locations and\
+        \ retrieves current\\nweather data and, dependent on the used service, also\
+        \ forecasts.\\nUp to now, GlobalWeather from CapeScience, Weather XML from\
+        \ EJSE (US\\nonly), a XOAP service from Weather.com and METAR/TAF from NOAA\
+        \ are\\nsupported. Further services will get included, if they become available,\\\
+        nhave a usable API and are properly documented.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-Services-Weather\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"This class acts as an interface to various\
+        \ online weather-services\",\n      \"upstream_url\": \"http://pear.php.net/package/Services_Weather\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package offers a toolkit to render out a datagrid\
+        \ in HTML format as well\\nas many other formats such as an XML Document,\
+        \ an Excel Spreadsheet, an XUL\\nDocument and more. It also offers paging\
+        \ and sorting functionality to limit\\nthe data that is presented and processed.\
+        \ This concept is based on the .NET\\nFramework DataGrid control and works\
+        \ very well with database and XML result\\nsets.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-Structures-DataGrid\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Tabular structure for converting data\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Structures_DataGrid\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is a DataSource driver for Structures_DataGrid\
+        \ using arrays. It is a\\nbase package for some other DataSource drivers like\
+        \ CSV or XML.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-Structures-DataGrid-DataSource-Array\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"DataSource driver using arrays\",\n\
+        \      \"upstream_url\": \"http://pear.php.net/package/Structures_DataGrid_DataSource_Array\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is a DataSource driver for Structures_DataGrid\
+        \ using PEAR::DB_DataObject.\",\n      \"koschei_monitor\": false,\n     \
+        \ \"monitor\": false,\n      \"name\": \"php-pear-Structures-DataGrid-DataSource-DataObject\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"DataSource driver using PEAR::DB_DataObject\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Structures_DataGrid_DataSource_DataObject\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is a DataSource driver for Structures_DataGrid\
+        \ using PEAR::MDB2 and an\\nSQL query.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-Structures-DataGrid-DataSource-MDB2\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"DataSource driver using PEAR::MDB2 and\
+        \ an SQL query\",\n      \"upstream_url\": \"http://pear.php.net/package/Structures_DataGrid_DataSource_MDB2\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is a DataSource driver for Structures_DataGrid\
+        \ using RSS files.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pear-Structures-DataGrid-DataSource-RSS\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"DataSource driver using RSS files\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Structures_DataGrid_DataSource_RSS\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is a Renderer driver for Structures_DataGrid\
+        \ using PEAR::Pager.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pear-Structures-DataGrid-Renderer-Pager\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Renderer driver using PEAR::Pager\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Structures_DataGrid_Renderer_Pager\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is a Rendering driver for Structures_DataGrid\
+        \ using Smarty. It adds the\\nnecessary variables and functions to a Smarty\
+        \ instance, in order to build a\\nfull-featured DataGrid within a Smarty template.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pear-Structures-DataGrid-Renderer-Smarty\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Renderer driver using Smarty\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/Structures_DataGrid_Renderer_Smarty\"\n  \
+        \  },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Implementation of CAPTCHAs (completely automated\
+        \ public Turing test to tell\\ncomputers and humans apart)\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-Text-CAPTCHA\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Generation of CAPTCHAs\",\n      \"\
+        upstream_url\": \"http://pear.php.net/package/Text_CAPTCHA\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"Engine for use FIGlet fonts to rendering text.\",\n     \
+        \ \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\":\
+        \ \"php-pear-Text-Figlet\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Render text\
+        \ using FIGlet fonts\",\n      \"upstream_url\": \"http://pear.php.net/package/Text_Figlet\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Text_Password allows one to create pronounceable\
+        \ and unpronounceable\\npasswords. The full functional range is explained\
+        \ in the manual at\\nhttp://pear.php.net/manual/.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-pear-Text-Password\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Creating passwords with PHP\",\n   \
+        \   \"upstream_url\": \"http://pear.php.net/package/Text_Password\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Package to validate various data. It includes :\\n-\
+        \ numbers (min/max, decimal or not)\\n- email (syntax, domain check, rfc822)\\\
+        n- string (predefined type alpha upper and/or lowercase, numeric,...)\\n-\
+        \ date (min, max)\\n- uri (RFC2396)\\n- possibility valid multiple data with\
+        \ a single method call (::multiple)\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-Validate\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Validation Class for Various Data Types\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Validate\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Package to validate Credit Card numbers and types.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pear-Validate-Finance-CreditCard\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n  \
+        \    \"summary\": \"Validation class for Credit Cards\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/Validate_Finance_CreditCard\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"The Var_Dump class is a wrapper for the var_dump function.\\\
+        n\\nThe var_dump function displays structured information about expressions\\\
+        nthat includes its type and value. Arrays are explored recursively with\\\
+        nvalues indented to show structure.\\n\\nThe Var_Dump class captures the output\
+        \ of the var_dump function, by using\\noutput control functions, and then\
+        \ uses external renderer classes for\\ndisplaying the result in various graphical\
+        \ ways :\\n* Simple text,\\n* HTML/XHTML text,\\n* HTML/XHTML table,\\n* XML,\\\
+        n* ...\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-Var-Dump\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Provides methods for dumping structured information about a variable\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/Var_Dump\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"XML_Beautifier is a package, that helps you making XML\
+        \ documents easier to\\nread for human beings.\\n\\nIt is able to add line-breaks,\
+        \ indentation, sorts attributes, convert tag\\ncases and wraps long comments.\
+        \ It recognizes tags, character data, comments,\\nXML declarations, processing\
+        \ instructions and external entities and is able\\nto format these tokens\
+        \ nicely.\\n\\nThe document is split into these tokens using the XML_Beautifier_Tokenizer\\\
+        nclass and the expat parser. Then a renderer is used to create the string\\\
+        nrepresentation of the document and formats it using the specified options.\\\
+        n\\nCurrently only one renderer is available, but as XML_Beautifier uses a\\\
+        ndriver-based architecture, other renderers (like syntax-highlighting)\\nwill\
+        \ follow soon.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-XML-Beautifier\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Class to format XML documents\",\n      \"upstream_url\": \"\
+        http://pear.php.net/package/XML_Beautifier\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ is an XML parser based on PHPs built-in xml extension.\\nIt supports two\
+        \ basic modes of operation: \\\"func\\\" and \\\"event\\\".\\nIn \\\"func\\\
+        \" mode, it will look for a function named after each element\\n(xmltag_ELEMENT\
+        \ for start tags and xmltag_ELEMENT_ for end tags),\\nand in \\\"event\\\"\
+        \ mode it uses a set of generic callbacks.\\n\\nSince version 1.2.0 there's\
+        \ a new XML_Parser_Simple class that makes\\nparsing of most XML documents\
+        \ easier, by automatically providing a stack\\nfor the elements. Furthermore\
+        \ its now possible to split the parser from\\nthe handler object, so you do\
+        \ not have to extend XML_Parser anymore in\\norder to parse a document with\
+        \ it.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n \
+        \     \"name\": \"php-pear-XML-Parser\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"XML parsing class based on PHP's bundled expat\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/XML_Parser\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"A\
+        \ PEAR-ified version of Useful Inc's XML-RPC for PHP.\\n\\nIt has support\
+        \ for HTTP/HTTPS transport, proxies and authentication.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pear-XML-RPC\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PHP implementation of the XML-RPC protocol\"\
+        ,\n      \"upstream_url\": \"http://pear.php.net/package/XML_RPC\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"XML_RPC2 is a pear package providing XML_RPC client\
+        \ and server services.\\nXML-RPC is a simple remote procedure call protocol\
+        \ built using HTTP as\\ntransport and XML as encoding.\\nAs a client library,\
+        \ XML_RPC2 is capable of creating a proxy class which\\nexposes the methods\
+        \ exported by the server. As a server library, XML_RPC2\\nis capable of exposing\
+        \ methods from a class or object instance, seamlessly\\nexporting local methods\
+        \ as remotely callable procedures.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pear-XML-RPC2\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"XML-RPC client/server library\",\n \
+        \     \"upstream_url\": \"http://pear.php.net/package/XML_RPC2\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Parser for Resource Description Framework (RDF) Site\
+        \ Summary (RSS)\\ndocuments.\",\n      \"koschei_monitor\": false,\n     \
+        \ \"monitor\": false,\n      \"name\": \"php-pear-XML-RSS\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"RSS parser\",\n      \"upstream_url\": \"http://pear.php.net/package/XML_RSS\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package provides an object-oriented API for\
+        \ building SVG documents.\",\n      \"koschei_monitor\": false,\n      \"\
+        monitor\": false,\n      \"name\": \"php-pear-XML-SVG\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"API for building SVG documents\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/XML_SVG\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"XML_Serializer\
+        \ serializes complex data structures like arrays or object as\\nXML documents.\
+        \ This class helps you generating any XML document you require\\nwithout the\
+        \ need for DOM.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-XML-Serializer\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Swiss-army knife for reading and writing XML files\",\n     \
+        \ \"upstream_url\": \"http://pear.php.net/package/XML_Serializer\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"XML_Util is a utility class that helps you working with\
+        \ (and especially\\ncreating) XML documents.\\n\\nAll methods of XML_Util\
+        \ can be called statically, that means you do not have\\nto instantiate an\
+        \ XML_Util object to use the provided methods.\\n\\nThe funcionality of XML_Util\
+        \ ranges from validating an XML tag name (as there\\nare strict rules for\
+        \ tag and attribute names) to the creation of namespaced\\nXML tags.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pear-XML-Util\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"XML utility\
+        \ class\",\n      \"upstream_url\": \"http://pear.php.net/package/XML_Util\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"You can use Console_Color::convert to transform\
+        \ colorcodes like %r into\\nANSI control codes.\\n  <?php\\n  include \\\"\
+        Console/Color2.php\\\";\\n  $console = new Console_Color2();\\n  print $console->convert(\\\
+        \"%rHello World!%n\\\");\\n  ?>\\nwould print \\\"Hello World\\\" in red,\
+        \ for example.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pear-console-color2\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Easily use ANSI console colors in your application\",\n     \
+        \ \"upstream_url\": \"http://pear.php.net/package/Console_Color2\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1451329227.0,\n    \
+        \  \"description\": \"This package provides an object oriented interface to\\\
+        nGNU Privacy Guard (GnuPG).\\n\\nThough GnuPG can support symmetric-key cryptography,\
+        \ this package\\nis intended only to facilitate public-key cryptography.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pear-crypt-gpg\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1292895\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"GNU Privacy Guard (GnuPG)\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/Crypt_GPG\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1480949180.0,\n      \"description\": \"Supports\
+        \ base-2, base-10, base-16, and base-256 numbers. Uses the GMP or\\nBCMath\
+        \ extensions, if available, and an internal implementation, otherwise.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pear-math-biginteger\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1401035\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Pure-PHP arbitrary precision integer\
+        \ arithmetic library\",\n      \"upstream_url\": \"http://pear.php.net/package/Math_BigInteger\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHing Is Not GNU make; it's a project build system\
+        \ based on Apache Ant.\\n\\nYou can do anything with it that you could do\
+        \ with a traditional build\\nsystem like GNU make, and its use of simple XML\
+        \ build files and extensible\\nPHP \\\"task\\\" classes make it an easy-to-use\
+        \ and highly flexible build\\nframework. Features include file transformations\
+        \ (e.g. token replacement,\\nXSLT transformation, Smarty template transformations),\
+        \ file system operations,\\ninteractive build support, SQL execution, CVS\
+        \ operations, tools for creating\\nPEAR packages, and much more.\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\":\
+        \ \"php-pear-phing\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A project build\
+        \ system based on Apache Ant\",\n      \"upstream_url\": \"http://phing.info/trac/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1401384106.0,\n\
+        \      \"description\": \"Transforms Wiki and BBCode markup into XHTML, LaTeX\
+        \ or plain text markup.\\nThis is the base engine for all of the Text_Wiki\
+        \ sub-classes\\n\\nThe text transformation is done in 2 steps.\\nThe chosen\
+        \ parser uses markup rules to tokenize the tags and content.\\nRenderers output\
+        \ the tokens and text into the requested format.\\nThe tokenized form replaces\
+        \ the tags by a protected byte value associated\\nto an index in an options\
+        \ table. This form shares up to 50 rules by all\\nparsers and renderers.\\\
+        n\\nThe package is intented for versatile transformers as well as converters.\\\
+        nText_Wiki is delivered with its own parser, which is used by Yawiki or\\\
+        nHorde's Wicked and three basic renderers: XHTML , LaTeX and plain text.\\\
+        nStrong sanitizing of XHTML is default.\\n\\nParsers and Renderers exist for\
+        \ BBCode, Cowiki, Dokuwiki, Mediawiki\\nand Tikiwiki.\\n\\nIt is highly configurable\
+        \ and can be easily extended.\",\n      \"koschei_monitor\": false,\n    \
+        \  \"monitor\": false,\n      \"name\": \"php-pear-text-wiki\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1098625\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Transforms Wiki and\
+        \ BBCode markup into XHTML, LaTeX or plain text\",\n      \"upstream_url\"\
+        : \"http://pear.php.net/package/Text_Wiki\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ extension allows the retrieval of file type information for the vast\\nmajority\
+        \ of files.  This information may include such information as dimensions\\\
+        nor compression quality of images, duration of sound files, etc...\\n\\nAdditionally,\
+        \ it can also be used to retrieve the MIME type for a particular\\nfile, and\
+        \ for text files, the proper language encoding.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pecl-Fileinfo\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Fileinfo is a PHP extension that wraps\
+        \ the libmagic library\",\n      \"upstream_url\": \"http://pecl.php.net/package/Fileinfo\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This extension can communicate with any AMQP spec\
+        \ 0-9-1 compatible server,\\nsuch as RabbitMQ, OpenAMQP and Qpid, giving you\
+        \ the ability to create and\\ndelete exchanges and queues, as well as publish\
+        \ to any exchange and consume\\nfrom any queue.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-pecl-amqp\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Communicate with any AMQP compliant\
+        \ server\",\n      \"upstream_url\": \"http://pecl.php.net/package/amqp\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"APCu is userland caching: APC stripped of opcode\
+        \ caching.\\n\\nAPCu only supports userland caching of variables.\\n\\nThe\
+        \ php-pecl-apcu-bc package provides a drop\\nin replacement for APC.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pecl-apcu\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"APC User Cache\"\
+        ,\n      \"upstream_url\": \"http://pecl.php.net/package/APCu\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1467262393.0,\n    \
+        \  \"description\": \"This module provides a backwards compatible API for\
+        \ APC.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n \
+        \     \"name\": \"php-pecl-apcu-bc\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/1350148\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"APCu Backwards Compatibility Module\"\
+        ,\n      \"upstream_url\": \"http://pecl.php.net/package/APCu\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1430063733.0,\n    \
+        \  \"description\": \"This tiny extension lets PHP's post handler parse `multipart/form-data`\
+        \ and\\n`application/x-www-form-urlencoded` (or any other customly registered\
+        \ form data\\nhandler, like \\\"json_post\\\") without regard to the request's\
+        \ request method.\\n\\nThis extension does not provide any INI entries, constants,\
+        \ functions or classes.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"php-pecl-apfd\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1203134\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Always Populate Form Data\"\
+        ,\n      \"upstream_url\": \"http://pecl.php.net/package/apfd\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1481720669.0,\n    \
+        \  \"description\": \"PHP supports the direct io functions as described in\
+        \ the\\nPosix Standard (Section 6) for performing I/O functions at\\na lower\
+        \ level than the C-Language stream I/O functions\\n(fopen(), fread(),..).\\\
+        n\\nDIO provides functions and stream wrappers which provide raw and\\nserial\
+        \ low level IO support.  The use of the DIO functions should\\nbe considered\
+        \ only when direct control of a device is needed.\\nIn all other cases, the\
+        \ standard filesystem functions are\\nmore than adequate.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-pecl-dio\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1404217\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Direct I/O functions\"\
+        ,\n      \"upstream_url\": \"http://pecl.php.net/package/dio\"\n    },\n \
+        \   {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n     \
+        \ \"description\": \"This is an extension to efficiently schedule I/O, time\
+        \ and signal based\\nevents using the best I/O notification mechanism available\
+        \ for specific\\nplatform. This is a port of libevent to the PHP infrastructure.\\\
+        n\\nVersion 1.0.0 introduces:\\n* new OO API breaking backwards compatibility\\\
+        n* support of libevent 2+ including HTTP, DNS, OpenSSL and the event listener.\\\
+        n\\nDocumentation: http://php.net/event\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pecl-event\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Provides interface to libevent library\"\
+        ,\n      \"upstream_url\": \"http://pecl.php.net/package/event\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1407158677.0,\n    \
+        \  \"description\": \"This package provides a PHP binding for FANN\\n(Fast\
+        \ Artificial Neural Network) Library.\\n\\nDocumentation: http://php.net/fann\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pecl-fann\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1126034\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Wrapper for FANN Library\",\n      \"upstream_url\"\
+        : \"http://pecl.php.net/package/fann\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"This extension\
+        \ uses libgearman library to provide API for\\ncommunicating with gearmand,\
+        \ and writing clients and workers\\n\\nDocumentation: http://php.net/gearman\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pecl-gearman\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"PHP wrapper\
+        \ to libgearman\",\n      \"upstream_url\": \"https://github.com/wcgallego/pecl-gearman\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The HTTP extension aims to provide a convenient\
+        \ and powerful set of\\nfunctionality for major applications.\\n\\nThe HTTP\
+        \ extension eases handling of HTTP URLs, dates, redirects, headers\\nand messages\
+        \ in a HTTP context (both incoming and outgoing). It also provides\\nmeans\
+        \ for client negotiation of preferred language and charset, as well as\\na\
+        \ convenient way to exchange arbitrary data with caching and resuming\\ncapabilities.\\\
+        n\\nAlso provided is a powerful request and parallel interface.\\n\\nVersion\
+        \ 2 is completely incompatible to previous version.\\n\\nDocumentation : https://mdref.m6w6.name/http\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pecl-http\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Extended HTTP\
+        \ support\",\n      \"upstream_url\": \"http://pecl.php.net/package/pecl_http\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The HTTP extension aims to provide a convenient\
+        \ and powerful set of\\nfunctionality for major applications.\\n\\nThe HTTP\
+        \ extension eases handling of HTTP URLs, dates, redirects, headers\\nand messages\
+        \ in a HTTP context (both incoming and outgoing). It also provides\\nmeans\
+        \ for client negotiation of preferred language and charset, as well as\\na\
+        \ convenient way to exchange arbitrary data with caching and resuming\\ncapabilities.\\\
+        n\\nIt provides powerful request functionality, if built with CURL\\nsupport.\
+        \ Parallel requests are available for PHP 5 and greater.\\n\\nNote:\\n. php-pecl-http1\
+        \ provides API version 1\\n. php-pecl-http  provides API version 2\",\n  \
+        \    \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pecl-http1\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Extended HTTP\
+        \ support\",\n      \"upstream_url\": \"http://pecl.php.net/package/pecl_http\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Igbinary is a drop in replacement for the standard\
+        \ PHP serializer.\\n\\nInstead of time and space consuming textual representation,\\\
+        nigbinary stores PHP data structures in a compact binary form.\\nSavings are\
+        \ significant when using memcached or similar memory\\nbased storages for\
+        \ serialized data.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pecl-igbinary\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n  \
+        \    \"summary\": \"Replacement for the standard PHP serializer\",\n     \
+        \ \"upstream_url\": \"http://pecl.php.net/package/igbinary\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1430063713.0,\n      \"\
+        description\": \"This extension provides a PHP content type handler for \\\
+        \"text/json\\\" to PHP's\\nform data parser. If the `Content-Type` of an incoming\
+        \ request is `text/json`,\\nthe JSON contents of the request body will by\
+        \ parsed into `$_POST`.\\n\\nThis extension does not provide any constants,\
+        \ functions or classes.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"php-pecl-json-post\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1203132\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"JSON POST handler\"\
+        ,\n      \"upstream_url\": \"http://pecl.php.net/package/json_post\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The php-pecl-jsonc module will add support for JSON\
+        \ (JavaScript Object Notation)\\nserialization to PHP.\\n\\nThis is a dropin\
+        \ alternative to standard PHP JSON extension which\\nuse the json-c library\
+        \ parser.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pecl-jsonc\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Support for JSON serialization\",\n      \"upstream_url\": \"http://pecl.php.net/package/jsonc\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHP Judy implements sparse dynamic arrays (aka Judy\
+        \ Arrays).\\nThis extension is based on the Judy C library. A Judy array\\\
+        nconsumes memory only when it is populated, yet can grow to\\ntake advantage\
+        \ of all available memory if desired. Judy's key\\nbenefits are scalability,\
+        \ high performance, and memory efficiency.\",\n      \"koschei_monitor\":\
+        \ true,\n      \"monitor\": false,\n      \"name\": \"php-pecl-judy\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PHP Judy implements sparse dynamic arrays\"\
+        ,\n      \"upstream_url\": \"http://pecl.php.net/package/Judy\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Features:\\n+ An interface for maintaining credential\
+        \ caches (KRB5CCache),\\n  that can be used for authenticating against a kerberos5\
+        \ realm\\n+ Bindings for nearly the complete GSSAPI (RFC2744)\\n+ The administrative\
+        \ interface (KADM5)\\n+ Support for HTTP Negotiate authentication via GSSAPI\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pecl-krb5\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Kerberos authentification\
+        \ extension\",\n      \"upstream_url\": \"http://pecl.php.net/package/krb5\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1449066286.0,\n\
+        \      \"description\": \"A simple, low-level PHP extension for libsodium.\\\
+        n\\nDocumentation: https://paragonie.com/book/pecl-libsodium\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-pecl-libsodium\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1286768\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Wrapper for the Sodium\
+        \ cryptographic library\",\n      \"upstream_url\": \"http://pecl.php.net/package/libsodium\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Mailparse is an extension for parsing and working\
+        \ with email messages.\\nIt can deal with rfc822 and rfc2045 (MIME) compliant\
+        \ messages.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pecl-mailparse\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"PHP PECL package for parsing and working with email messages\",\n    \
+        \  \"upstream_url\": \"http://pecl.php.net/package/mailparse\"\n    },\n \
+        \   {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n     \
+        \ \"description\": \"Memcached is a caching daemon designed especially for\\\
+        ndynamic web applications to decrease database load by\\nstoring objects in\
+        \ memory.\\n\\nThis extension allows you to work with memcached through\\\
+        nhandy OO and procedural interfaces.\\n\\nMemcache can be used as a PHP session\
+        \ handler.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pecl-memcache\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Extension to work with the Memcached caching daemon\",\n      \"upstream_url\"\
+        : \"http://pecl.php.net/package/memcache\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ extension uses libmemcached library to provide API for communicating\\nwith\
+        \ memcached servers.\\n\\nmemcached is a high-performance, distributed memory\
+        \ object caching system,\\ngeneric in nature, but intended for use in speeding\
+        \ up dynamic web\\napplications by alleviating database load.\\n\\nIt also\
+        \ provides a session handler (memcached).\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pecl-memcached\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Extension to work with the Memcached\
+        \ caching daemon\",\n      \"upstream_url\": \"http://pecl.php.net/package/memcached\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Memory usage profiler for PHP scripts.\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\":\
+        \ \"php-pecl-memprof\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Memory usage\
+        \ profiler\",\n      \"upstream_url\": \"http://pecl.php.net/package/memprof\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package provides an interface for communicating\
+        \ with the\\nMongoDB database in PHP.\\n\\nDocumentation: http://php.net/mongo\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"php-pecl-mongo\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"PHP MongoDB\
+        \ database driver\",\n      \"upstream_url\": \"http://pecl.php.net/package/mongo\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468942516.0,\n\
+        \      \"description\": \"The purpose of this driver is to provide exceptionally\
+        \ thin glue between\\nMongoDB and PHP, implementing only fundemental and performance-critical\\\
+        ncomponents necessary to build a fully-functional MongoDB driver.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pecl-mongodb\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1269056\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"MongoDB driver for PHP\",\n      \"upstream_url\"\
+        : \"http://pecl.php.net/package/mongodb\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ extension provide API for communicating with MessagePack serialization.\\\
+        n\\nMessagePack is an efficient binary serialization format. It lets you exchange\\\
+        ndata among multiple languages like JSON but it's faster and smaller.\\nFor\
+        \ example, small integers (like flags or error code) are encoded into a\\\
+        nsingle byte, and typical short strings only require an extra byte in addition\\\
+        nto the strings themselves.\\n\\nIf you ever wished to use JSON for convenience\
+        \ (storing an image with metadata)\\nbut could not for technical reasons (encoding,\
+        \ size, speed...), MessagePack is\\na perfect replacement.\\n\\nThis extension\
+        \ is still EXPERIMENTAL.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pecl-msgpack\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"API for communicating with MessagePack serialization\",\n   \
+        \   \"upstream_url\": \"http://pecl.php.net/package/msgpack\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"The replication and load balancing plugin is a plugin for\
+        \ the mysqlnd library.\\nIt can be used with PHP MySQL extensions (ext/mysql,\
+        \ ext/mysqli, PDO_MySQL),\\nif they are compiled to use mysqlnd. The plugin\
+        \ inspects queries to do\\nread-write splitting. Read-only queries are send\
+        \ to configured MySQL\\nreplication slave servers all other queries are redirected\
+        \ to the MySQL\\nreplication master server. Very little, if any, application\
+        \ changes required,\\ndependent on the usage scenario required.\\n\\nDocumentation\
+        \ : http://www.php.net/mysqlnd_ms\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pecl-mysqlnd-ms\",\n   \
+        \   \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A replication and load balancing plugin\
+        \ for mysqlnd\",\n      \"upstream_url\": \"http://pecl.php.net/package/mysqlnd_ms\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The mysqlnd query result cache plugin is a mysqlnd\
+        \ plugin.\\nIt adds basic client side result set caching to all PHP MySQL\
+        \ extensions\\n(ext/mysql, ext/mysqli, PDO_MySQL). if they are compiled to\
+        \ use mysqlnd.\\nIt does not change the API of the MySQL extensions and thus\
+        \ it operates\\nvirtually transparent for applications.\\n\\nDocumentation\
+        \ : http://www.php.net/mysqlnd_qc\",\n      \"koschei_monitor\": true,\n \
+        \     \"monitor\": false,\n      \"name\": \"php-pecl-mysqlnd-qc\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A query cache plugin for mysqlnd\",\n\
+        \      \"upstream_url\": \"http://pecl.php.net/package/mysqlnd_qc\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"ncurses (new curses) is a free software emulation of\
+        \ curses in\\nSystem V Rel 4.0 (and above). It uses terminfo format, supports\\\
+        npads, colors, multiple highlights, form characters and function\\nkey mapping.\
+        \ Because of the interactive nature of this library,\\nit will be of little\
+        \ use for writing Web applications, but may\\nbe useful when writing scripts\
+        \ meant using PHP from the command\\nline.\",\n      \"koschei_monitor\":\
+        \ true,\n      \"monitor\": false,\n      \"name\": \"php-pecl-ncurses\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Terminal screen handling and optimization\
+        \ package\",\n      \"upstream_url\": \"http://pecl.php.net/package/ncurses\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1457712930.0,\n\
+        \      \"description\": \"PostgreSQL client library (libpq) binding.\\n\\\
+        nDocuments: http://devel-m6w6.rhcloud.com/mdref/pq\\n\\nHighlights:\\n* Nearly\
+        \ complete support for asynchronous usage\\n* Extended type support by pg_type\\\
+        n* Fetching simple multi-dimensional array maps\\n* Working Gateway implementation\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pecl-pq\",\n      \"namespace\": \"rpms\",\n      \"review_url\":\
+        \ \"https://bugzilla.redhat.com/1299907\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"PostgreSQL client library (libpq) binding\",\n   \
+        \   \"upstream_url\": \"http://pecl.php.net/package/pq\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"A reusable split-off of pecl_http's property proxy API.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-pecl-propro\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Property proxy\",\n      \"upstream_url\"\
+        : \"http://pecl.php.net/package/propro\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"This package\
+        \ is based on the libradius of FreeBSD, with some modifications\\nand extensions.\
+        \  This PECL provides full support for RADIUS authentication\\n(RFC 2865)\
+        \ and RADIUS accounting (RFC 2866), works on Unix and on Windows.\\nIts an\
+        \ easy way to authenticate your users against the user-database of your\\\
+        nOS (for example against Windows Active-Directory via IAS).\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pecl-radius\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Radius client library\",\n      \"upstream_url\"\
+        : \"http://pecl.php.net/package/radius\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"A reusable\
+        \ split-off of pecl_http's persistent handle and resource\\nfactory API.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pecl-raphf\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Resource and\
+        \ persistent handles factory\",\n      \"upstream_url\": \"http://pecl.php.net/package/raphf\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The phpredis extension provides an API for communicating\\\
+        nwith the Redis key-value store.\\n\\nThis Redis client implements most of\
+        \ the latest Redis API.\\nAs method only only works when also implemented\
+        \ on the server side,\\nsome doesn't work with an old redis server version.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pecl-redis\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Extension for\
+        \ communicating with the Redis key-value store\",\n      \"upstream_url\"\
+        : \"http://pecl.php.net/package/redis\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"Procedural\
+        \ and simple OO wrapper for rrdtool - data logging and graphing\\nsystem for\
+        \ time series data.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-pecl-rrd\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"PHP Bindings for rrdtool\",\n      \"upstream_url\": \"http://pecl.php.net/package/rrd\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Feature-rich library that allows PHP developers\
+        \ to communicate easily and\\nefficiently with Apache Solr server instances\
+        \ using an object-oriented API.\\n\\nIt effectively simplifies the process\
+        \ of interacting with Apache Solr using\\nPHP5 and it already comes with built-in\
+        \ readiness for the latest features\\nadded in Solr 3.1. The extension has\
+        \ features such as built-in,\\nserializable query string builder objects which\
+        \ effectively simplifies the\\nmanipulation of name-value pair request parameters\
+        \ across repeated requests.\\nThe response from the Solr server is also automatically\
+        \ parsed into native php\\nobjects whose properties can be accessed as array\
+        \ keys or object properties\\nwithout any additional configuration on the\
+        \ client-side. Its advanced HTTP\\nclient reuses the same connection across\
+        \ multiple requests and provides\\nbuilt-in support for connecting to Solr\
+        \ servers secured behind HTTP\\nAuthentication or HTTP proxy servers. It is\
+        \ also able to connect to\\nSSL-enabled containers.\\n\\nMore info on PHP-Solr\
+        \ can be found at:\\nhttp://www.php.net/manual/en/book.solr.php\\n\\nWarning:\
+        \ PECL Solr 1 is not compatible with Solr Server >= 4.0.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pecl-solr\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Object oriented API to Apache Solr\"\
+        ,\n      \"upstream_url\": \"http://pecl.php.net/package/solr\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1405973421.0,\n    \
+        \  \"description\": \"It effectively simplifies the process of interacting\
+        \ with Apache Solr using\\nPHP5 and it already comes with built-in readiness\
+        \ for the latest features.\\n\\nThe extension has features such as built-in,\
+        \ serializable query string builder\\nobjects which effectively simplifies\
+        \ the manipulation of name-value pair\\nrequest parameters across repeated\
+        \ requests.\\n\\nThe response from the Solr server is also automatically parsed\
+        \ into native php\\nobjects whose properties can be accessed as array keys\
+        \ or object properties\\nwithout any additional configuration on the client-side.\\\
+        n\\nIts advanced HTTP client reuses the same connection across multiple requests\\\
+        nand provides built-in support for connecting to Solr servers secured behind\\\
+        nHTTP Authentication or HTTP proxy servers. It is also able to connect to\\\
+        nSSL-enabled containers.\\n\\nPlease consult the documentation for more details\
+        \ on features.\\n  http://php.net/solr\\n\\nWarning: PECL Solr 2 is not compatible\
+        \ with Solr Server < 4.0\\n\\nPECL Solr 1 is available in php-pecl-solr package.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pecl-solr2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1112705\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Object oriented API to Apache Solr\",\n      \"upstream_url\"\
+        : \"http://pecl.php.net/package/solr\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1405973374.0,\n      \"description\": \"The ssdeep\
+        \ project page describes it as a library for\\n\\\"...computing context triggered\
+        \ piecewise hashes (CTPH).\\nAlso called fuzzy hashes, CTPH can match inputs\
+        \ that have homologies.\\nSuch inputs have sequences of identical bytes in\
+        \ the same order,\\nalthough bytes in between these sequences may be different\
+        \ in both\\ncontent and length\\\".\\n\\nFor an in depth paper explaining\
+        \ context triggered piecewise hashes please\\nsee http://dfrws.org/2006/proceedings/12-Kornblum.pdf\\\
+        n\\nThis extensions wraps the ssdeep fuzzy hashing API created by Jesse Kornblum.\\\
+        n\\nDocumentation: http://php.net/ssdeep\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pecl-ssdeep\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1104032\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Wrapper for libfuzzy\
+        \ library\",\n      \"upstream_url\": \"http://pecl.php.net/package/ssdeep\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1476367772.0,\n\
+        \      \"description\": \"User Operations for Zend: doing things you probably\
+        \ shouldn't since 2014.\\n\\nThe uopz extension exposes Zend engine functionality\
+        \ normally used at\\ncompilation and execution time in order to allow modification\
+        \ of the\\ninternal structures that represent PHP code.\\n\\nIt supports the\
+        \ following activities:\\n- Overloading some Zend opcodes including exit/new\
+        \ and composure opcodes\\n- Renaming functions and methods\\n- Aliasing functions\
+        \ and methods\\n- Deletion of functions and methods\\n- Redefinition of constants\\\
+        n- Deletion of constants\\n- Runtime composition and modification of classes\\\
+        n\\nDocumentation: http://php.net/uopz\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-pecl-uopz\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1384317\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"User Operations for\
+        \ Zend\",\n      \"upstream_url\": \"http://pecl.php.net/package/uopz\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A wrapper around Universally Unique Identifier library\
+        \ (libuuid).\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pecl-uuid\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Universally Unique Identifier extension for PHP\",\n      \"upstream_url\"\
+        : \"http://pecl.php.net/package/uuid\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1442772669.0,\n      \"description\": \"This package\
+        \ allows to manipulate extended attributes on filesystems\\nthat support them.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pecl-xattr\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1264491\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Extended attributes\",\n      \"upstream_url\": \"\
+        http://pecl.php.net/package/xattr\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"The Xdebug\
+        \ extension helps you debugging your script by providing a lot of\\nvaluable\
+        \ debug information. The debug information that Xdebug can provide\\nincludes\
+        \ the following:\\n\\n* stack and function traces in error messages with:\\\
+        n  o full parameter display for user defined functions\\n  o function name,\
+        \ file name and line indications\\n  o support for member functions\\n* memory\
+        \ allocation\\n* protection for infinite recursions\\n\\nXdebug also provides:\\\
+        n\\n* profiling information for PHP scripts\\n* code coverage analysis\\n*\
+        \ capabilities to debug your scripts interactively with a debug client\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pecl-xdebug\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"PECL package\
+        \ for debugging PHP scripts\",\n      \"upstream_url\": \"http://xdebug.org/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"XHProf is a function-level hierarchical profiler\
+        \ for PHP.\\n\\nThis package provides the raw data collection component,\\\
+        nimplemented in C (as a PHP extension).\\n\\nThe HTML based navigational interface\
+        \ is provided in the \\\"xhprof\\\" package.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-pecl-xhprof\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PHP extension for XHProf, a Hierarchical\
+        \ Profiler\",\n      \"upstream_url\": \"http://pecl.php.net/package/xhprof\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1414411597.0,\n\
+        \      \"description\": \"Yac (Yet Another Cache) is a shared memory user\
+        \ data cache for PHP.\\n\\nIt can be used to replace APC or local memcached.\\\
+        n\\nYac is lockless, that means, it is very fast, but there could be a\\nchance\
+        \ you will get a wrong data(depends on how many key slots are\\nallocated\
+        \ and how many keys are stored), so you'd better make sure\\nthat your product\
+        \ is not very sensitive to that.\",\n      \"koschei_monitor\": true,\n  \
+        \    \"monitor\": false,\n      \"name\": \"php-pecl-yac\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1138901\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Lockless user data\
+        \ cache\",\n      \"upstream_url\": \"http://pecl.php.net/package/yac\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The YAML PHP Extension provides a wrapper to the\
+        \ LibYAML library. It gives the\\nuser the ability to parse YAML document\
+        \ streams into PHP constructs and emit PHP\\nconstructs as valid YAML 1.1\
+        \ documents.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pecl-yaml\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Support for YAML 1.1 serialization using the LibYAML library\",\n    \
+        \  \"upstream_url\": \"http://pecl.php.net/package/yaml\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"The Zend OPcache provides faster PHP execution through opcode caching\
+        \ and\\noptimization. It improves PHP performance by storing precompiled script\\\
+        nbytecode in the shared memory. This eliminates the stages of reading code\
+        \ from\\nthe disk and compiling it on future access. In addition, it applies\
+        \ a few\\nbytecode optimization patterns that make code execution faster.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"php-pecl-zendopcache\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        The Zend OPcache\",\n      \"upstream_url\": \"http://pecl.php.net/package/ZendOpcache\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Zip is an extension to create and read zip files.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-pecl-zip\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A ZIP archive\
+        \ management extension\",\n      \"upstream_url\": \"http://pecl.php.net/package/zip\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1462553758.0,\n\
+        \      \"description\": \"Using this library it is possible to statically\
+        \ reflect one or more files\\nand create an object graph representing your\
+        \ application's structure,\\nincluding accompanying in-source documentation\
+        \ using DocBlocks.\\n\\nThe information that this library provides is similar\
+        \ to what the (built-in)\\nReflection extension of PHP provides; there are\
+        \ however several advantages\\nto using this library:\\n\\n* Due to its Static\
+        \ nature it does not execute procedural code in your\\n  reflected files where\
+        \ Dynamic Reflection does.\\n* Because the none of the code is interpreted\
+        \ by PHP (and executed)\\n  Static Reflection uses less memory.\\n* Can reflect\
+        \ complete files\\n* Can reflect a whole project by reflecting multiple files.\\\
+        n* Reflects the contents of a DocBlock instead of just mentioning there is\
+        \ one.\\n* Is capable of analyzing code written for any PHP version (starting\
+        \ at 5.2)\\n  up to and including your installed PHP version.\\n\\nFeatures\\\
+        n* [Creates an object graph] containing the structure of your application\
+        \ much\\n  like a site map shows the structure of a website.\\n* Can read\
+        \ and interpret code of any PHP version starting with 5.2 up to and\\n  including\
+        \ your currently installed version of PHP.\\n* Due it's clean interface it\
+        \ can be in any application without a complex setup.\\n\\nAutoloader: /usr/share/php/phpDocumentor/Reflection/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-phpdocumentor-reflection\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": \"https://bugzilla.redhat.com/1327424\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Reflection library to do Static Analysis\
+        \ for PHP Projects\",\n      \"upstream_url\": \"https://github.com/phpDocumentor/Reflection\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1424725458.0,\n\
+        \      \"description\": \"The ReflectionDocBlock component of phpDocumentor\
+        \ provides a DocBlock\\nparser that is fully compatible with the PHPDoc standard.\\\
+        n\\nWith this component, a library can provide support for annotations via\\\
+        nDocBlocks or otherwise retrieve information that is embedded in a DocBlock.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"php-phpdocumentor-reflection-docblock\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1188530\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"DocBlock parser\",\n      \"\
+        upstream_url\": \"https://github.com/phpDocumentor/ReflectionDocBlock\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480342961.0,\n\
+        \      \"description\": \"Phpiredis is an extension for PHP 5.x and 7.x based\
+        \ on hiredis\\nthat provides a simple and efficient client for Redis and a\
+        \ fast\\nincremental parser / serializer for the RESP protocol.\",\n     \
+        \ \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"\
+        php-phpiredis\",\n      \"namespace\": \"rpms\",\n      \"review_url\": \"\
+        https://bugzilla.redhat.com/1398799\",\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Client extension for Redis\",\n      \"upstream_url\"\
+        : \"https://github.com/nrk/phpiredis\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1488812939.0,\n      \"description\": \"Translation\
+        \ API for PHP using Gettext MO files.\\n\\nFeatures\\n\\n* All strings are\
+        \ stored in memory for fast lookup\\n* Fast loading of MO files\\n* Low level\
+        \ API for reading MO files\\n* Emulation of Gettext API\\n* No use of eval()\
+        \ for plural equation\\n\\nLimitations\\n\\n* Not suitable for huge MO files\
+        \ which you don't want to store in memory\\n* Input and output encoding has\
+        \ to match (preferably UTF-8)\\n\\nAutoloader: /usr/share/php/PhpMyAdmin/MoTranslator/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-phpmyadmin-motranslator\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1415390\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Translation API for PHP using Gettext\
+        \ MO files\",\n      \"upstream_url\": \"https://github.com/phpmyadmin/motranslator\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1488812497.0,\n\
+        \      \"description\": \"Currently the 2D and 3D variants except MultiPatch\
+        \ of the ShapeFile format\\nas defined in [1].\\n\\nThe library currently\
+        \ supports reading and editing of ShapeFiles and the\\nAssociated information\
+        \ (DBF file). There are a lot of things that can be\\nimproved in the code,\
+        \ if you are interested in developing, helping with the\\ndocumentation, making\
+        \ translations or offering new ideas please contact us.\\n\\n[1] https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf\\\
+        n\\nAutoloader: /usr/share/php/PhpMyAdmin/ShapeFile/autoload.php\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\":\
+        \ \"php-phpmyadmin-shapefile\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1415389\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"ESRI ShapeFile library for PHP\",\n\
+        \      \"upstream_url\": \"https://github.com/phpmyadmin/shapefile\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1421414345.0,\n\
+        \      \"description\": \"Pure-PHP ASN1 parser.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-phpseclib-file-asn1\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1182446\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Pure-PHP ASN1 parser\"\
+        ,\n      \"upstream_url\": \"http://phpseclib.sourceforge.net\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1430768800.0,\n    \
+        \  \"description\": \"phpspec is a tool which can help you write clean and\
+        \ working PHP code\\nusing behaviour driven development or BDD. BDD is a technique\
+        \ derived\\nfrom test-first development.\\n\\nBDD is a technique used at story\
+        \ level and spec level. phpspec is a tool\\nfor use at the spec level or SpecBDD.\
+        \ The technique is to first use a tool\\nlike phpspec to describe the behaviour\
+        \ of an object you are about to write.\\nNext you write just enough code to\
+        \ meet that specification and finally you\\nrefactor this code.\",\n     \
+        \ \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"\
+        php-phpspec\",\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1193531\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Specification-oriented\
+        \ BDD framework for PHP\",\n      \"upstream_url\": \"https://github.com/phpspec/phpspec\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1424771348.0,\n\
+        \      \"description\": \"A comprehensive library for generating differences\
+        \ between two hashable\\nobjects (strings or arrays). Generated differences\
+        \ can be rendered in\\nall of the standard formats including:\\n * Unified\\\
+        n * Context\\n * Inline HTML\\n * Side by Side HTML\\n\\nThe logic behind\
+        \ the core of the diff engine (ie, the sequence matcher)\\nis primarily based\
+        \ on the Python difflib package. The reason for doing\\nso is primarily because\
+        \ of its high degree of accuracy.\",\n      \"koschei_monitor\": true,\n \
+        \     \"monitor\": true,\n      \"name\": \"php-phpspec-php-diff\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1193481\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A library for generating\
+        \ differences between two hashable objects\",\n      \"upstream_url\": \"\
+        https://github.com/phpspec/php-diff\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1424770526.0,\n      \"description\": \"Prophecy\
+        \ is a highly opinionated yet very powerful and flexible PHP object\\nmocking\
+        \ framework.\\n\\nThough initially it was created to fulfil phpspec2 needs,\
+        \ it is flexible enough\\nto be used inside any testing framework out there\
+        \ with minimal effort.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-phpspec-prophecy\",\n      \"namespace\":\
+        \ \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1192493\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Highly opinionated\
+        \ mocking framework for PHP\",\n      \"upstream_url\": \"https://github.com/phpspec/prophecy\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"DbUnit port for PHP/PHPUnit.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-phpunit-DbUnit\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"DbUnit port for PHP/PHPUnit\",\n   \
+        \   \"upstream_url\": \"https://github.com/sebastianbergmann/dbunit\"\n  \
+        \  },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"FilterIterator implementation that filters files\
+        \ based on a list of suffixes.\",\n      \"koschei_monitor\": true,\n    \
+        \  \"monitor\": true,\n      \"name\": \"php-phpunit-File-Iterator\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"FilterIterator implementation that filters\
+        \ files based on a list of suffixes\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/php-file-iterator\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Convenience wrapper for Symfony's Finder component.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-phpunit-FinderFacade\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Wrapper for Symfony Finder component\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/finder-facade\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHP_CodeBrowser generates a HTML view for code browsing\
+        \ with highlighted and\\ncolored errors, parsed from XML reports generated\
+        \ from code-sniffer or\\nphpunit.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"php-phpunit-PHP-CodeBrowser\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PHP_CodeBrowser for integration in Hudson\
+        \ and CruiseControl\",\n      \"upstream_url\": \"http://github.com/mayflowergmbh/PHP_CodeBrowser\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Library that provides collection, processing, and\
+        \ rendering functionality\\nfor PHP code coverage information.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-phpunit-PHP-CodeCoverage\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PHP code coverage information\",\n \
+        \     \"upstream_url\": \"https://github.com/sebastianbergmann/php-code-coverage\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Utility class for invoking callables with a timeout.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-phpunit-PHP-Invoker\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Utility class\
+        \ for invoking callables with a timeout\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/php-invoker\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHP Utility class for timing\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-phpunit-PHP-Timer\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PHP Utility class for timing\",\n  \
+        \    \"upstream_url\": \"https://github.com/sebastianbergmann/php-timer\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Wrapper around PHP tokenizer extension.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-phpunit-PHP-TokenStream\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Wrapper around PHP tokenizer extension\",\n      \"upstream_url\": \"\
+        https://github.com/sebastianbergmann/php-token-stream\"\n    },\n    {\n \
+        \     \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"PHPUnit is a family of PEAR packages that supports the development of\\\
+        nobject-oriented PHP applications using the concepts and methods of Agile\\\
+        nSoftware Development, Extreme Programming, Test-Driven Development and\\\
+        nDesign-by-Contract Development by providing an elegant and robust framework\\\
+        nfor the creation, execution and analysis of Unit Tests.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-phpunit-PHPUnit\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"The PHP Unit Testing framework\",\n\
+        \      \"upstream_url\": \"https://github.com/sebastianbergmann/phpunit\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Mock Object library for PHPUnit\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-phpunit-PHPUnit-MockObject\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Mock Object library for PHPUnit\",\n\
+        \      \"upstream_url\": \"https://github.com/sebastianbergmann/phpunit-mock-objects\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Selenium RC integration for PHPUnit.\\n\\nThis package\
+        \ contains a base Testcase Class that can be used to run end-to-end\\ntests\
+        \ against Selenium 2 (using its Selenium 1 backward compatible Api).\\n\\\
+        nOptional dependency: XDebug (php-pecl-xdebug)\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-phpunit-PHPUnit-Selenium\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Selenium RC integration for PHPUnit\"\
+        ,\n      \"upstream_url\": \"https://github.com/giorgiosironi/phpunit-selenium\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Tool that can generate skeleton test classes from\
+        \ production code classes\\nand vice versa.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-phpunit-PHPUnit-SkeletonGenerator\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Tool that can generate skeleton test\
+        \ classes\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/phpunit-skeleton-generator\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Story extension for PHPUnit to facilitate Behaviour-Driven\
+        \ Development\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-phpunit-PHPUnit-Story\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Story extension for PHPUnit to facilitate Behaviour-Driven Development\"\
+        ,\n      \"upstream_url\": \"https://github.com/sebastianbergmann/phpunit-story\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Simple template engine.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-phpunit-Text-Template\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Simple template engine\",\n      \"\
+        upstream_url\": \"https://github.com/sebastianbergmann/php-text-template\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Library that helps with managing the version number\\\
+        nof Git-hosted PHP projects.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": false,\n      \"name\": \"php-phpunit-Version\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Managing the version number of Git-hosted PHP projects\"\
+        ,\n      \"upstream_url\": \"https://github.com/sebastianbergmann/version\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This component provides the functionality to compare\
+        \ PHP values for equality.\\n\\nAutoloader: /usr/share/php/SebastianBergmann/Comparator/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-phpunit-comparator\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Compare PHP\
+        \ values for equality\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/comparator\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Diff implementation.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-phpunit-diff\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Diff implementation\",\n      \"upstream_url\"\
+        : \"https://github.com/sebastianbergmann/diff\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ component provides functionality that helps writing PHP code that\\nhas\
+        \ runtime-specific (PHP / HHVM) execution paths.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-phpunit-environment\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Handle HHVM/PHP environments\",\n  \
+        \    \"upstream_url\": \"https://github.com/sebastianbergmann/environment\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Provides the functionality to export PHP variables\
+        \ for visualization.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-phpunit-exporter\",\n      \"namespace\":\
+        \ \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Export PHP variables for visualization\",\n      \"\
+        upstream_url\": \"https://github.com/sebastianbergmann/exporter\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Simple PHP wrapper for Git.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-phpunit-git\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Simple wrapper for Git\",\n      \"\
+        upstream_url\": \"https://github.com/sebastianbergmann/git\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1489408945.0,\n      \"\
+        description\": \"Mock Object library for PHPUnit\\n\\nAutoloader: /usr/share/php/PHPUnit6/Framework/MockObject/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-phpunit-mock-objects4\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1420378\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Mock Object library for PHPUnit\",\n\
+        \      \"upstream_url\": \"https://github.com/sebastianbergmann/phpunit-mock-objects\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1488816360.0,\n\
+        \      \"description\": \"Library that provides collection, processing, and\
+        \ rendering functionality\\nfor PHP code coverage information.\\n\\nAutoloader:\
+        \ /usr/share/php/SebastianBergmann/CodeCoverage5/autoload.php\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-phpunit-php-code-coverage5\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1420374\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"PHP code coverage\
+        \ information\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/php-code-coverage\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"TextUI front-end for PHP_CodeCoverage.\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\":\
+        \ \"php-phpunit-phpcov\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"TextUI front-end\
+        \ for PHP_CodeCoverage\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/phpcov\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"phpdcd is a Dead Code Detector (DCD) for PHP code.\
+        \ It scans a PHP project\\nfor all declared functions and methods and reports\
+        \ those as being \\\"dead\\ncode\\\" that are not called at least once.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"php-phpunit-phpdcd\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Dead Code Detector\
+        \ (DCD) for PHP code\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/phpdcd\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1488384760.0,\n\
+        \      \"description\": \"This package holds all interfaces/classes/traits\
+        \ related to PSR-11.\\n\\nNote that this is not a container implementation\
+        \ of its own.\\n\\nAutoloader: /usr/share/php/Psr/Container/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-psr-container\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1427017\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Common Container Interface\",\n      \"upstream_url\"\
+        : \"https://github.com/php-fig/container\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"The\
+        \ phpredis extension provides an API for communicating\\nwith the Redis key-value\
+        \ store.\\n\\nThis Redis client implements most of the latest Redis API.\\\
+        nAs method only only works when also implemented on the server side,\\nsome\
+        \ doesn't work with an old redis server version.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-redis\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Extension for communicating with the\
+        \ Redis key-value store\",\n      \"upstream_url\": \"https://github.com/nicolasff/phpredis\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"What is SabreDAV\\n\\nSabreDAV allows you to easily\
+        \ add WebDAV support to a PHP application.\\nSabreDAV is meant to cover the\
+        \ entire standard, and attempts to allow\\nintegration using an easy to understand\
+        \ API.\\n\\nFeature list:\\n* Fully WebDAV compliant\\n* Supports Windows\
+        \ XP, Windows Vista, Mac OS/X, DavFSv2, Cadaver, Netdrive,\\n  Open Office,\
+        \ and probably more.\\n* Passing all Litmus tests.\\n* Supporting class 1,\
+        \ 2 and 3 Webdav servers.\\n* Locking support.\\n* Custom property support.\\\
+        n* CalDAV (tested with Evolution, iCal, iPhone and Lightning).\\n* CardDAV\
+        \ (tested with OS/X addressbook, the iOS addressbook and Evolution).\\n* Over\
+        \ 97% unittest code coverage.\\n\\nAutoloader: /usr/share/php/Sabre/DAV/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-sabre-dav\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"WebDAV Framework\
+        \ for PHP\",\n      \"upstream_url\": \"https://github.com/fruux/sabre-dav\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A lightweight library for event management in PHP.\\\
+        nIt's design is inspired by Node.js's EventEmitter. sabre/event requires PHP\
+        \ 5.4.\\n\\nAutoloader: /usr/share/php/Sabre/Event/autoload.php\",\n     \
+        \ \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"\
+        php-sabre-event\",\n      \"namespace\": \"rpms\",\n      \"review_url\":\
+        \ null,\n      \"status\": \"Approved\",\n      \"summary\": \"Lightweight\
+        \ library for event-based programming\",\n      \"upstream_url\": \"http://sabre.io/event\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This library provides a toolkit to make working\
+        \ with the HTTP protocol easier.\\n\\nMost PHP scripts run within a HTTP request\
+        \ but accessing information about\\nthe HTTP request is cumbersome at least,\
+        \ mainly do to superglobals and the\\nCGI standard.\\n\\nThere's bad practices,\
+        \ inconsistencies and confusion.\\nThis library is effectively a wrapper around\
+        \ the following PHP constructs:\\n\\nFor Input:\\n    $_GET\\n    $_POST\\\
+        n    $_SERVER\\n    php://input or $HTTP_RAW_POST_DATA.\\n\\nFor output:\\\
+        n    php://output or echo.\\n    header()\\n\\nWhat this library provides,\
+        \ is a Request object, and a Response object.\\nThe objects are extendable\
+        \ and easily mockable.\\n\\nAutoloader: /usr/share/php/Sabre/HTTP/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-sabre-http\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Library for\
+        \ dealing with http requests and responses\",\n      \"upstream_url\": \"\
+        https://github.com/fruux/sabre-http\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1457713167.0,\n      \"description\": \"sabre/uri\
+        \ is a lightweight library that provides several functions for\\nworking with\
+        \ URIs, staying true to the rules of RFC3986.\\n\\nPartially inspired by Node.js\
+        \ URL library, and created to solve real\\nproblems in PHP applications. 100%\
+        \ unitested and many tests are based\\non examples from RFC3986.\\n\\nThe\
+        \ library provides the following functions:\\n* resolve to resolve relative\
+        \ urls.\\n* normalize to aid in comparing urls.\\n* parse, which works like\
+        \ PHP's parse_url.\\n* build to do the exact opposite of parse.\\n* split\
+        \ to easily get the 'dirname' and 'basename' of a URL without\\n  all the\
+        \ problems those two functions have.\\n\\nAutoloader: /usr/share/php/Sabre/Uri/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-sabre-uri\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316906\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Functions for making sense out of URIs\",\n      \"\
+        upstream_url\": \"https://github.com/fruux/sabre-uri\"\n    },\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"The VObject library allows you to easily parse and manipulate iCalendar\\\
+        nand vCard objects using PHP. The goal of the VObject library is to create\\\
+        na very complete library, with an easy to use API.\\n\\nThis project is a\
+        \ spin-off from SabreDAV, where it has been used for several\\nyears. The\
+        \ VObject library has 100% unittest coverage.\\n\\nAutoloader: /usr/share/php/Sabre/VObject/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-sabre-vobject\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Library to\
+        \ parse and manipulate iCalendar and vCard objects\",\n      \"upstream_url\"\
+        : \"http://sabre.io/vobject/\"\n    },\n    {\n      \"acls\": [],\n     \
+        \ \"creation_date\": 1487684434.0,\n      \"description\": \"The VObject library\
+        \ allows you to easily parse and manipulate iCalendar\\nand vCard objects\
+        \ using PHP. The goal of the VObject library is to create\\na very complete\
+        \ library, with an easy to use API.\\n\\nThis project is a spin-off from SabreDAV,\
+        \ where it has been used for several\\nyears. The VObject library has 100%\
+        \ unittest coverage.\\n\\nAutoloader: /usr/share/php/Sabre/VObject4/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-sabre-vobject4\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1413978\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Library to parse and manipulate iCalendar and vCard\
+        \ objects\",\n      \"upstream_url\": \"http://sabre.io/vobject/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1458655561.0,\n    \
+        \  \"description\": \"The sabre/xml library is a specialized XML reader and\
+        \ writer.\\n\\nAutoloader: /usr/share/php/Sabre/Xml/autoload.php\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\":\
+        \ \"php-sabre-xml\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316912\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"XML library that you may not hate\",\n      \"upstream_url\"\
+        : \"https://github.com/fruux/sabre-xml\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1456152152.0,\n      \"description\": \"Looks up\
+        \ which function or method a line of code belongs to.\\n\\nAutoloader: /usr/share/php/SebastianBergmann/CodeUnitReverseLookup/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-sebastian-code-unit-reverse-lookup\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1307216\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Looks up which function or method\
+        \ a line of code belongs to\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/code-unit-reverse-lookup\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1488893865.0,\n\
+        \      \"description\": \"Provides the functionality to export PHP variables\
+        \ for visualization.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"php-sebastian-exporter3\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1428912\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Export PHP variables\
+        \ for visualization\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/exporter\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1418048191.0,\n\
+        \      \"description\": \"Snapshotting of global state,\\nfactored out of\
+        \ PHPUnit into a stand-alone component.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-sebastian-global-state\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1170948\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Snapshotting of global\
+        \ state\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/global-state\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460552761.0,\n\
+        \      \"description\": \"Traverses array structures and object graphs to\
+        \ enumerate all\\nreferenced objects.\\n\\nAutoloader: /usr/share/php/SebastianBergmann/ObjectEnumerator/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-sebastian-object-enumerator\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/1320532\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Traverses array and object to enumerate\
+        \ all referenced objects\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/object-enumerator\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490195290.0,\n\
+        \      \"description\": \"Allows reflection of object attributes, including\
+        \ inherited\\nand non-public ones.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-sebastian-object-reflector\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1431451\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Allows reflection\
+        \ of object attributes\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/object-reflector\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1422222543.0,\n\
+        \      \"description\": \"Provides functionality to recursively process PHP\
+        \ variables.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-sebastian-recursion-context\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1185606\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Recursively process\
+        \ PHP variables\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/recursion-context\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1488893823.0,\n\
+        \      \"description\": \"Provides functionality to recursively process PHP\
+        \ variables.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-sebastian-recursion-context3\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1428908\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Recursively process\
+        \ PHP variables\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/recursion-context\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1444576633.0,\n\
+        \      \"description\": \"Provides a list of PHP built-in functions that operate\
+        \ on resources.\",\n      \"koschei_monitor\": false,\n      \"monitor\":\
+        \ true,\n      \"name\": \"php-sebastian-resource-operations\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1267233\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Provides a list of\
+        \ PHP built-in functions that operate on resources\",\n      \"upstream_url\"\
+        : \"https://github.com/sebastianbergmann/resource-operations\"\n    },\n \
+        \   {\n      \"acls\": [],\n      \"creation_date\": 1431367713.0,\n     \
+        \ \"description\": \"While prompting for user input using fgets() is quite\
+        \ easy, sometimes you\\nneed to prompt for sensitive information. In these\
+        \ cases, the characters typed\\nin by the user should not be directly visible,\
+        \ and this is quite a pain to do\\nin a cross-platform way.\\n\\nTo use this\
+        \ library, you just have to add, in your project:\\n  require_once '/usr/share/php/Seld/CliPrompt/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-seld-cli-prompt\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1218089\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Allows you to prompt for user input on the command\
+        \ line\",\n      \"upstream_url\": \"https://github.com/Seldaek/cli-prompt\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1431367761.0,\n\
+        \      \"description\": \"PHAR file format utilities, for when PHP phars you\
+        \ up.\\n\\nTo use this library, you just have to add, in your project:\\n\
+        \  require_once '/usr/share/php/Seld/PharUtils/autoload.php';\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-seld-phar-utils\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1218090\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"PHAR file format\
+        \ utilities\",\n      \"upstream_url\": \"https://github.com/Seldaek/phar-utils\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The php-shout package is an extension to the PHP\
+        \ Hypertext Preprocessor.\\nIt wraps the libshout library available from http://icecast.org/\
+        \ and\\nprovides native Shout functions to the PHP runtime engine.  Libshout\
+        \ is\\na streaming audio library that connects and sends properly formatted\\\
+        naudio data to an Icecast Streaming Media server (also http://icecast.org/).\\\
+        nLibshout \\\"handles the socket connection, the timing of the data, and\\\
+        nprevents bad data from getting to the icecast server.\\\"  With php-shout,\
+        \ a\\nPHP developer can write PHP scripts that act as a streaming media source,\\\
+        nand focus on other robust features, without worrying about the\\ndetails\
+        \ of the server communication.\",\n      \"koschei_monitor\": false,\n   \
+        \   \"monitor\": false,\n      \"name\": \"php-shout\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"PHP module for communicating with Icecast servers\"\
+        ,\n      \"upstream_url\": \"http://phpshout.sourceforge.net/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1442772643.0,\n    \
+        \  \"description\": \"smbclient is a PHP extension that uses Samba's libsmbclient\\\
+        nlibrary to provide Samba related functions and 'smb' streams\\nto PHP programs.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-smbclient\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1263958\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"PHP wrapper for libsmbclient\",\n      \"upstream_url\"\
+        : \"https://github.com/eduardok/libsmbclient-php\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Solarium is a PHP Solr client library that accurately model Solr concepts.\\\
+        n\\nWhere many other Solr libraries only handle the communication with Solr,\\\
+        nSolarium also relieves you of handling all the complex Solr query parameters\\\
+        nusing a well documented API.\\n\\nAutoloader: /usr/share/php/Solarium/autoload.php\\\
+        n\\nDocumentation: http://wiki.solarium-project.org/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-solarium\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Solarium PHP Solr client library\",\n\
+        \      \"upstream_url\": \"http://www.solarium-project.org/\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1458858833.0,\n      \"\
+        description\": \"Swift Mailer integrates into any web app written in PHP,\
+        \ offering a\\nflexible and elegant object-oriented approach to sending emails\
+        \ with\\na multitude of features.\\n\\nAutoloader: /usr/share/php/Swift/swift_required.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-swiftmailer\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1320583\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Free Feature-rich PHP Mailer\",\n      \"upstream_url\"\
+        : \"http://www.swiftmailer.org/\"\n    },\n    {\n      \"acls\": [],\n  \
+        \    \"creation_date\": 1400070978.0,\n      \"description\": \"The Symfony\
+        \ YAML Component.\\n\\nSymfony YAML is a PHP library that parses YAML strings\
+        \ and converts them to\\nPHP arrays. It can also converts PHP arrays to YAML\
+        \ strings.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-symfony-YAML\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"The Symfony YAML Component\",\n      \"upstream_url\": \"http://components.symfony-project.org/yaml/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHP class for generating PDF documents.\\n\\n* no\
+        \ external libraries are required for the basic functions;\\n* all standard\
+        \ page formats, custom page formats, custom margins and units\\n  of measure;\\\
+        n* UTF-8 Unicode and Right-To-Left languages;\\n* TrueTypeUnicode, OpenTypeUnicode,\
+        \ TrueType, OpenType, Type1 and CID-0 fonts;\\n* font subsetting;\\n* methods\
+        \ to publish some XHTML + CSS code, Javascript and Forms;\\n* images, graphic\
+        \ (geometric figures) and transformation methods;\\n* supports JPEG, PNG and\
+        \ SVG images natively, all images supported by GD\\n  (GD, GD2, GD2PART, GIF,\
+        \ JPEG, PNG, BMP, XBM, XPM) and all images supported\\n  via ImagMagick (http:\
+        \ www.imagemagick.org/www/formats.html)\\n* 1D and 2D barcodes: CODE 39, ANSI\
+        \ MH10.8M-1983, USD-3, 3 of 9, CODE 93,\\n  USS-93, Standard 2 of 5, Interleaved\
+        \ 2 of 5, CODE 128 A/B/C, 2 and 5 Digits\\n  UPC-Based Extention, EAN 8, EAN\
+        \ 13, UPC-A, UPC-E, MSI, POSTNET, PLANET,\\n  RMS4CC (Royal Mail 4-state Customer\
+        \ Code), CBC (Customer Bar Code),\\n  KIX (Klant index - Customer index),\
+        \ Intelligent Mail Barcode, Onecode,\\n  USPS-B-3200, CODABAR, CODE 11, PHARMACODE,\
+        \ PHARMACODE TWO-TRACKS,\\n  Datamatrix ECC200, QR-Code, PDF417;\\n* ICC Color\
+        \ Profiles, Grayscale, RGB, CMYK, Spot Colors and Transparencies;\\n* automatic\
+        \ page header and footer management;\\n* document encryption up to 256 bit\
+        \ and digital signature certifications;\\n* transactions to UNDO commands;\\\
+        n* PDF annotations, including links, text and file attachments;\\n* text rendering\
+        \ modes (fill, stroke and clipping);\\n* multiple columns mode;\\n* no-write\
+        \ page regions;\\n* bookmarks and table of content;\\n* text hyphenation;\\\
+        n* text stretching and spacing (tracking/kerning);\\n* automatic page break,\
+        \ line break and text alignments including justification;\\n* automatic page\
+        \ numbering and page groups;\\n* move and delete pages;\\n* page compression\
+        \ (requires php-zlib extension);\\n* XOBject templates;\\n* PDF/A-1b (ISO\
+        \ 19005-1:2005) support.\\n\\nBy default, TCPDF uses the GD library which\
+        \ is know as slower than ImageMagick\\nsolution. You can optionally install\
+        \ php-pecl-imagick; TCPDF will use it.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-tcpdf\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"PHP class for generating PDF documents and barcodes\"\
+        ,\n      \"upstream_url\": \"http://www.tcpdf.org\"\n    },\n    {\n     \
+        \ \"acls\": [],\n      \"creation_date\": 1440365839.0,\n      \"description\"\
+        : \"Provides tc-lib-barcode: PHP classes to generate linear and bidimensional\\\
+        nbarcodes: CODE 39, ANSI MH10.8M-1983, USD-3, 3 of 9, CODE 93, USS-93,\\nStandard\
+        \ 2 of 5, Interleaved 2 of 5, CODE 128 A/B/C, 2 and 5 Digits\\nUPC-Based Extension,\
+        \ EAN 8, EAN 13, UPC-A, UPC-E, MSI, POSTNET, PLANET,\\nRMS4CC (Royal Mail\
+        \ 4-state Customer Code), CBC (Customer Bar Code),\\nKIX (Klant index - Customer\
+        \ index), Intelligent Mail Barcode, Onecode,\\nUSPS-B-3200, CODABAR, CODE\
+        \ 11, PHARMACODE, PHARMACODE TWO-TRACKS, Datamatrix\\nECC200, QR-Code, PDF417.\\\
+        n\\nOptional dependency: php-pecl-imagick\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"php-tecnickcom-tc-lib-barcode\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1252924\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"PHP library to generate\
+        \ linear and bidimensional barcodes\",\n      \"upstream_url\": \"https://github.com/tecnickcom/tc-lib-barcode\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1440365816.0,\n\
+        \      \"description\": \"Provides tc-lib-color: PHP library to manipulate\
+        \ various color\\nrepresentations (GRAY, RGB, HSL, CMYK) and parse Web colors.\\\
+        n\\nThe initial source code has been extracted from TCPDF (http://www.tcpdf.org).\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"php-tecnickcom-tc-lib-color\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1252918\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PHP library to manipulate various color\
+        \ representations\",\n      \"upstream_url\": \"https://github.com/tecnickcom/tc-lib-color\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The PHP AutoloadBuilder CLI tool phpab is a command\
+        \ line application\\nto automate the process of generating an autoload require\
+        \ file with\\nthe option of creating static require lists as well as phar\
+        \ archives.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-theseer-autoload\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"A tool and library to generate autoload code\",\n      \"upstream_url\"\
+        : \"https://github.com/theseer/Autoload\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"A\
+        \ recursive directory scanner and filter.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-theseer-directoryscanner\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A recursive directory scanner and filter\"\
+        ,\n      \"upstream_url\": \"https://github.com/theseer/DirectoryScanner\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"An Extension to PHP's standard DOM to add various\
+        \ convenience methods\\nand exceptions by default\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-theseer-fDOMDocument\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An Extension to PHP standard DOM\",\n\
+        \      \"upstream_url\": \"https://github.com/theseer/fDOMDocument\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1448810915.0,\n\
+        \      \"description\": \"Tracy library is a useful PHP everyday programmer's\
+        \ helper. It helps you to:\\n\\n- quickly detect and correct errors\\n- log\
+        \ errors\\n- dump variables\\n- measure the time\\n\\nTo use this library,\
+        \ you just have to add, in your project:\\n  require_once '/usr/share/php/Tracy/autoload.php';\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-tracy\",\n      \"namespace\": \"rpms\",\n      \"review_url\": \"\
+        https://bugzilla.redhat.com/1277400\",\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Tracy: useful PHP debugger\",\n      \"upstream_url\"\
+        : \"https://github.com/nette/tracy\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1420635866.0,\n      \"description\": \"A Bootstring\
+        \ encoding of Unicode for Internationalized Domain Names\\nin Applications\
+        \ (IDNA).\\n\\nAutoloader: /usr/share/php/TrueBV/autoload.php\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-true-punycode\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1179665\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A Bootstring encoding\
+        \ of Unicode for IDNA\",\n      \"upstream_url\": \"https://github.com/true/php-punycode\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Twig is a PHP template engine.\\n\\nThis package\
+        \ provides the Twig C extension (CTwig) to improve performance\\nof the Twig\
+        \ template language, used by Twig PHP extension (php-twig-Twig).\",\n    \
+        \  \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-twig-ctwig\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Extension to\
+        \ improve performance of Twig\",\n      \"upstream_url\": \"http://twig.sensiolabs.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483971862.0,\n\
+        \      \"description\": \"The flexible, fast, and secure template engine for\
+        \ PHP.\\n\\n* Fast: Twig compiles templates down to plain optimized PHP code.\
+        \ The\\n  overhead compared to regular PHP code was reduced to the very minimum.\\\
+        n\\n* Secure: Twig has a sandbox mode to evaluate untrusted template code.\
+        \ This\\n  allows Twig to be used as a template language for applications\
+        \ where users\\n  may modify the template design.\\n\\n* Flexible: Twig is\
+        \ powered by a flexible lexer and parser. This allows the\\n  developer to\
+        \ define its own custom tags and filters, and create its own\\n  DSL.\\n\\\
+        nAutoloader: /usr/share/php/Twig2/autoload.php\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-twig2\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1410985\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"The flexible, fast,\
+        \ and secure template engine for PHP\",\n      \"upstream_url\": \"http://twig.sensiolabs.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1442858457.0,\n\
+        \      \"description\": \"A validating SQL lexer and parser with a focus on\
+        \ MySQL dialect.\\n\\nThis library was originally developed for phpMyAdmin\
+        \ during\\nthe Google Summer of Code 2015.\\n\\nAutoloader: /usr/share/php/SqlParser/autoload.php\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-udan11-sql-parser\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1262807\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A validating SQL lexer and parser with a focus on\
+        \ MySQL dialect\",\n      \"upstream_url\": \"https://github.com/phpmyadmin/sql-parser\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"XCache is a fast, stable  PHP opcode and data cacher\
+        \ that has been tested\\nand is now running on production servers under high\
+        \ load.\\n\\nIt is tested (on linux) and supported on all of the latest PHP\
+        \ release.\\nThreadSafe is also perfectly supported.\\n\\nNOTICE: opcode cacher\
+        \ is disable to allow use with php-opcache only for user\\ndata cache. You\
+        \ need to edit configuration file (xcache.ini) to enable it.\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\": \"php-xcache\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Fast, stable PHP opcode cacher\",\n\
+        \      \"upstream_url\": \"http://xcache.lighttpd.net/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"XMPPHP is the successor to Class.Jabber.PHP which can connect to XMPP\\\
+        n1.0 server (google talk, jabber.orgf, LJ Talk, etc, supports TLS,\\nseveral\
+        \ XML processing approaches and supported styles, persistent\\nconnection,\
+        \ etc.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-xmpphp\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        XMPPHP is the successor to Class.Jabber.PHP\",\n      \"upstream_url\": \"\
+        http://code.google.com/p/xmpphp/\"\n    },\n    {\n      \"acls\": [],\n \
+        \     \"creation_date\": 1443660800.0,\n      \"description\": \"Zend Framework\
+        \ is an open source framework for developing web applications\\nand services\
+        \ using PHP.\\n\\nThis package is a metapackage aggregating most of the components.\\\
+        n\\nDocumentation: https://zendframework.github.io/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"php-zendframework\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework\"\
+        ,\n      \"upstream_url\": \"https://framework.zend.com/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1443662052.0,\n      \"description\"\
+        : \"The Zend\\\\Authentication component provides an API for authentication\
+        \ and\\nincludes concrete authentication adapters for common use case scenarios.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-authentication\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Authentication\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443662627.0,\n\
+        \      \"description\": \"Zend\\\\Barcode provides a generic way to generate\
+        \ barcodes.\\nThe Zend\\\\Barcode component is divided into two subcomponents:\
+        \ barcode objects\\nand renderers. Objects allow you to create barcodes independently\
+        \ of the\\nrenderer. Renderer allow you to draw barcodes based on the support\
+        \ required.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-zendframework-zend-barcode\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Barcode\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443662771.0,\n\
+        \      \"description\": \"Zend\\\\Cache provides a general cache system for\
+        \ PHP.\\nThe Zend\\\\Cache component is able to cache different patterns\\\
+        n(class, object, output, etc) using different storage adapters\\n(DB, File,\
+        \ Memcache, etc).\\n\\nDocumentation: https://zendframework.github.io/zend-cache/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-cache\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Cache\
+        \ component\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-cache/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443662867.0,\n\
+        \      \"description\": \"Zend\\\\Captcha component is able to manage \\u201cCompletely\
+        \ Automated Public\\nTuring test to tell Computers and Humans Apart\\u201d\
+        \ (CAPTCHA); it is used\\nas a challenge-response to ensure that the individual\
+        \ submitting\\ninformation is a human and not an automated process. Typically,\
+        \ a captcha\\nis used with form submissions where authenticated users are\
+        \ not necessary,\\nbut you want to prevent spam submissions.\\n\\nDocumentation:\
+        \ https://zendframework.github.io/zend-captcha/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-captcha\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Captcha\
+        \ component\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-captcha/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443662947.0,\n\
+        \      \"description\": \"Zend\\\\Code\\\\Generator provides facilities to\
+        \ generate arbitrary code using\\nan object-oriented interface, both to create\
+        \ new code as well as to update\\nexisting code. While the current implementation\
+        \ is limited to generating\\nPHP code, you can easily extend the base class\
+        \ in order to provide code\\ngeneration for other tasks: JavaScript, configuration\
+        \ files, apache vhosts,\\netc.\\n\\nDocumentation: https://zendframework.github.io/zend-code/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-code\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Code\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443662954.0,\n\
+        \      \"description\": \"Zend\\\\Config is designed to simplify access to\
+        \ configuration data within\\napplications. It provides a nested object property-based\
+        \ user interface\\nfor accessing this configuration data within application\
+        \ code. The\\nconfiguration data may come from a variety of media supporting\
+        \ hierarchical\\ndata storage.\",\n      \"koschei_monitor\": true,\n    \
+        \  \"monitor\": false,\n      \"name\": \"php-zendframework-zend-config\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Config\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663024.0,\n\
+        \      \"description\": \"Zend\\\\Console is a component to design and implement\
+        \ console applications in PHP.\\n\\nDocumentation: https://zendframework.github.io/zend-console/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-console\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Console\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663028.0,\n\
+        \      \"description\": \"Zend\\\\Crypt provides support of some cryptographic\
+        \ tools.\\nThe available features are:\\n* encrypt-then-authenticate using\
+        \ symmetric ciphers\\n  (the authentication step is provided using HMAC);\\\
+        n* encrypt/decrypt using symmetric and public key algorithm\\n  (e.g. RSA\
+        \ algorithm);\\n* generate digital sign using public key algorithm (e.g. RSA\
+        \ algorithm);\\n* key exchange using the Diffie-Hellman method;\\n* key derivation\
+        \ function (e.g. using PBKDF2 algorithm);\\n* secure password hash (e.g. using\
+        \ Bcrypt algorithm);\\n* generate Hash values;\\n* generate HMAC values;\\\
+        n\\nThe main scope of this component is to offer an easy and secure way\\\
+        nto protect and authenticate sensitive data in PHP.\\n\\nDocumentation: https://zendframework.github.io/zend-crypt/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-crypt\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Crypt\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663034.0,\n\
+        \      \"description\": \"Zend\\\\Db is a component that abstract the access\
+        \ to a Database using an object\\noriented API to build the queries. Zend\\\
+        \\Db consumes different storage adapters\\nto access different database vendors\
+        \ such as MySQL, PostgreSQL, Oracle,\\nIBM DB2, Microsoft Sql Server, PDO,\
+        \ etc.\\n\\nDocumentation: https://zendframework.github.io/zend-db/\",\n \
+        \     \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-db\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\",\n \
+        \     \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Db component\"\
+        ,\n      \"upstream_url\": \"https://framework.zend.com/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1443663039.0,\n      \"description\"\
+        : \"Zend\\\\Debug is a component that help the debugging of PHP applications.\\\
+        nIn particular it offers a static method Zend\\\\Debug\\\\Debug::dump() that\\\
+        nprints or returns information about an expression. This simple technique\\\
+        nof debugging is common because it is easy to use in an ad hoc fashion and\\\
+        nrequires no initialization, special tools, or debugging environment.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-debug\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Debug\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663045.0,\n\
+        \      \"description\": \"Zend\\\\Di is an example of an Inversion of Control\
+        \ (IoC) container.\\nIoC containers are widely used to create object instances\
+        \ that have all\\ndependencies resolved and injected. Dependency Injection\
+        \ containers are\\none form of IoC \\u2013 but not the only form.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-di\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\",\n \
+        \     \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Di component\"\
+        ,\n      \"upstream_url\": \"http://framework.zend.com/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1443663052.0,\n      \"description\"\
+        : \"The Zend\\\\Dom component provides tools for working with DOM documents\
+        \ and\\nstructures. Currently, we offer Zend\\\\Dom\\\\Query, which provides\
+        \ a unified\\ninterface for querying DOM documents utilizing both XPath and\
+        \ CSS selectors.\",\n      \"koschei_monitor\": true,\n      \"monitor\":\
+        \ false,\n      \"name\": \"php-zendframework-zend-dom\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Dom\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663058.0,\n\
+        \      \"description\": \"The OWASP Top 10 web security risks study lists\
+        \ Cross-Site Scripting (XSS)\\nin second place. PHP\\u2019s sole functionality\
+        \ against XSS is limited to two\\nfunctions of which one is commonly misapplied.\
+        \ Thus, the Zend\\\\Escaper\\ncomponent was written. It offers developers\
+        \ a way to escape output and defend\\nfrom XSS and related vulnerabilities\
+        \ by introducing contextual escaping based\\non peer-reviewed rules.\\n\\\
+        nDocumentation: https://zendframework.github.io/zend-escaper/\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-escaper\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Escaper\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663066.0,\n\
+        \      \"description\": \"The Zend\\\\EventManager is a component designed\
+        \ for the following use cases:\\n\\n    Implementing simple subject/observer\
+        \ patterns.\\n    Implementing Aspect-Oriented designs.\\n    Implementing\
+        \ event-driven architectures.\\n\\nThe basic architecture allows you to attach\
+        \ and detach listeners to named\\nevents, both on a per-instance basis as\
+        \ well as via shared collections;\\ntrigger events; and interrupt execution\
+        \ of listeners.\\n\\nDocumentation: https://zendframework.github.io/zend-eventmanager/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-eventmanager\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Trigger and listen\
+        \ to events within a PHP application\",\n      \"upstream_url\": \"https://framework.zend.com/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468942678.0,\n\
+        \      \"description\": \"zend-expressive builds on zend-stratigility to provide\
+        \ a minimalist PSR-7\\nmiddleware framework for PHP, with the following features:\\\
+        n* Routing. Choose your own router; we support:\\n  - Aura.Router\\n  - FastRoute\\\
+        n  - ZF2's MVC router\\n* DI Containers, via container-interop. Middleware\
+        \ matched via routing is\\n  retrieved from the composed container.\\n* Optionally,\
+        \ templating. We support:\\n  -  Plates\\n  -  Twig\\n  -  ZF2's PhpRenderer\\\
+        n\\nDocumentation: http://zend-expressive.readthedocs.io/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-expressive\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352536\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"PSR-7 Middleware\
+        \ Microframework based on Stratigility\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-expressive/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468942482.0,\n\
+        \      \"description\": \"Provides Aura.Router integration for zend-expressive.\\\
+        n\\nDocumentation: http://zend-expressive.readthedocs.io/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-expressive-aurarouter\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352516\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Aura.Router integration\
+        \ for Expressive\",\n      \"upstream_url\": \"https://framework.zend.com/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468942352.0,\n\
+        \      \"description\": \"Provides FastRoute integration for Expressive.\\\
+        n\\nDocumentation:\\nhttps://zendframework.github.io/zend-expressive/features/router/fast-route/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-expressive-fastroute\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352520\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"FastRoute integration\
+        \ for Expressive\",\n      \"upstream_url\": \"https://framework.zend.com/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468942567.0,\n\
+        \      \"description\": \"Helper classes for Expressive.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-expressive-helpers\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352538\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Helper/Utility classes\
+        \ for Expressive\",\n      \"upstream_url\": \"https://docs.zendframework.com/zend-expressive/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468942644.0,\n\
+        \      \"description\": \"Provides integration with Plates for Expressive.\\\
+        n\\nDocumentation: http://zend-expressive.readthedocs.io/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-expressive-platesrenderer\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352549\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Plates integration\
+        \ for Expressive\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-expressive/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468942076.0,\n\
+        \      \"description\": \"Router subcomponent for Expressive.\\n\\nThis package\
+        \ provides the following classes and interfaces:\\n\\n* RouterInterface, a\
+        \ generic interface to implement for providing routing\\n  capabilities around\
+        \ PSR-7 ServerRequest messages.\\n* Route, a value object describing routed\
+        \ middleware.\\n* RouteResult, a value object describing the results of routing.\\\
+        n\\nWe currently support and provide the following routing integrations:\\\
+        n\\n* Aura.Router: php-zendframework-zend-expressive-aurarouter\\n* FastRoute:\
+        \ php-zendframework-zend-expressive-fastroute\\n* ZF2 MVC Router: php-zendframework-zend-expressive-zendviewrouter\\\
+        n\\nDocumentation: http://zend-expressive.readthedocs.io/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-expressive-router\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352469\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Router subcomponent\
+        \ for Expressive\",\n      \"upstream_url\": \"https://framework.zend.com/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468942190.0,\n\
+        \      \"description\": \"Template subcomponent for Expressive\\n\\nThis package\
+        \ provides the following classes, interfaces, and traits:\\n\\n* TemplateRendererInterface,\
+        \ a generic interface for providing template rendering capabilities.\\n* TemplatePath,\
+        \ a value object describing a (optionally) namespaced path in which templates\
+        \ reside; the TemplateRendererInterface returns these.\\n* ArrayParametersTrait\
+        \ provides helper methods you can mix in to implementations for normalizing\
+        \ template parameters to an array.\\n* DefaultParamsTrait provides helper\
+        \ methods you can mix in to implementations for aggregating default parameters\
+        \ as well as merging global, template-specific, and provided parameters when\
+        \ rendering.\\n\\nWe currently support and provide the following routing integrations:\\\
+        n\\n* Plates: php-zendframework-zend-expressive-platesrenderer\\n* Twig: php-zendframework-zend-expressive-twigrenderer\\\
+        n* ZF2 PhpRenderer: php-zendframework-zend-expressive-zendviewrenderer\\n\\\
+        nDocumentation: http://zend-expressive.readthedocs.io/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-expressive-template\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352471\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Template subcomponent\
+        \ for Expressive\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-expressive/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468942845.0,\n\
+        \      \"description\": \"Provides Twig integration for Expressive.\\n\\nDocumentation:\
+        \ http://zend-expressive.readthedocs.io/\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-expressive-twigrenderer\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352553\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Twig integration\
+        \ for Expressive\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-expressive/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468942384.0,\n\
+        \      \"description\": \"Provides ZF2's MVC router integration for zend-expressive.\\\
+        n\\nDocumentation:\\nhttps://zendframework.github.io/zend-expressive/features/router/zf2/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-expressive-zendrouter\",\n      \"namespace\":\
+        \ \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352528\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"zend-mvc router support\
+        \ for Expressive\",\n      \"upstream_url\": \"https://framework.zend.com/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468942607.0,\n\
+        \      \"description\": \"zend-view PhpRenderer integration for Expressive.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-expressive-zendviewrenderer\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352539\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"zend-view PhpRenderer\
+        \ integration for Expressive\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-expressive/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663074.0,\n\
+        \      \"description\": \"Zend\\\\Feed provides functionality for consuming\
+        \ RSS and Atom feeds.\\nIt provides a natural syntax for accessing elements\
+        \ of feeds, feed attributes,\\nand entry attributes. Zend\\\\Feed also has\
+        \ extensive support for modifying feed\\nand entry structure with the same\
+        \ natural syntax, and turning the result back\\ninto XML.\\n\\nDocumentation:\
+        \ https://zendframework.github.io/zend-feed/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-feed\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Feed\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663080.0,\n\
+        \      \"description\": \"Zend\\\\File is a component used to manage file\
+        \ transfer and class autoloading.\\n\\nDocumentation: https://zendframework.github.io/zend-file/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-file\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework File\
+        \ component\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-file/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663087.0,\n\
+        \      \"description\": \"The Zend\\\\Filter component provides a set of commonly\
+        \ needed data filters.\\nIt also provides a simple filter chaining mechanism\
+        \ by which multiple\\nfilters may be applied to a single datum in a user-defined\
+        \ order.\\n\\nDocumentation: https://zendframework.github.io/zend-filter/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-filter\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Filter\
+        \ component\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-filter/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663095.0,\n\
+        \      \"description\": \"The Zend\\\\Form is intended primarily as a bridge\
+        \ between your domain models\\nand the View Layer. It composes a thin layer\
+        \ of objects representing form\\nelements, an InputFilter, and a small number\
+        \ of methods for binding data to\\nand from the form and attached objects.\\\
+        n\\nDocumentation: https://zendframework.github.io/zend-form/\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-form\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Form\
+        \ component\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-form/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663100.0,\n\
+        \      \"description\": \"Zend\\\\Http is a primary foundational component\
+        \ of Zend Framework.\\nSince much of what PHP does is web-based, specifically\
+        \ HTTP,\\nit makes sense to have a performant, extensible, concise and\\nconsistent\
+        \ API to do all things HTTP.\\n\\nDocumentation: https://zendframework.github.io/zend-http/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-http\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Http\
+        \ component\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-http/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454334794.0,\n\
+        \      \"description\": \"Zend\\\\Hydrator provides utilities for mapping\
+        \ arrays to objects,\\nand vice versa, including facilities for filtering\
+        \ which data\\nis mapped as well as providing mechanisms for mapping nested\\\
+        nstructures.\\n\\nDocumentation: https://zendframework.github.io/zend-hydrator/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-hydrator\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/1302552\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Zend Framework Hydrator component\"\
+        ,\n      \"upstream_url\": \"https://framework.zend.com/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1443663107.0,\n      \"description\"\
+        : \"Zend\\\\I18n comes with a complete translation suite which supports all\
+        \ major\\nformats and includes popular features like plural translations and\
+        \ text\\ndomains. The Translator component is mostly dependency free, except\
+        \ for\\nthe fallback to a default locale, where it relies on the Intl PHP\
+        \ extension.\\n\\nThe translator itself is initialized without any parameters,\
+        \ as any\\nconfiguration to it is optional. A translator without any translations\\\
+        nwill actually do nothing but just return the given message IDs.\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\":\
+        \ \"php-zendframework-zend-i18n\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework I18n\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663114.0,\n\
+        \      \"description\": \"This \\\"component\\\" provides translation resources,\
+        \ specifically\\nfor zendframework/zend-validate and zendframework/zend-captcha,\\\
+        nfor use with zendframework/zend-i18n's Translator subcomponent.\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\":\
+        \ \"php-zendframework-zend-i18n-resources\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Translator\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663120.0,\n\
+        \      \"description\": \"The Zend\\\\InputFilter component can be used to\
+        \ filter and validate generic sets\\nof input data. For instance, you could\
+        \ use it to filter $_GET or $_POST values,\\nCLI arguments, etc.\\n\\nDocumentation:\
+        \ https://zendframework.github.io/zend-inputfilter/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-inputfilter\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework InputFilter\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663127.0,\n\
+        \      \"description\": \"Zend\\\\Json provides convenience methods for serializing\
+        \ native PHP to JSON\\nand decoding JSON to native PHP.\\n\\nDocumentation:\
+        \ https://zendframework.github.io/zend-json/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-json\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Json\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480343444.0,\n\
+        \      \"description\": \"Provides a JSON-RPC server implementation.\\n\\\
+        n* File issues at https://github.com/zendframework/zend-json-server/issues\\\
+        n* Documentation is at http://framework.zend.com/manual/current/en/index.html#zend-json-server\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-json-server\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/1358149\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Zend Json-Server is a JSON-RPC\
+        \ server implementation\",\n      \"upstream_url\": \"https://framework.zend.com/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663132.0,\n\
+        \      \"description\": \"Zend\\\\Ldap\\\\Ldap is a class for performing LDAP\
+        \ operations including but\\nnot limited to binding, searching and modifying\
+        \ entries in an LDAP directory.\\n\\nDocumentation: https://zendframework.github.io/zend-ldap/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-ldap\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Ldap\
+        \ component\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-ldap/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663139.0,\n\
+        \      \"description\": \"Zend\\\\Loader provides different strategies for\
+        \ autoloading PHP classes.\\n\\nYou can include /usr/share/php/Zend/autoload.php\
+        \ from\\nyour application to use the Zend Framework.\\n\\nDocumentation: https://zendframework.github.io/zend-loader/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-loader\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Loader\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663147.0,\n\
+        \      \"description\": \"Zend\\\\Log is a component for general purpose logging.\
+        \ It supports multiple\\nlog backends, formatting messages sent to the log,\
+        \ and filtering messages\\nfrom being logged.\\n\\nDocumentation: https://zendframework.github.io/zend-log/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-log\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\",\n \
+        \     \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Log component\"\
+        ,\n      \"upstream_url\": \"https://framework.zend.com/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1443663153.0,\n      \"description\"\
+        : \"Zend\\\\Mail provides generalized functionality to compose and send both\
+        \ text\\nand MIME-compliant multipart email messages. Mail can be sent with\
+        \ Zend\\\\Mail\\nvia the Mail\\\\Transport\\\\Sendmail, Mail\\\\Transport\\\
+        \\Smtp or the\\nMail\\\\Transport\\\\File transport. Of course, you can also\
+        \ implement your own\\ntransport by implementing the Mail\\\\Transport\\\\\
+        TransportInterface.\\n\\nDocumentation: https://zendframework.github.io/zend-mail/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-mail\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Mail\
+        \ component\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-mail/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663159.0,\n\
+        \      \"description\": \"Zend\\\\Math provides general mathematical functions.\\\
+        nSo far the supported functionalities are:\\n* Zend\\\\Math\\\\Rand, a random\
+        \ number generator;\\n* Zend\\\\Math\\\\BigInteger, a library to manage big\
+        \ integers.\\n\\nDocumentation: https://zendframework.github.io/zend-math/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-math\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Math\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663166.0,\n\
+        \      \"description\": \"The Zend\\\\Memory component is intended to manage\
+        \ data in an environment with\\nlimited memory.\\n\\nMemory objects (memory\
+        \ containers) are generated by memory manager by request\\nand transparently\
+        \ swapped/loaded when it\\u2019s necessary.\\n\\nFor example, if creating\
+        \ or loading a managed object would cause the total\\nmemory usage to exceed\
+        \ the limit you specify, some managed objects are copied\\nto cache storage\
+        \ outside of memory. In this way, the total memory used by\\nmanaged objects\
+        \ does not exceed the limit you need to enforce.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-memory\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Memory\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663173.0,\n\
+        \      \"description\": \"Zend\\\\Mime is a support class for handling multipart\
+        \ MIME messages.\\nIt is used by Zend\\\\Mail and Zend\\\\Mime\\\\Message\
+        \ and may be used by\\napplications requiring MIME support.\\n\\nDocumentation:\
+        \ https://zendframework.github.io/zend-mime/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-mime\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Mime\
+        \ component\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-mime/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663179.0,\n\
+        \      \"description\": \"Zend Framework 2.0 introduces a new and powerful\
+        \ approach to modules.\\nThis new module system is designed with flexibility,\
+        \ simplicity, and\\nre-usability in mind. A module may contain just about\
+        \ anything:\\nPHP code, including MVC functionality; library code; view scripts;\\\
+        nand/or public assets such as images, CSS, and JavaScript.\\nThe possibilities\
+        \ are endless.\\n\\nZend\\\\ModuleManager is the component that enables the\
+        \ design of a module architecture for PHP applcations.\\n\\nDocumentation:\
+        \ https://zendframework.github.io/zend-modulemanager/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-modulemanager\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework ModuleManager\
+        \ component\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-modulemanager/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663187.0,\n\
+        \      \"description\": \"Zend\\\\Mvc is a brand new MVC implementation designed\
+        \ from the ground up\\nfor Zend Framework 2, focusing on performance and flexibility.\\\
+        n\\nThe MVC layer is built on top of the following components:\\n* Zend\\\\\
+        ServiceManager - Zend Framework provides a set of default service\\n  definitions\
+        \ set up at Zend\\\\Mvc\\\\Service. The ServiceManager creates and\\n  configures\
+        \ your application instance and workflow.\\n* Zend\\\\EventManager - The MVC\
+        \ is event driven. This component is used\\n  everywhere from initial bootstrapping\
+        \ of the application, through returning\\n  response and request calls, to\
+        \ setting and retrieving routes and matched\\n  routes, as well as render\
+        \ views.\\n* Zend\\\\Http - specifically the request and response objects,\
+        \ used within:\\n  Zend\\\\Stdlib\\\\DispatchableInterface. All \\u201ccontrollers\\\
+        u201d are simply dispatchable\\n  objects.\\n\\nDocumentation: https://zendframework.github.io/zend-mvc/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-mvc\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\",\n \
+        \     \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Mvc component\"\
+        ,\n      \"upstream_url\": \"https://zendframework.github.io/zend-mvc/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480514749.0,\n\
+        \      \"description\": \"zend-mvc-console provides integration between:\\\
+        n\\n* zend-console\\n* zend-mvc\\n* zend-router\\n* zend-view\\n\\nand replaces\
+        \ the console functionality found in the v2 releases of the latter\\nthree\
+        \ components.\\n\\n* File issues at https://github.com/zendframework/zend-mvc-console/issues\\\
+        n* Documentation is at https://zendframework.github.io/zend-mvc-console/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-mvc-console\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/1358143\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Zend Framework Mvc-Console component\"\
+        ,\n      \"upstream_url\": \"https://framework.zend.com/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1480343470.0,\n      \"description\"\
+        : \"zend-mvc-form is a metapackage that provides a single package for installing\\\
+        nall packages necessary to fully use zend-form under zend-mvc, including:\\\
+        n\\n* zendframework/zend-code\\n* zendframework/zend-form\\n* zendframework/zend-i18n\\\
+        n\\ni18n integration: this package only requires zend-i18n, and not zend-mvc-i18n.\\\
+        nThis is to allow providing the bare minimum required to use zend-form, as\
+        \ its\\nbase view helper extends from the base zend-i18n view helper. If you\
+        \ want to\\nprovide translations for your form elements, please install zend-mvc-i18n\
+        \ as\\nwell.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-zendframework-zend-mvc-form\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1358153\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Mvc-Form\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480343553.0,\n\
+        \      \"description\": \"zend-mvc-i18n provides integration between:\\n\\\
+        n* zend-i18n\\n* zend-mvc\\n* zend-router\\n\\nand replaces the i18n functionality\
+        \ found in the v2 releases of the latter\\ntwo components.\\n\\n* File issues\
+        \ at https://github.com/zendframework/zend-mvc-i18n/issues\\n* Documentation\
+        \ is at https://zendframework.github.io/zend-mvc-i18n/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-mvc-i18n\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1358155\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Mvc-I18n\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480514893.0,\n\
+        \      \"description\": \"Provides a Post-Redirect-Get controller plugin for\
+        \ zend-mvc versions 3.0\\nand up, specifically for submissions that include\
+        \ file uploads.\\n\\nIf you want a generic PRG plugin without file upload\
+        \ support, see zend-mvc-plugin-prg.\\n\\n* Issues at https://github.com/zendframework/zend-mvc-plugin-fileprg/issues\\\
+        n* Documentation is at https://zendframework.github.io/zend-mvc-plugin-fileprg/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-mvc-plugin-fileprg\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1358157\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Mvc-Plugin-FilePrg\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480514802.0,\n\
+        \      \"description\": \"Flash messages derive from Rails, and are used to\
+        \ expose messages from one\\naction to the next, after which they are cleared;\
+        \ a typical use case is with\\nPost/Redirect/Get, where they are created in\
+        \ the POST handler, and then\\ndisplayed by the GET handler to indicate success\
+        \ or failure to the end-user.\\n\\nThis component provides a flash messenger\
+        \ controller plugin for zend-mvc\\nversions 3.0 and up.\\n\\n* Issues at https://github.com/zendframework/zend-mvc-plugin-flashmessenger/issues\\\
+        n* Documentation is at https://zendframework.github.io/zend-mvc-plugin-flashmessenger/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-mvc-plugin-flashmessenger\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1358145\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Mvc-Plugin-FlashMessenger\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480514932.0,\n\
+        \      \"description\": \"Provides a zend-mvc plugin (for versions 3.0 and\
+        \ up) that allows retrieving\\nthe current identity as provided by zend-authentication.\\\
+        n\\n* Issues at https://github.com/zendframework/zend-mvc-plugin-identity/issues\\\
+        n* Documentation is at https://zendframework.github.io/zend-mvc-plugin-identity/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-mvc-plugin-identity\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1358162\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Mvc-Plugin-Identity\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480514999.0,\n\
+        \      \"description\": \"Provides a Post-Redirect-Get controller plugin for\
+        \ zend-mvc versions 3.0\\nand up.\\n\\n* Issues at https://github.com/zendframework/zend-mvc-plugin-prg/issues\\\
+        n* Documentation is at https://zendframework.github.io/zend-mvc-plugin-prg/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-mvc-plugin-prg\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1358163\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Zend Framework Mvc-Plugin-Prg\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480343666.0,\n\
+        \      \"description\": \"zend-mvc-plugins is a metapackage that provides\
+        \ a single package for\\ninstalling all official zend-mvc plugins shipped\
+        \ as separate packages\\nunder the zendframework organization. Currently,\
+        \ these include:\\n\\n* zendframework/zend-mvc-plugin-fileprg\\n* zendframework/zend-mvc-plugin-flashmessenger\\\
+        n* zendframework/zend-mvc-plugin-identity\\n* zendframework/zend-mvc-plugin-prg\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-mvc-plugins\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/1358164\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Zend Framework Mvc-Plugins component\"\
+        ,\n      \"upstream_url\": \"https://framework.zend.com/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1443663193.0,\n      \"description\"\
+        : \"Zend\\\\Navigation is a component for managing trees of pointers to web\
+        \ pages.\\nSimply put: It can be used for creating menus, breadcrumbs, links,\\\
+        nand sitemaps, or serve as a model for other navigation related purposes.\\\
+        n\\nDocumentation: https://zendframework.github.io/zend-navigation/\",\n \
+        \     \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-navigation\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Navigation\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663199.0,\n\
+        \      \"description\": \"Zend\\\\Paginator is a flexible component for paginating\\\
+        ncollections of data and presenting that data to users.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-paginator\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Paginator\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663207.0,\n\
+        \      \"description\": \"Provides a lightweight and flexible access control\
+        \ list (ACL)\\nimplementation for privileges management.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-permissions-acl\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Permissions-Acl\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663213.0,\n\
+        \      \"description\": \"Provides role-based access control (RBAC) permissions\
+        \ management.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-zendframework-zend-permissions-rbac\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Permissions/Rbac\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663226.0,\n\
+        \      \"description\": \"Zend\\\\ProgressBar is a component to create and\
+        \ update progress bars in\\ndifferent environments. It consists of a single\
+        \ backend, which outputs\\nthe progress through one of the multiple adapters.\
+        \ On every update, it\\ntakes an absolute value and optionally a status message,\
+        \ and then calls\\nthe adapter with some precalculated values like percentage\
+        \ and estimated\\ntime left.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": false,\n      \"name\": \"php-zendframework-zend-progressbar\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework ProgressBar\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1457712771.0,\n\
+        \      \"description\": \"Code for converting PSR-7 messages to zend-http\
+        \ messages, and vice versa.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": false,\n      \"name\": \"php-zendframework-zend-psr7bridge\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1313683\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Psr7Bridge\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1464624419.0,\n\
+        \      \"description\": \"zend-router provides flexible HTTP routing.\\n\\\
+        nRouting currently works against the zend-http request and responses,\\nand\
+        \ provides capabilities around:\\n\\n* Literal path matches\\n* Path segment\
+        \ matches (at path boundaries, and optionally validated\\n  using regex)\\\
+        n* Regular expression path matches\\n* HTTP request scheme\\n* HTTP request\
+        \ method\\n* Hostname\\n\\nAdditionally, it supports combinations of different\
+        \ route types in tree\\nstructures, allowing for fast, b-tree lookups.\\n\\\
+        nDocumentation: https://zendframework.github.io/zend-router/\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-router\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1328346\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Router\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663239.0,\n\
+        \      \"description\": \"The Zend\\\\Serializer component provides an adapter\
+        \ based interface\\nto simply generate storable representation of PHP types\
+        \ by different\\nfacilities, and recover.\\n\\nDocumentation: https://zendframework.github.io/zend-serializer/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-serializer\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Serializer\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663247.0,\n\
+        \      \"description\": \"The Zend\\\\Server family of classes provides functionality\
+        \ for the various\\nserver classes, including Zend\\\\XmlRpc\\\\Server and\
+        \ Zend\\\\Json\\\\Server.\\nZend\\\\Server\\\\Server provides an interface\
+        \ that mimics PHP 5\\u2019s SoapServer class;\\nall server classes should\
+        \ implement this interface in order to provide a\\nstandard server API.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-server\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Server\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663254.0,\n\
+        \      \"description\": \"The Service Locator design pattern is implemented\
+        \ by the Zend\\\\ServiceManager\\ncomponent. The Service Locator is a service/object\
+        \ locator, tasked with\\nretrieving other objects.\\n\\nDocumentation: https://zendframework.github.io/zend-servicemanager/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-servicemanager\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework ServiceManager\
+        \ component\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-servicemanager/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480514846.0,\n\
+        \      \"description\": \"Provides integration for zend-di within zend-servicemanager.\\\
+        n\\nDocumentation: https://zendframework.github.io/zend-servicemanager-di/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-servicemanager-di\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1358147\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Zend Framework ServiceManager-Di\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663259.0,\n\
+        \      \"description\": \"Zend\\\\Session is a component to manage PHP session\
+        \ using an object\\noriented interface.\\n\\nDocumentation: https://zendframework.github.io/zend-session/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-session\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Session\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663266.0,\n\
+        \      \"description\": \"Zend\\\\Soap is a component to manage the SOAP protocol\
+        \ in order\\nto design client or server PHP application.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-soap\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Soap\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663272.0,\n\
+        \      \"description\": \"Zend\\\\Stdlib is a set of components that implements\
+        \ general purpose utility\\nclass for different scopes like:\\n* array utilities\
+        \ functions;\\n* hydrators;\\n* json serializable interfaces;\\n* general\
+        \ messaging systems;\\n* string wrappers;\\n* etc.\\n\\nDocumentation: https://zendframework.github.io/zend-stdlib/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-stdlib\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Stdlib\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468942287.0,\n\
+        \      \"description\": \"From \\\"Strata\\\", Latin for \\\"layer\\\", and\
+        \ \\\"agility\\\".\\n\\nThis package supercedes and replaces phly/conduit.\\\
+        n\\nStratigility is a port of Sencha Connect to PHP.\\nIt allows you to create\
+        \ and dispatch middleware pipelines.\\n\\n* File issues at https://github.com/zendframework/zend-stratigility/issues\\\
+        n* Issue patches to https://github.com/zendframework/zend-stratigility/pulls\\\
+        n* Documentation is at https://zendframework.github.io/zend-stratigility/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-stratigility\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1352475\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Middleware for PHP\",\n    \
+        \  \"upstream_url\": \"https://zendframework.github.io/zend-stratigility/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663278.0,\n\
+        \      \"description\": \"Zend\\\\Tag is a component suite which provides\
+        \ a facility to work with\\ntaggable Items. As its base, it provides two classes\
+        \ to work with Tags,\\nZend\\\\Tag\\\\Item and Zend\\\\Tag\\\\ItemList. Additionally,\
+        \ it comes with the\\ninterface Zend\\\\Tag\\\\TaggableInterface, which allows\
+        \ you to use any of\\nyour models as a taggable item in conjunction with Zend\\\
+        \\Tag.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n \
+        \     \"name\": \"php-zendframework-zend-tag\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Tag\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663284.0,\n\
+        \      \"description\": \"The Zend\\\\Test component provides tools to facilitate\
+        \ unit testing of your\\nZend Framework applications. At this time, we offer\
+        \ facilities to enable\\ntesting of your Zend Framework MVC applications.\\\
+        n\\nPHPUnit is the only library supported currently.\\n\\nDocumentation: https://zendframework.github.io/zend-test/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-test\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Test\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663289.0,\n\
+        \      \"description\": \"Zend\\\\Text is a component to work on text strings.\\\
+        nIt contains the subcomponents:\\n\\n* Zend\\\\Text\\\\Figlet that enables\
+        \ developers to create a so called FIGlet text.\\n  A FIGlet text is a string,\
+        \ which is represented as ASCII art. FIGlets use a\\n  special font format,\
+        \ called FLT (FigLet Font). By default, one standard font\\n  is shipped with\
+        \ Zend\\\\Text\\\\Figlet, but you can download additional fonts here\\n\\\
+        n* Zend\\\\Text\\\\Table to create text based tables on the fly with different\\\
+        n  decorators. This can be helpful, if you either want to send structured\
+        \ data\\n  in text emails, which are used to have mono-spaced fonts, or to\
+        \ display table\\n  information in a CLI application. Zend\\\\Text\\\\Table\
+        \ supports multi-line columns,\\n  colspan and align as well.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-text\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Text\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663295.0,\n\
+        \      \"description\": \"Zend\\\\Uri is a component that aids in manipulating\
+        \ and validating Uniform\\nResource Identifiers (URIs). Zend\\\\Uri exists\
+        \ primarily to service other\\ncomponents, such as Zend\\\\Http, but is also\
+        \ useful as a standalone utility.\",\n      \"koschei_monitor\": true,\n \
+        \     \"monitor\": false,\n      \"name\": \"php-zendframework-zend-uri\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Uri\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663303.0,\n\
+        \      \"description\": \"The Zend\\\\Validator component provides a set of\
+        \ commonly needed validators.\\nIt also provides a simple validator chaining\
+        \ mechanism by which multiple\\nvalidators may be applied to a single datum\
+        \ in a user-defined order.\\n\\nDocumentation: https://zendframework.github.io/zend-validator/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-validator\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Validator\
+        \ component\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-validator/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663309.0,\n\
+        \      \"description\": \"Zend\\\\Version provides a class constant Zend\\\
+        \\Version\\\\Version::VERSION\\nthat contains a string identifying the version\
+        \ number of your Zend\\nFramework installation. Zend\\\\Version\\\\Version::VERSION\
+        \ might contain \\u201c2.4.1\\u201d,\\nfor example.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-version\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework Version\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663316.0,\n\
+        \      \"description\": \"Zend\\\\View provides the \\u201cView\\u201d layer\
+        \ of Zend Framework 2\\u2019s MVC system.\\nIt is a multi-tiered system allowing\
+        \ a variety of mechanisms for extension,\\nsubstitution, and more.\\n\\nDocumentation:\
+        \ https://zendframework.github.io/zend-view/\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zend-view\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework View\
+        \ component\",\n      \"upstream_url\": \"https://zendframework.github.io/zend-view/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480343708.0,\n\
+        \      \"description\": \"zend-xml2json provides functionality for converting\
+        \ XML structures to JSON.\\n\\n* File issues at https://github.com/zendframework/zend-xml2json/issues\\\
+        n* Documentation is at https://zendframework.github.io/zend-xml2json/\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-xml2json\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/1358165\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Provides functionality for converting\
+        \ XML to JSON\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663329.0,\n\
+        \      \"description\": \"From its home page, XML-RPC is described as a \\\
+        u201d...remote procedure calling\\nusing HTTP as the transport and XML as\
+        \ the encoding. XML-RPC is designed\\nto be as simple as possible, while allowing\
+        \ complex data structures to be\\ntransmitted, processed and returned.\\u201d\\\
+        n\\nZend\\\\XmlRpc provides support for both consuming remote XML-RPC services\
+        \ and\\nbuilding new XML-RPC servers.\\n\\nDocumentation: https://zendframework.github.io/zend-xmlrpc/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"php-zendframework-zend-xmlrpc\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework XmlRpc\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1440365791.0,\n\
+        \      \"description\": \"Zend Framework ZendPdf component.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zendpdf\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1251034\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework ZendPdf\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1488384648.0,\n\
+        \      \"description\": \"Zend Framework ReCaptcha component.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"php-zendframework-zendservice-recaptcha\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1425073\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework ReCaptcha\
+        \ component\",\n      \"upstream_url\": \"https://framework.zend.com/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1443663324.0,\n\
+        \      \"description\": \"An utility component for XML usage and best practices\
+        \ in PHP.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-zendframework-zendxml\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1266336\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zend Framework ZendXml\
+        \ component\",\n      \"upstream_url\": \"http://framework.zend.com/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1435593580.0,\n\
+        \      \"description\": \"This is the base package of the Zeta components,\
+        \ offering the basic\\nsupport that all Components need. In the first version\
+        \ this will be the\\nautoload support.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"php-zetacomponents-base\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1228089\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zeta Base Component\"\
+        ,\n      \"upstream_url\": \"http://zetacomponents.org/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1437020374.0,\n      \"description\"\
+        : \"A set of classes to do different actions with the console, also called\
+        \ shell.\\nIt can render a progress bar, tables and a status bar and contains\
+        \ a class for\\nparsing command line options.\\n\\nDocumentation is available\
+        \ in the php-zetacomponents-console-tools-doc package.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"php-zetacomponents-console-tools\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1228091\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Zeta ConsoleTools\
+        \ Component\",\n      \"upstream_url\": \"http://zetacomponents.org/\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1437020333.0,\n\
+        \      \"description\": \"A component for creating pie charts, line graphs\
+        \ and other kinds of diagrams.\\n\\nDocumentation is available in the php-zetacomponents-graph-doc\
+        \ package.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"php-zetacomponents-graph\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1228090\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Zeta Graph Component\",\n  \
+        \    \"upstream_url\": \"http://zetacomponents.org/\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1434981843.0,\n      \"description\"\
+        : \"UnitTest is an internal component which extends PhpUnit to facilitate\
+        \ test\\nrunning and reports of the components themselves.\\n\\nFor this reason,\
+        \ there is no tutorial for this component. If you really want\\nto use it\
+        \ for some reason it's sane to expect some community support on IRC or\\nthe\
+        \ mailing list.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"php-zetacomponents-unit-test\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1228087\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Zeta UnitTest Component\"\
+        ,\n      \"upstream_url\": \"http://zetacomponents.org/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1432298966.0,\n      \"description\"\
+        : \"Implementation of RFC 3454 Preparation of Internationalized Strings.\\\
+        n\\nSee: http://tools.ietf.org/html/rfc3454\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"php-znerol-php-stringprep\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1222794\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Implementation of\
+        \ RFC 3454 Preparation of Internationalized Strings\",\n      \"upstream_url\"\
+        : \"https://github.com/znerol/Stringprep\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"SimplePie\
+        \ is a very fast and easy-to-use class, written in PHP, that puts the\\n'simple'\
+        \ back into 'really simple syndication'. Flexible enough to suit\\nbeginners\
+        \ and veterans alike, SimplePie is focused on speed, ease of use,\\ncompatibility\
+        \ and standards compliance.\",\n      \"koschei_monitor\": false,\n      \"\
+        monitor\": false,\n      \"name\": \"php53-simplepie\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Simple RSS Library in PHP\",\n      \"upstream_url\"\
+        : \"http://simplepie.org/\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1489409124.0,\n      \"description\": \"PHPUnit is a programmer-oriented\
+        \ testing framework for PHP.\\nIt is an instance of the xUnit architecture\
+        \ for unit testing frameworks.\",\n      \"koschei_monitor\": true,\n    \
+        \  \"monitor\": false,\n      \"name\": \"phpunit6\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1420381\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"The PHP Unit Testing\
+        \ framework\",\n      \"upstream_url\": \"https://github.com/sebastianbergmann/phpunit\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"QElectroTech is a Qt application to design electric\
+        \ diagrams. It uses XML\\nfiles for elements and diagrams, and includes both\
+        \ a diagram editor and an\\nelement editor.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"qelectrotech\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An electric diagrams editor\",\n   \
+        \   \"upstream_url\": \"http://qelectrotech.org/\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"RoundCube Webmail is a browser-based multilingual IMAP client\\nwith an\
+        \ application-like user interface. It provides full\\nfunctionality you expect\
+        \ from an e-mail client, including MIME\\nsupport, address book, folder manipulation,\
+        \ message searching\\nand spell checking. RoundCube Webmail is written in\
+        \ PHP and\\nrequires a database: MySQL, PostgreSQL and SQLite are known to\\\
+        nwork. The user interface is fully skinnable using XHTML and\\nCSS 2.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"roundcubemail\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Round Cube\
+        \ Webmail is a browser-based multilingual IMAP client\",\n      \"upstream_url\"\
+        : \"http://www.roundcube.net\"\n    },\n    {\n      \"acls\": [],\n     \
+        \ \"creation_date\": 1400070978.0,\n      \"description\": \"ssdeep is a program\
+        \ for computing context triggered piecewise hashes (CTPH).\\nAlso called fuzzy\
+        \ hashes, CTPH can match inputs that have homologies.\\nSuch inputs have sequences\
+        \ of identical bytes in the same order, although bytes\\nin between these\
+        \ sequences may be different in both content and length.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"ssdeep\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Compute context triggered piecewise hashes\"\
+        ,\n      \"upstream_url\": \"http://ssdeep.sourceforge.net/\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"Wordpress is an online publishing / weblog package that makes\
+        \ it very easy,\\nalmost trivial, to get information out to people on the\
+        \ web.\\n\\nImportant information in /usr/share/doc/wordpress/README.fedora\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"wordpress\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Blog tool and publishing\
+        \ platform\",\n      \"upstream_url\": \"http://www.wordpress.org\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Extract headers from rpm in a old yum repository.\\\
+        n\\nThis package only provides the old yum-arch command from yum-2.2.2\\nIt\
+        \ should be used to generate repository informations for Fedora Core  < 3\\\
+        nand RedHat Enterprise Linux < 4.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"yum-arch\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Extract headers from rpm in a old yum repository\",\n\
+        \      \"upstream_url\": \"http://linux.duke.edu/yum/\"\n    }\n  ],\n  \"\
+        watch\": [\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Mozilla Firefox is an open-source web browser, designed\
+        \ for standards\\ncompliance, performance and portability.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"firefox\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Mozilla Firefox Web browser\",\n      \"\
+        upstream_url\": \"https://www.mozilla.org/firefox/\"\n    },\n    {\n    \
+        \  \"acls\": [],\n      \"creation_date\": 1455282328.0,\n      \"description\"\
+        : \"This is a library providing useful routines related to building, parsing,\\\
+        nand iterating BSON documents <http://bsonspec.org/>.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": \"nobuild\",\n      \"name\": \"libbson\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1208101\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Building, parsing,\
+        \ and iterating BSON documents\",\n      \"upstream_url\": \"https://github.com/mongodb/libbson\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PHP language bindings for Libvirt API.\\nFor more\
+        \ details see: http://www.libvirt.org/php/\",\n      \"koschei_monitor\":\
+        \ true,\n      \"monitor\": false,\n      \"name\": \"php-libvirt\",\n   \
+        \   \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"PHP language bindings for Libvirt\"\
+        ,\n      \"upstream_url\": \"http://libvirt.org/php\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"imagick is a native php extension to create and modify images using the\\\
+        nImageMagick API.\\nThis extension requires ImageMagick version 6.2.4+ and\
+        \ PHP 5.1.3+.\\n\\nIMPORTANT: Version 2.x API is not compatible with earlier\
+        \ versions.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"php-pecl-imagick\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Provides a wrapper to the ImageMagick library\",\n      \"upstream_url\"\
+        : \"http://pecl.php.net/package/imagick\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Mozilla\
+        \ Thunderbird is a standalone mail and newsgroup client.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"thunderbird\",\n   \
+        \   \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Mozilla Thunderbird mail/newsgroup client\"\
+        ,\n      \"upstream_url\": \"http://www.mozilla.org/projects/thunderbird/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"XULRunner is a Mozilla runtime package that can\
+        \ be used to bootstrap XUL+XPCOM\\napplications that are as rich as Firefox\
+        \ and Thunderbird. It provides mechanisms\\nfor installing, upgrading, and\
+        \ uninstalling these applications. XULRunner also\\nprovides libxul, a solution\
+        \ which allows the embedding of Mozilla technologies\\nin other projects and\
+        \ products.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"xulrunner\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        XUL Runtime for Gecko Applications\",\n      \"upstream_url\": \"http://developer.mozilla.org/En/XULRunner\"\
+        \n    }\n  ]\n}"}
+    headers:
+      accept-ranges: [bytes]
+      age: ['0']
+      appserver: [proxy10.phx2.fedoraproject.org]
+      apptime: [D=3245340]
+      connection: [Keep-Alive]
+      content-length: ['374708']
+      content-type: [application/json]
+      date: ['Wed, 29 Mar 2017 20:40:01 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['pkgdb=eyJfcGVybWFuZW50Ijp0cnVlfQ.C72tJA.eWDYdehFal8EhbKepznguXIQ0U0;
+          Expires=Wed, 29-Mar-2017 21:40:04 GMT; Secure; HttpOnly; Path=/pkgdb/']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['6737093']
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_generic.UserPackageFilterTests.test_matching_packages
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_generic.UserPackageFilterTests.test_matching_packages
@@ -1,0 +1,1459 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.12.5]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/packager/package/besser82
+  response:
+    body: {string: !!python/unicode "{\n  \"co-maintained\": [\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"LuxRender\
+        \ is a rendering system for physically correct image synthesis.\",\n     \
+        \ \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\":\
+        \ \"LuxRender\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Lux Renderer, an unbiased\
+        \ rendering system\",\n      \"upstream_url\": \"http://www.luxrender.net\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"SuperLU contains a set of subroutines to solve a\
+        \ sparse linear system\\nA*X=B. It uses Gaussian elimination with partial\
+        \ pivoting (GEPP).\\nThe columns of A may be preordered before factorization;\
+        \ the\\npreordering for sparsity is completely separate from the factorization.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"SuperLU\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Subroutines to solve\
+        \ sparse linear systems\",\n      \"upstream_url\": \"http://crd-legacy.lbl.gov/~xiaoye/SuperLU/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"ARPACK is a collection of Fortran 77 subroutines\
+        \ designed to solve large\\nscale eigenvalue problems.\\n\\nThe package is\
+        \ designed to compute a few eigenvalues and corresponding\\neigenvectors of\
+        \ a general n by n matrix A. It is most appropriate for\\nlarge sparse or\
+        \ structured matrices A where structured means that a\\nmatrix-vector product\
+        \ w <- Av requires order n rather than the usual\\norder n**2 floating point\
+        \ operations. This software is based upon an\\nalgorithmic variant of the\
+        \ Arnoldi process called the Implicitly\\nRestarted Arnoldi Method (IRAM).\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": \"nobuild\",\n   \
+        \   \"name\": \"arpack\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Fortran 77\
+        \ subroutines for solving large scale eigenvalue problems\",\n      \"upstream_url\"\
+        : \"https://github.com/opencollab/arpack-ng\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Cinnamon\
+        \ is a Linux desktop which provides advanced\\ninnovative features and a traditional\
+        \ user experience.\\n\\nThe desktop layout is similar to Gnome 2.\\nThe underlying\
+        \ technology is forked from Gnome Shell.\\nThe emphasis is put on making users\
+        \ feel at home and providing\\nthem with an easy to use and comfortable desktop\
+        \ experience.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"cinnamon\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Window management\
+        \ and application launching for GNOME\",\n      \"upstream_url\": \"http://cinnamon.linuxmint.com\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package contains configuration utilities for\
+        \ the Cinnamon desktop, which\\nallow to configure accessibility options,\
+        \ desktop fonts, keyboard and mouse\\nproperties, sound setup, desktop theme\
+        \ and background, user interface\\nproperties, screen resolution, and other\
+        \ settings.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"cinnamon-control-center\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Utilities to configure the Cinnamon desktop\",\n      \"upstream_url\"\
+        : \"http://cinnamon.linuxmint.com\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"The cinnamon-desktop\
+        \ package contains an internal library\\n(libcinnamondesktop) used to implement\
+        \ some portions of the CINNAMON\\ndesktop, and also some data files and other\
+        \ shared components of the\\nCINNAMON user environment.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"cinnamon-desktop\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Shared code among cinnamon-session,\
+        \ nemo, etc\",\n      \"upstream_url\": \"http://cinnamon.linuxmint.com\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"cinnamon-menus is an implementation of the draft\
+        \ \\\"Desktop\\nMenu Specification\\\" from freedesktop.org. This package\\\
+        nalso contains the Cinnamon menu layout configuration files,\\n.directory\
+        \ files and assorted menu related utility programs,\\nPython bindings, and\
+        \ a simple menu editor.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"cinnamon-menus\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"A menu system for the Cinnamon project\",\n      \"upstream_url\"\
+        : \"http://cinnamon.linuxmint.com\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"cinnamon-screensaver\
+        \ is a screen saver and locker.\",\n      \"koschei_monitor\": false,\n  \
+        \    \"monitor\": false,\n      \"name\": \"cinnamon-screensaver\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Cinnamon Screensaver\",\n      \"upstream_url\"\
+        : \"http://cinnamon.linuxmint.com\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"Cinnamon-session\
+        \ manages a Cinnamon desktop or GDM login session. It starts up\\nthe other\
+        \ core components and handles logout and saving the session.\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\": \"cinnamon-session\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Cinnamon session manager\",\n      \"\
+        upstream_url\": \"http://cinnamon.linuxmint.com\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"A daemon to share settings from CINNAMON to other applications. It also\\\
+        nhandles global keybindings, and many of desktop-wide settings.\",\n     \
+        \ \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\":\
+        \ \"cinnamon-settings-daemon\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        The daemon sharing settings from CINNAMON to GTK+/KDE applications\",\n  \
+        \    \"upstream_url\": \"http://cinnamon.linuxmint.com\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Translations for Cinnamon, Nemo and Mintlocale\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"cinnamon-translations\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Translations for Cinnamon and Nemo\"\
+        ,\n      \"upstream_url\": \"http://cinnamon.linuxmint.com\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"CMake is used to control the software compilation process\
+        \ using simple\\nplatform and compiler independent configuration files. CMake\
+        \ generates\\nnative makefiles and workspaces that can be used in the compiler\\\
+        nenvironment of your choice. CMake is quite sophisticated: it is possible\\\
+        nto support complex environments requiring system configuration, preprocessor\\\
+        ngeneration, code generation, and template instantiation.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"cmake\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Cross-platform make system\",\n      \"upstream_url\"\
+        : \"http://www.cmake.org\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\"\
+        : 1400070978.0,\n      \"description\": \"CMake is used to control the software\
+        \ compilation process using simple\\nplatform and compiler independent configuration\
+        \ files. CMake generates\\nnative makefiles and workspaces that can be used\
+        \ in the compiler\\nenvironment of your choice. CMake is quite sophisticated:\
+        \ it is possible\\nto support complex environments requiring system configuration,\
+        \ preprocessor\\ngeneration, code generation, and template instantiation.\\\
+        n\\nThis package is for compatibility purposes only, and links to cmake as\\\
+        ndistributed by EL-6.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"cmake28\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Cross-platform make system\",\n      \"upstream_url\": \"http://www.cmake.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1413547076.0,\n\
+        \      \"description\": \"Dbus daemon for performing package actions with\
+        \ the dnf package manager\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"dnfdaemon\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/1149390\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"DBus daemon for dnf package\
+        \ actions\",\n      \"upstream_url\": \"https://github.com/timlau/dnf-daemon\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"FDUPES is a program for identifying duplicate files\
+        \ residing within specified\\ndirectories.\",\n      \"koschei_monitor\":\
+        \ false,\n      \"monitor\": true,\n      \"name\": \"fdupes\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Finds duplicate files in a given set of\
+        \ directories\",\n      \"upstream_url\": \"https://github.com/adrianlopezroche/fdupes\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A multi-threaded file watch utility. It can monitor\
+        \ files for changes in\\ncontent or modification times. If it notices a change,\
+        \ it will kick off a\\nuser-defined script.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"fido\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Multi-threaded file watch utility\",\n      \"upstream_url\"\
+        : \"http://www.joedog.org/fido-home/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"Git is a\
+        \ fast, scalable, distributed revision control system with an\\nunusually\
+        \ rich command set that provides both high-level operations\\nand full access\
+        \ to internals.\\n\\nThe git rpm installs common set of tools which are usually\
+        \ using with\\nsmall amount of dependencies. To install all git packages,\
+        \ including\\ntools for integrating with other SCMs, install the git-all meta-package.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"git\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Fast Version Control\
+        \ System\",\n      \"upstream_url\": \"https://git-scm.com/\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"HtmlCleaner is open-source HTML parser written in Java. HTML\
+        \ found on Web is\\nusually dirty, ill-formed and unsuitable for further processing.\\\
+        nFor any serious consumption of such documents, it is necessary to first\\\
+        nclean up the mess and bring the order to tags, attributes and ordinary text.\\\
+        nFor the given HTML document, HtmlCleaner reorders individual elements and\\\
+        nproduces well-formed XML. By default, it follows similar rules that the most\\\
+        nof web browsers use in order to create Document Object Model. However, user\\\
+        nmay provide custom tag and rule set for tag filtering and balancing.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"htmlcleaner\",\n      \"namespace\": \"rpms\",\n      \"review_url\":\
+        \ null,\n      \"status\": \"Approved\",\n      \"summary\": \"HTML parser\
+        \ written in Java\",\n      \"upstream_url\": \"http://htmlcleaner.sourceforge.net/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Icecast is a streaming media server which currently\
+        \ supports\\nOgg Vorbis and MP3 audio streams.  It can be used to create an\\\
+        nInternet radio station or a privately running jukebox and many\\nthings in\
+        \ between.  It is very versatile in that new formats\\ncan be added relatively\
+        \ easily and supports open standards for\\ncommunication and interaction.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"icecast\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"ShoutCast compatible\
+        \ streaming media server\",\n      \"upstream_url\": \"http://www.icecast.org/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"jsoncpp is an implementation of a JSON (http://json.org)\
+        \ reader and writer in\\nC++. JSON (JavaScript Object Notation) is a lightweight\
+        \ data-interchange format.\\nIt is easy for humans to read and write. It is\
+        \ easy for machines to parse and\\ngenerate.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": \"nobuild\",\n      \"name\": \"jsoncpp\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"JSON library implemented in C++\",\n\
+        \      \"upstream_url\": \"https://github.com/open-source-parsers/jsoncpp\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"libjoedog is a library containing the common code\
+        \ base of siege and fido by Jeff\\nFulmer. It consists mostly of convenience\
+        \ wrapper functions and a hash table\\nimplementation.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"libjoedog\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Repack of the common code base of fido\
+        \ and siege as shared library\",\n      \"upstream_url\": \"http://www.joedog.org/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"LIBSVM is an integrated software for support vector\
+        \ classification,\\n(C-SVC, nu-SVC ), regression (epsilon-SVR, nu-SVR) and\
+        \ distribution\\nestimation (one-class SVM ). It supports multi-class classification.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"libsvm\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A Library for\
+        \ Support Vector Machines\",\n      \"upstream_url\": \"http://www.csie.ntu.edu.tw/~cjlin/libsvm/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"OpenCL ICD Bindings.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"ocl-icd\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"OpenCL ICD Bindings\",\n      \"upstream_url\"\
+        : \"https://forge.imag.fr/projects/ocl-icd/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ package provides some directories required by packages which use OpenCL.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"opencl-filesystem\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"OpenCL filesystem\
+        \ layout\",\n      \"upstream_url\": \"http://www.khronos.org/registry/cl/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"pngquant converts 24/32-bit RGBA PNG images to 8-bit\
+        \ palette with alpha channel\\npreserved.  Such images are compatible with\
+        \ all modern web browsers and a\\ncompatibility setting is available to help\
+        \ transparency degrade well in\\nInternet Explorer 6.  Quantized files are\
+        \ often 40-70 percent smaller than\\ntheir 24/32-bit version. pngquant uses\
+        \ the median cut algorithm.\",\n      \"koschei_monitor\": false,\n      \"\
+        monitor\": true,\n      \"name\": \"pngquant\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"PNG quantization tool for reducing image file size\",\n     \
+        \ \"upstream_url\": \"http://pngquant.org\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Pocl's\
+        \ goal is to become an efficient open source (MIT-licensed) implementation\\\
+        nof the OpenCL 1.2 (and soon OpenCL 2.0) standard.\\n\\nIn addition to producing\
+        \ an easily portable open-source OpenCL implementation,\\nanother major goal\
+        \ of this project is improving performance portability of\\nOpenCL programs\
+        \ with compiler optimizations, reducing the need for\\ntarget-dependent manual\
+        \ optimizations.\\n\\nAt the core of pocl is the kernel compiler that consists\
+        \ of a set of LLVM\\npasses used to statically transform kernels into work-group\
+        \ functions with\\nmultiple work-items, even in the presence of work-group\
+        \ barriers. These\\nfunctions are suitable for parallelization in multiple\
+        \ ways (SIMD, VLIW,\\nsuperscalar,...).\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"pocl\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Portable Computing Language - an OpenCL implementation\"\
+        ,\n      \"upstream_url\": \"http://pocl.sourceforge.net\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"The Atomic Simulation Environment (ASE) is the common part of the simulation\\\
+        ntools developed at CAMd. ASE provides Python modules for manipulating atoms,\\\
+        nanalyzing simulations, visualization etc.\",\n      \"koschei_monitor\":\
+        \ false,\n      \"monitor\": true,\n      \"name\": \"python-ase\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Atomic Simulation Environment\",\n \
+        \     \"upstream_url\": \"https://wiki.fysik.dtu.dk/ase/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Behavior-driven development (or BDD) is an agile software development\\\
+        ntechnique that encourages collaboration between developers, QA and non-\\\
+        ntechnical or business participants in a software project.\\n\\nbehave uses\
+        \ tests written in a natural language style, backed up\\nby Python code.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-behave\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Tools for the\
+        \ behavior-driven development, Python style\",\n      \"upstream_url\": \"\
+        http://pypi.python.org/pypi/behave\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1421329015.0,\n      \"description\": \"Django-Angular\
+        \ is a collection of utilities, which aim to ease the\\nintegration of Django\
+        \ with AngularJS by providing reusable components.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-django-angular\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1182533\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Classes and utility\
+        \ functions to integrate AngularJS with Django\",\n      \"upstream_url\"\
+        : \"https://github.com/jrief/django-angular\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"\\\
+        nJoblib is a set of tools to provide lightweight pipelining in Python.\\nIn\
+        \ particular, joblib offers:\\n * transparent disk-caching of the output values\
+        \ and lazy\\n   re-evaluation (memorize pattern)\\n * easy simple parallel\
+        \ computing\\n * logging and tracing of the execution\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-joblib\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Lightweight pipelining: using Python\
+        \ functions as pipeline jobs\",\n      \"upstream_url\": \"https://pythonhosted.org/joblib/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"\\nScikit-learn integrates machine learning algorithms\
+        \ in the tightly-knit\\nscientific Python world, building upon numpy, scipy,\
+        \ and matplotlib.\\nAs a machine-learning module, it provides versatile tools\
+        \ for data mining\\nand analysis in any field of science and engineering.\
+        \ It strives to be\\nsimple and efficient, accessible to everybody, and reusable\\\
+        nin various contexts.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"python-scikit-learn\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n  \
+        \    \"summary\": \"Machine learning in Python\",\n      \"upstream_url\"\
+        : \"http://scikit-learn.org/\"\n    },\n    {\n      \"acls\": [],\n     \
+        \ \"creation_date\": 1485954885.0,\n      \"description\": \"\\nThis sphinx\
+        \ theme integrates the Booststrap CSS / Javascript framework\\nwith various\
+        \ layout options, hierarchical menu navigation, and mobile-friendly\\nresponsive\
+        \ design.  It is configurable, extensible and can use any number\\nof different\
+        \ Bootswatch CSS themes.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-sphinx-bootstrap-theme\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1268380\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A sphinx theme that\
+        \ integrates the Bootstrap framework\",\n      \"upstream_url\": \"http://ryan-roemer.github.com/sphinx-bootstrap-theme\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1401710054.0,\n\
+        \      \"description\": \"Ratools is a fast, dynamic, multi-threading framework\
+        \ for creating, modifying\\nand sending IPv6 Router Advertisements (RA).\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"ratools\",\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1100899\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Framework for IPv6\
+        \ Router Advertisements\",\n      \"upstream_url\": \"https://www.nonattached.net/ratools\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Bundler manages an application's dependencies through\
+        \ its entire life, across\\nmany machines, systematically and repeatably.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"rubygem-bundler\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Library and\
+        \ utilities to manage a Ruby application's gem dependencies\",\n      \"upstream_url\"\
+        : \"http://bundler.io\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\"\
+        : 1400070978.0,\n      \"description\": \"Thor is a toolkit for building powerful\
+        \ command-line interfaces.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": true,\n      \"name\": \"rubygem-thor\",\n      \"namespace\":\
+        \ \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Thor is a toolkit for building powerful command-line\
+        \ interfaces\",\n      \"upstream_url\": \"http://whatisthor.com/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Siege is an HTTP regression testing and benchmarking\
+        \ utility.\\nIt was designed to let web developers measure the performance\
+        \ of their code\\nunder duress, to see how it will stand up to load on the\
+        \ internet.\\nSiege supports basic authentication, cookies, HTTP and HTTPS\
+        \ protocols.\\nIt allows the user hit a web server with a configurable number\
+        \ of concurrent\\nsimulated users. Those users place the web-server \\\"under\
+        \ siege.\\\"\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"siege\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A HTTP regression\
+        \ testing and benchmarking utility\",\n      \"upstream_url\": \"http://www.joedog.org/JoeDog/Siege\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1411251082.0,\n\
+        \      \"description\": \"Command line interface for testing internet bandwidth\
+        \ using speedtest.net\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"speedtest-cli\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1119369\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Command line interface for testing\
+        \ internet bandwidth\",\n      \"upstream_url\": \"https://github.com/sivel/speedtest-cli\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Simplified Wrapper and Interface Generator (SWIG)\
+        \ is a software\\ndevelopment tool for connecting C, C++ and Objective C programs\
+        \ with a\\nvariety of high-level programming languages.  SWIG is primarily\
+        \ used\\nwith Perl, Python and Tcl/TK, but it has also been extended to Java,\\\
+        nEiffel and Guile. SWIG is normally used to create high-level\\ninterpreted\
+        \ programming environments, systems integration, and as a\\ntool for building\
+        \ user interfaces\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : \"nobuild\",\n      \"name\": \"swig\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Connects C/C++/Objective C to some high-level programming languages\"\
+        ,\n      \"upstream_url\": \"http://swig.sourceforge.net/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Wine as a compatibility layer for UNIX to run Windows applications. This\\\
+        npackage includes a program loader, which allows unmodified Windows\\n3.x/9x/NT\
+        \ binaries to run on x86 and x86_64 Unixes. Wine can use native system\\n.dll\
+        \ files if they are available.\\n\\nIn Fedora wine is a meta-package which\
+        \ will install everything needed for wine\\nto work smoothly. Smaller setups\
+        \ can be achieved by installing some of the\\nwine-* sub packages.\",\n  \
+        \    \"koschei_monitor\": false,\n      \"monitor\": \"nobuild\",\n      \"\
+        name\": \"wine\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"A compatibility layer\
+        \ for windows applications\",\n      \"upstream_url\": \"http://www.winehq.org/\"\
+        \n    }\n  ],\n  \"output\": \"ok\",\n  \"point of contact\": [\n    {\n \
+        \     \"acls\": [],\n      \"creation_date\": 1417698223.0,\n      \"description\"\
+        : \"A cli version of the game 2048 for your Linux terminal.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"2048-cli\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1170231\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"The game 2048 for\
+        \ your Linux terminal\",\n      \"upstream_url\": \"https://github.com/Tiehuis/2048-cli\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"ColPack is a package comprising of implementation\
+        \ of algorithms for\\nspecialized vertex coloring problems that arise in sparse\
+        \ derivative\\ncomputation. It is written in an object-oriented fashion heavily\
+        \ using\\nthe Standard Template Library (STL).  It is designed to be simple,\\\
+        nmodular, extendable and efficient.\\n\\nThis build has openMP-support enabled.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"ColPack\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Algorithms for specialized\
+        \ vertex coloring problems\",\n      \"upstream_url\": \"http://cscapes.cs.purdue.edu\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1435594614.0,\n\
+        \      \"description\": \"This browser plugin has the same methods and properties\
+        \ as the\\nofficial Garmin Communicator Plugin.  It can be used to transfer\\\
+        nGPX files (Geocache Descriptions) to your garmin device using\\nthe official\
+        \ Garmin Javascript API.  Its functionality depends\\non the device you use:\\\
+        n  * Edge305/Forerunner305: ReadFitnessData, ReadGpsData, No write support\\\
+        n  * Edge705/Oregon/Dakota: ReadFitnessData, ReadGpsData, Write Gpx files\\\
+        n  * Edge800: ReadFitnessData, Write Gpx/Tcx Files\\n  * Other devices: Executes\
+        \ external command to write Gpx to device\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"GarminPlugin\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1236300\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Garmin Communicator\
+        \ Plugin port for Linux\",\n      \"upstream_url\": \"http://www.andreas-diesner.de/garminplugin\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"NLopt is a library for nonlinear local and global\
+        \ optimization, for\\nfunctions with and without gradient information.  It\
+        \ is designed as\\nas simple, unified interface and packaging of several free/open-source\\\
+        nnonlinear optimization libraries.\\n\\nIt features bindings for GNU Guile,\
+        \ Octave and Python.  This build has\\nbeen made with C++-support enabled.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"NLopt\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Open-Source library\
+        \ for nonlinear optimization\",\n      \"upstream_url\": \"http://ab-initio.mit.edu/nlopt\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"SuperLU contains a set of subroutines to solve a\
+        \ sparse linear system\\nA*X=B. It uses Gaussian elimination with partial\
+        \ pivoting (GEPP).\\nThe columns of A may be preordered before factorization;\
+        \ the\\npreordering for sparsity is completely separate from the factorization.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"SuperLU\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Subroutines to solve\
+        \ sparse linear systems\",\n      \"upstream_url\": \"http://crd-legacy.lbl.gov/~xiaoye/SuperLU/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1424204993.0,\n\
+        \      \"description\": \"This is a different, Qt5-compatible approach of\
+        \ the existing appmenu-qt\\n(https://launchpad.net/appmenu-qt).\\n\\nappmenu-qt5\
+        \ is a Qt5 QPA theme plugin that adds support for application\\nmenus to Qt5\
+        \ applications.  This only works for Qt5 versions >= 5.2\\ncurrently.  To\
+        \ enable the support, set QT_QPA_PLATFORMTHEME=appmenu-qt5\\nin your environment\
+        \ or install the appmenu-qt5-profile.d package to\\nenable system-wide, see\
+        \ README.fedora *BEFORE* for further information.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"appmenu-qt5\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1185002\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Support for global\
+        \ DBus-exported application menu in Qt5\",\n      \"upstream_url\": \"https://launchpad.net/appmenu-qt5\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484059095.0,\n\
+        \      \"description\": \"\\nArc is a flat theme with transparent elements\
+        \ for GTK 3, GTK 2 and\\nGnome-Shell which supports GTK 3 and GTK 2 based\
+        \ desktop environments\\nlike Gnome, Cinnamon, Budgie, Pantheon, XFCE, Mate,\
+        \ etc.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n  \
+        \    \"name\": \"arc-theme\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1411438\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Flat theme with transparent elements\",\n      \"\
+        upstream_url\": \"https://github.com/horst3180/arc-theme\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"ARPREC is a software package for performing arbitrary precision\\narithmetic.\
+        \  It consists of a revision and extension of Bailey's\\nearlier MPFUN package,\
+        \ enhanced with special IEEE numerical\\ntechniques.  Features include:\\\
+        n\\n  * Written in C++ for broad portability and fast execution.\\n\\n  *\
+        \ Includes C++ and Fortran 90/95 interfaces based on custom data-types\\n\
+        \    and operator/function overloading, which permit the library to be\\n\
+        \    used with only minor modifications for many conventional C++ and\\n \
+        \   Fortran-90 programs.\\n\\n  * Includes all of the usual arithmetic operations,\
+        \ as well as many\\n    transcendental functions, including cos, sin, tan,\
+        \ arccos, arcsin,\\n    arctan, exp, log, log10, erf, gamma and Bessel functions.\\\
+        n\\n  * Supports three arbitrary precision data-types: mp_real, mp_int\\n\
+        \    and mp_complex.\\n\\n  * Supports many mixed-mode operations between\
+        \ arbitrary precision\\n    variables or constants and conventional variables\
+        \ or constants.\\n\\n  * Includes special library routines, incorporating\
+        \ advanced\\n    algorithms for extra-high precision (above 1000 digits) computation.\\\
+        n\\n  * Includes a number of sample application programs, including programs\\\
+        n    for quadrature (numerical definite integrals), PLSQ (integer relation\\\
+        n    finding) and polynomial root finding.\\n\\n  * Includes the \\\"Experimental\
+        \ Mathematician's Toolkit\\\".  This is a\\n    self-contained interactive\
+        \ program that performs many operations\\n    typical of modern experimental\
+        \ mathematics, including arithmetic\\n    expressions, common transcendental\
+        \ functions, infinite series\\n    evaluation, definite integrals, polynomial\
+        \ roots, user-defined\\n    functions, all evaluated to a user-defined level\
+        \ of numeric\\n    precision, up to 1000 decimal digits.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"arprec\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Software package for performing arbitrary\
+        \ precision arithmetic\",\n      \"upstream_url\": \"http://crd.lbl.gov/~dhbailey/mpdist\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483655017.0,\n\
+        \      \"description\": \"Bluetooth configuration tool depending on gnome-bluetooth.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"blueberry\",\n      \"namespace\": \"rpms\",\n      \"review_url\": \"\
+        https://bugzilla.redhat.com/1409404\",\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Bluetooth configuration tool\",\n      \"upstream_url\"\
+        : \"https://github.com/linuxmint/blueberry\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1487684706.0,\n      \"description\": \"This\
+        \ was a GSoC'10 project to implement a new command line tools for\\nbluez\
+        \ (Bluetooth stack for Linux).  It is currently an active open\\nsource project.\\\
+        n\\nThe project is implemented in C and uses the D-Bus interface of bluez.\\\
+        n\\nThe project is still a work in progress, and not all APIs from Bluez\\\
+        nhave been implemented as a part of bluez-tools.  The APIs which have\\nbeen\
+        \ implemented in bluez-tools are adapter, agent, device, network\\nand obex.\
+        \  Other APIs, such as interfaces for medical devices,\\npedometers and other\
+        \ specific APIs have not been ported to bluez-tools.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"bluez-tools\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1424772\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A set of tools to\
+        \ manage Bluetooth devices for Linux\",\n      \"upstream_url\": \"https://github.com/khvzak/bluez-tools\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The BuildBot is a system to automate the compile/test\
+        \ cycle required by\\nmost software projects to validate code changes. By\
+        \ automatically\\nrebuilding and testing the tree each time something has\
+        \ changed, build\\nproblems are pinpointed quickly, before other developers\
+        \ are\\ninconvenienced by the failure.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"buildbot\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Build/test automation system\",\n      \"upstream_url\"\
+        : \"http://buildbot.net\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\"\
+        : 1400070978.0,\n      \"description\": \"Modern Linux distributions offer\
+        \ some mitigation techniques to make it harder\\nto exploit software vulnerabilities\
+        \ reliably. Mitigations such as RELRO,\\nNoExecute (NX), Stack Canaries, Address\
+        \ Space Layout Randomization (ASLR) and\\nPosition Independent Executables\
+        \ (PIE) have made reliably exploiting any\\nvulnerabilities that do exist\
+        \ far more challenging. The checksec script is\\ndesigned to test what *standard*\
+        \ Linux OS and PaX (http://pax.grsecurity.net/)\\nsecurity features are being\
+        \ used.\\n\\nAs of version 1.3 the script also lists the status of various\
+        \ Linux kernel\\nprotection mechanisms.\\n\\nchecksec can check binary-files\
+        \ and running processes for hardening features.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"checksec\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Tool to check system for binary-hardening\"\
+        ,\n      \"upstream_url\": \"http://www.trapkit.de/tools/checksec.html\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1476187308.0,\n\
+        \      \"description\": \"This applet integrates the Ubuntu Application Menu\
+        \ (Global Menu)\\nsupport into the Cinnamon Desktop.  It uses the same idea\
+        \ as the\\nGnome Shell extension made by rgcjonas.\\n\\nThis is a third-party\
+        \ applet, not official.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"cinnamon-applet-globalappmenu\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1382810\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Ubuntu AppMenu support\
+        \ for Cinnamon Desktop\",\n      \"upstream_url\": \"https://github.com/lestcape/Global-AppMenu\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483971831.0,\n\
+        \      \"description\": \"Collection of the best themes available for Cinnamon.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"cinnamon-themes\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1411151\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Collection of the best themes available for Cinnamon\"\
+        ,\n      \"upstream_url\": \"http://cinnamon.linuxmint.com\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"CMake is used to control the software compilation process\
+        \ using simple\\nplatform and compiler independent configuration files. CMake\
+        \ generates\\nnative makefiles and workspaces that can be used in the compiler\\\
+        nenvironment of your choice. CMake is quite sophisticated: it is possible\\\
+        nto support complex environments requiring system configuration, preprocessor\\\
+        ngeneration, code generation, and template instantiation.\\n\\nThis package\
+        \ is for compatibility purposes only, and links to cmake as\\ndistributed\
+        \ by EL-6.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"cmake28\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Cross-platform\
+        \ make system\",\n      \"upstream_url\": \"http://www.cmake.org\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1457453001.0,\n    \
+        \  \"description\": \"CMake is used to control the software compilation process\
+        \ using simple\\nplatform and compiler independent configuration files. CMake\
+        \ generates\\nnative makefiles and workspaces that can be used in the compiler\\\
+        nenvironment of your choice. CMake is quite sophisticated: it is possible\\\
+        nto support complex environments requiring system configuration, preprocessor\\\
+        ngeneration, code generation, and template instantiation.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": \"None\",\n      \"name\": \"cmake3\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1315193\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Cross-platform make\
+        \ system\",\n      \"upstream_url\": \"http://www.cmake.org\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1486064435.0,\n      \"\
+        description\": \"dnfdragora is a DNF frontend, based on rpmdragora from Mageia\\\
+        n(originally rpmdrake) Perl code.\\n\\ndnfdragora is written in Python 3 and\
+        \ uses libYui, the widget\\nabstraction library written by SUSE, so that it\
+        \ can be run\\nusing Qt 5, GTK+ 3, or ncurses interfaces.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"dnfdragora\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1418788\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"DNF package-manager\
+        \ based on libYui abstraction\",\n      \"upstream_url\": \"https://github.com/manatools/dnfdragora\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1427748861.0,\n\
+        \      \"description\": \"\\nRyan, a bartender from a dystopian future can't\
+        \ sleep peacefully\\nfor months.  His nights are sequences of nightmares and\
+        \ strange\\ndreams, days with frequent black-outs with strange visions, until\\\
+        none night a figure in monk attire appears to him, and tells him the\\nstory\
+        \ of the seven evil ones, uniting to destroy to Dreamweb, the\\nonly barrier\
+        \ between the world and darkness.  The monk makes a\\nproposition:  Ryan becomes\
+        \ the \\\"deliverer\\\":  the one who would keep\\nthe Dreamweb safe by killing\
+        \ those who try to destroy it.\\n\\nDescending into paranoia and just wanting\
+        \ dreams to stop, Ryan\\naccepts the mission, then wakes up in a puddle of\
+        \ cold sweat, next\\nto his beloved girlfriend in her house, and late for\
+        \ work.  Again.\\n\\nDreamWeb is a top-down adventure game set in a gritty\
+        \ futuristic\\ndystopian city.  Each location takes only a small portion of\
+        \ the\\nscreen without panning (except an optional small zoom window in the\\\
+        ncorner that follows the cursor), with the player interacting with\\nobjects\
+        \ and people by simply clicking them.  Ryan has a limited\\ninventory space,\
+        \ and as a lot of objects can be picked up (many\\nwithout any use), the player\
+        \ must rationalize what might be useful\\nand what just serves as filler.\\\
+        n\\nDialogue is straightforward, with no options, but still required\\nto\
+        \ advance in the game (to find new locations, for instance).  In\\nsituations\
+        \ where many adventure games usually feature an indirect\\napproach to solve\
+        \ a problem, Ryan often faces himself with\\nsituations where it's \\\"killed\
+        \ or be killed\\\", which result in deaths\\n(sometimes of innocents).\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"dreamweb\",\n      \"namespace\": \"rpms\",\n      \"review_url\": \"\
+        https://bugzilla.redhat.com/1206901\",\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Click-and-point adventure with the look and feel of\
+        \ Ridley Scott's Blade Runner\",\n      \"upstream_url\": \"http://www.mobygames.com/game/dreamweb\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1457203210.0,\n\
+        \      \"description\": \"\\nDynamic plugin-loading like a boss.\",\n    \
+        \  \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\":\
+        \ \"dynaplugz\",\n      \"namespace\": \"rpms\",\n      \"review_url\": \"\
+        https://bugzilla.redhat.com/1314895\",\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Dynamic plugin-loading like a boss\",\n      \"upstream_url\"\
+        : \"https://github.com/shogun-toolbox/dynaplugz\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This is expat, the C library for parsing XML, written by James Clark.\\\
+        nExpat is a stream oriented XML parser.  This means that you register\\nhandlers\
+        \ with the parser prior to starting the parse.  These handlers\\nare called\
+        \ when the parser discovers the associated structures in the\\ndocument being\
+        \ parsed.  A start tag is an example of the kind of\\nstructures for which\
+        \ you may register handlers.\",\n      \"koschei_monitor\": false,\n     \
+        \ \"monitor\": false,\n      \"name\": \"expat21\",\n      \"namespace\":\
+        \ \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"An XML parser library\",\n      \"upstream_url\": \"\
+        http://www.libexpat.org/\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\"\
+        : 1409055383.0,\n      \"description\": \"This package contains desktop backgrounds\
+        \ for the Fedora 21 default theme.\\nPulls in themes for GNOME, KDE, Mate\
+        \ and Xfce desktops.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"f21-backgrounds\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1133217\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Fedora 21 default desktop background\"\
+        ,\n      \"upstream_url\": \"https://fedoraproject.org/wiki/F21_Artwork\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1438110814.0,\n\
+        \      \"description\": \"This package contains desktop backgrounds for the\
+        \ Fedora 23 default\\ntheme.  Pulls in themes for GNOME, KDE, Mate and Xfce\
+        \ desktops.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"f23-backgrounds\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/1247747\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Fedora 23 default desktop background\"\
+        ,\n      \"upstream_url\": \"https://fedoraproject.org/wiki/F23_Artwork\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"FDUPES is a program for identifying duplicate files\
+        \ residing within specified\\ndirectories.\",\n      \"koschei_monitor\":\
+        \ false,\n      \"monitor\": true,\n      \"name\": \"fdupes\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Finds duplicate files in a given set of\
+        \ directories\",\n      \"upstream_url\": \"https://github.com/adrianlopezroche/fdupes\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package contains desktop backgrounds for the\
+        \ Fedora Infinity theme,\\nwhich was the default theme for Fedora 8.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"fedorainfinity-backgrounds\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Fedora Infinity desktop backgrounds\",\n      \"upstream_url\": \"http://fedoraproject.org/wiki/Artwork/F8Themes/Infinity\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"freetiger is an implementation of the tiger hash\
+        \ algorithm made looking\\nonly at the tiger reference paper (thus ignoring\
+        \ the reference code until\\na working implementation was made). It also includes\
+        \ a modified version\\nof the main program included with the tiger reference\
+        \ implementation which\\nwas used for benchmarking purposes.\\n\\nIt has been\
+        \ optimized for usage in the TTH calculation algorithm and\\nincludes optimized\
+        \ versions that will calculate the hashes for the\\n1024 byte file chunks\
+        \ and the 48 byte hash concatenation appending the\\nproper suffix automatically\
+        \ thus minimizing memory to memory copying.\\n\\nAlso freetiger features interleaved\
+        \ hashing where the hashes of two\\ndifferent blocks are calculated at the\
+        \ same time interleaving the\\noperations of one and the other. Using this\
+        \ increases the\\nimplementation performance.\\n\\nfreetiger also supports\
+        \ SSE2 for key scheduling during the tiger rounds\\nwhich also increases performance\
+        \ on processors supporting it and\\nprovides an implementation of the partial\
+        \ hashing scheme for a more\\nsecure password storage when authenticating\
+        \ clients using the GPA\\ncommand in ADC.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"freetiger\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Free implementation of the tiger hash algorithm\",\n\
+        \      \"upstream_url\": \"http://klondike.es/freetiger\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This software provides Linux users with the ability to communicate\\nwith\
+        \ the Garmin Forerunner 305 via the USB interface.  It\\nimplements all of\
+        \ the documented Garmin protocols as of Rev C\\n(May 19, 2006) over the USB\
+        \ physical link.\\n\\nThis means that if you have a Garmin with a USB connection\
+        \ to a PC,\\nyou ought to be able to use this software to communicate with\
+        \ it.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n \
+        \     \"name\": \"garmintools\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Tools for Garmin GPS-devices\",\n      \"upstream_url\": \"https://garmintools.googlecode.com\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"git-extras adds the following extra-commands to\
+        \ git:\\n\\nalias, archive-file, bug, changelog, commits-since, contrib, count,\\\
+        ncreate-branch, delete-branch, delete-submodule, delete-tag, effort,\\nextras,\
+        \ feature, fresh-branch, gh-pages, graft, ignore, info,\\nlocal-commits, obliterate,\
+        \ promote, refactor, release, repl, setup,\\nsquash, summary, touch, undo\\\
+        n\\nFor more information about the extra-commands, see the included\\nREADME.md,\
+        \ HTML, mark-down or man-pages.\",\n      \"koschei_monitor\": false,\n  \
+        \    \"monitor\": true,\n      \"name\": \"git-extras\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Little git extras\",\n      \"upstream_url\": \"https://github.com/tj/git-extras\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"hardening-check is a tool to check whether an already\
+        \ compiled ELF file\\nwas built using hardening flags.\\n\\nIt checks, using\
+        \ readelf, for these hardening characteristics:\\n\\n  * Position Independent\
+        \ Executable\\n  * Stack protected\\n  * Fortify source functions\\n  * Read-only\
+        \ relocations\\n  * Immediate binding\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"hardening-check\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Tool to check ELF for being built hardened\"\
+        ,\n      \"upstream_url\": \"http://packages.debian.org/source/sid/hardening-wrapper\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Icecast is a streaming media server which currently\
+        \ supports\\nOgg Vorbis and MP3 audio streams.  It can be used to create an\\\
+        nInternet radio station or a privately running jukebox and many\\nthings in\
+        \ between.  It is very versatile in that new formats\\ncan be added relatively\
+        \ easily and supports open standards for\\ncommunication and interaction.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"icecast\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"ShoutCast compatible\
+        \ streaming media server\",\n      \"upstream_url\": \"http://www.icecast.org/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"JSON-C implements a reference counting object model\
+        \ that allows you to easily\\nconstruct JSON objects in C, output them as\
+        \ JSON formatted strings and parse\\nJSON formatted strings back into the\
+        \ C representation of JSON objects.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"json-c\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"A JSON implementation in C\",\n      \"upstream_url\"\
+        : \"https://github.com/json-c/json-c/wiki\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"jsoncpp\
+        \ is an implementation of a JSON (http://json.org) reader and writer in\\\
+        nC++. JSON (JavaScript Object Notation) is a lightweight data-interchange\
+        \ format.\\nIt is easy for humans to read and write. It is easy for machines\
+        \ to parse and\\ngenerate.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": \"nobuild\",\n      \"name\": \"jsoncpp\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"JSON library implemented in C++\",\n      \"upstream_url\"\
+        : \"https://github.com/open-source-parsers/jsoncpp\"\n    },\n    {\n    \
+        \  \"acls\": [],\n      \"creation_date\": 1457377727.0,\n      \"description\"\
+        : \"Libarchive is a programming library that can create and read several different\\\
+        nstreaming archive formats, including most popular tar variants, several cpio\\\
+        nformats, and both BSD and GNU ar variants. It can also write shar archives\
+        \ and\\nread ISO9660 CDROM images and ZIP archives.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"libarchive3\",\n   \
+        \   \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1315307\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A library for handling\
+        \ streaming archive formats\",\n      \"upstream_url\": \"http://www.libarchive.org/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The Berkeley Database (Berkeley DB) is a programmatic\
+        \ toolkit that\\nprovides embedded database support for both traditional and\\\
+        nclient/server applications. The Berkeley DB includes B+tree, Extended\\nLinear\
+        \ Hashing, Fixed and Variable-length record access methods,\\ntransactions,\
+        \ locking, logging, shared memory caching, and database\\nrecovery. The Berkeley\
+        \ DB supports C, C++, Java, and Perl APIs. It is\\nused by many applications,\
+        \ including Python and Perl, so this should\\nbe installed on all systems.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"libdb4\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"The Berkeley DB database\
+        \ library (version 4) for C\",\n      \"upstream_url\": \"http://www.oracle.com/database/berkeley-db/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"LibFlatArray acts as a highly efficient multi-dimensional\
+        \ array of\\narbitrary objects (array of structs, AoS), but really uses a\
+        \ struct of\\narrays (SoA) memory layout. It's great for writing vectorized\
+        \ code and\\nits lightning-fast iterators give you access to neighboring elements\\\
+        nwith zero address generation overhead.\\n\\nUse cases include:\\n- computer\
+        \ simulations (e.g. stencil codes such as Lattice Boltzmann Methods)\\n- image\
+        \ processing (e.g. Gaussian filters)\\n- numerical methods (e.g. multiplication\
+        \ of complex matrices)\\n\\nThe library is written in C++ and uses templates\
+        \ to shift the burden\\nof address computation from runtime to compile time.\
+        \ It shares some\\ninfrastructure with its parent project LibGeoDecomp.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"libflatarray\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"C++ library\
+        \ for highly efficient multi-dimensional arrays\",\n      \"upstream_url\"\
+        : \"http://www.libgeodecomp.org/libflatarray.html\"\n    },\n    {\n     \
+        \ \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"liblinear is an open source library for large-scale linear classification.\\\
+        nIt supports logistic regression and linear support vector machines.  It\\\
+        nprovides easy-to-use command-line tools and library calls for users and\\\
+        ndevelopers.  Comprehensive documents are available for both beginners\\nand\
+        \ advanced users.\\n\\nExperiments demonstrate that liblinear is very efficient\
+        \ on large sparse\\ndata sets.  liblinear is the winner of ICML 2008 large-scale\
+        \ learning\\nchallenge (linear SVM track).  It is also used for winning KDD\
+        \ Cup 2010.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"liblinear\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Library for Large Linear Classification\",\n      \"upstream_url\": \"http://www.csie.ntu.edu.tw/~cjlin/liblinear\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is the user interface engine that provides\
+        \ the abstraction\\nfrom graphical user interfaces (Qt, Gtk) and text based\
+        \ user\\ninterfaces (ncurses).\\n\\nOriginally developed for YaST, libyui\
+        \ can now be used\\nindependently of YaST for generic (C++) applications.\\\
+        n\\nlibyui has very few dependencies.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"libyui\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"GUI-abstraction library\",\n      \"upstream_url\":\
+        \ \"https://github.com/libyui/libyui\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"This package\
+        \ provides Mono / CSharp, Perl, Python and Ruby language\\nbindings to access\
+        \ functions of libyui.\\nAn User Interface engine that provides abstraction\
+        \ from graphical user\\ninterfaces (Qt, Gtk) and text based user interfaces\
+        \ (ncurses).\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"libyui-bindings\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Language bindings for libyui\",\n      \"upstream_url\": \"https://github.com/libyui/libyui-bindings\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package contains the Gtk3 user interface component\\\
+        nfor libyui.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"libyui-gtk\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Gtk3 User Interface for libyui\",\n      \"upstream_url\": \"https://github.com/libyui/libyui-gtk\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1486061005.0,\n\
+        \      \"description\": \"This package contains the Libyui extensions for\
+        \ Mageia tools.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"libyui-mga\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1418661\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Libyui extensions for Mageia tools\"\
+        ,\n      \"upstream_url\": \"https://github.com/xquiet/libyui-mga\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1486062814.0,\n    \
+        \  \"description\": \"This package contains the Libyui-Gtk extensions for\
+        \ Mageia tools.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"libyui-mga-gtk\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": \"https://bugzilla.redhat.com/1418785\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Libyui-Gtk extensions for Mageia tools\"\
+        ,\n      \"upstream_url\": \"https://github.com/xquiet/libyui-mga-gtk\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1486128250.0,\n\
+        \      \"description\": \"This package contains the Libyui-Ncurses extensions\
+        \ for Mageia tools.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"libyui-mga-ncurses\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1418872\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Libyui-Ncurses extensions\
+        \ for Mageia tools\",\n      \"upstream_url\": \"https://github.com/xquiet/libyui-mga-ncurses\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1486128191.0,\n\
+        \      \"description\": \"This package contains the Libyui-Qt extensions for\
+        \ Mageia tools.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"libyui-mga-qt\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": \"https://bugzilla.redhat.com/1418882\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Libyui-Qt extensions for Mageia tools\"\
+        ,\n      \"upstream_url\": \"https://github.com/xquiet/libyui-mga-qt\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package contains the character based (ncurses)\
+        \ user interface\\ncomponent for libyui.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"libyui-ncurses\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Character Based User Interface for libyui\",\n     \
+        \ \"upstream_url\": \"https://github.com/libyui/libyui-ncurses\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"This package contains the qt user interface component\\\
+        nfor libyui.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"libyui-qt\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Qt User Interface for libyui\",\n      \"upstream_url\": \"https://github.com/libyui/libyui-qt\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The Apache Mahout project's goal is to build a scalable\
+        \ machine\\nlearning library.\\n\\nThis package contains the Maven plugin\
+        \ used to generate code\\nfor Mahout Collections.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"mahout-collection-codegen-plugin\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Maven Mojo to generate code for Mahout\
+        \ Collections\",\n      \"upstream_url\": \"http://mahout.apache.org/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483971411.0,\n\
+        \      \"description\": \"Icon theme for Linux Mint.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"mint-x-icons\",\n   \
+        \   \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1411152\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Icon theme for Linux\
+        \ Mint\",\n      \"upstream_url\": \"http://linuxmint.com\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1483971339.0,\n      \"description\"\
+        : \"The Mint-Y icon theme.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": true,\n      \"name\": \"mint-y-icons\",\n      \"namespace\":\
+        \ \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1411153\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"The Mint-Y icon theme\"\
+        ,\n      \"upstream_url\": \"http://linuxmint.com\"\n    },\n    {\n     \
+        \ \"acls\": [],\n      \"creation_date\": 1405361161.0,\n      \"description\"\
+        : \"This package contains the\\nSELinux-policy-module for pipelight.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"pipelight-selinux\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1119288\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"SELinux-policy-module for pipelight\",\n      \"upstream_url\"\
+        : \"https://github.com/besser82/pipelight-selinux\"\n    },\n    {\n     \
+        \ \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Premake is a build configuration tool that can generate project files\
+        \ for:\\n - GNU make\\n - Code::Blocks\\n - CodeLite\\n - MonoDevelop\\n -\
+        \ SharpDevelop\\n - Apple XCode\\n - Microsoft Visual Studio\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\": \"premake\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Cross-platform build configuration tool\"\
+        ,\n      \"upstream_url\": \"http://industriousone.com/premake\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1476707802.0,\n    \
+        \  \"description\": \"Purple Facebook implements the Facebook Messenger protocol\
+        \ for pidgin,\\nfinch, and libpurple.  While the primary implementation is\
+        \ for purple3,\\nthis plugin is back-ported for purple2.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"purple-facebook\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1385180\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Facebook protocol\
+        \ plugin for purple2\",\n      \"upstream_url\": \"https://github.com/dequis/purple-facebook\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A Pure-Python library built as a PDF toolkit. It\
+        \ is capable of:\\n * extracting document information (title, author, ...),\\\
+        n * splitting documents page by page,\\n * merging documents page by page,\\\
+        n * cropping pages,\\n * merging multiple pages into a single page,\\n * encrypting\
+        \ and decrypting PDF files.\",\n      \"koschei_monitor\": false,\n      \"\
+        monitor\": true,\n      \"name\": \"pyPdf\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"PDF toolkit\",\n      \"upstream_url\": \"http://pybrary.net/pyPdf/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"\\nAn interface for creating both directed and non\
+        \ directed graphs from Python.\\nCurrently all attributes implemented in the\
+        \ Dot language are supported (up\\nto Graphviz 2.16).\\n\\nOutput can be inlined\
+        \ in Postscript into interactive scientific environments\\nlike TeXmacs, or\
+        \ output in any of the format's supported by the Graphviz\\ntools dot, neato,\
+        \ twopi.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"pydot\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Python interface\
+        \ to Graphviz's Dot language\",\n      \"upstream_url\": \"http://code.google.com/p/pydot/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Pure-Python library for parsing and analyzing ELF\
+        \ files\\nand DWARF debugging information.\",\n      \"koschei_monitor\":\
+        \ true,\n      \"monitor\": false,\n      \"name\": \"pyelftools\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Pure-Python library for parsing and\
+        \ analyzing ELF files\",\n      \"upstream_url\": \"https://github.com/eliben/pyelftools\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"python-Bottleneck is a collection of fast NumPy\
+        \ array functions\\nwritten in Cython.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-Bottleneck\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Collection of fast NumPy array functions\
+        \ written in Cython\",\n      \"upstream_url\": \"http://berkeleyanalytics.com/bottleneck\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Building a command-line interface?  Found yourself\
+        \ uttering \\u201cargh!\\u201d while\\nstruggling with the API of argparse?\
+        \  Don\\u2019t want to lose its power but don\\u2019t\\nneed the complexity?\\\
+        n\\npython-argh provides a wrapper for argparse.  Argparse is a very\\npowerful\
+        \ tool;  python-argh just makes it easy to use.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-argh\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Unobtrusive argparse wrapper with natural\
+        \ syntax\",\n      \"upstream_url\": \"https://pypi.python.org/pypi/argh\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1477325086.0,\n\
+        \      \"description\": \"\\nThe binstruct library allows you to access binary\
+        \ data using a\\npredefined structure.  The binary data can be provided in\
+        \ any form\\nthat allows an indexed access to single bytes.  This could for\
+        \ example\\nbe a memory-mapped file.  The data structure itself is defined\
+        \ in way\\nsimilar to Django database table definitions by declaring a new\
+        \ class\\nwith its fields.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": true,\n      \"name\": \"python-binstruct\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1387835\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Library for read/write\
+        \ access of binary data via structures\",\n      \"upstream_url\": \"https://pypi.python.org/pypi/binstruct\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1477325147.0,\n\
+        \      \"description\": \"\\nThis module performs conversions between Python\
+        \ values and C bit\\nfield structs represented as Python byte strings.  It\
+        \ is intended to\\nhave a similar interface as the python struct module, but\
+        \ working on\\nbits instead of primitive data types (char, int, \\u2026).\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-bitstruct\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1387836\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Interpret strings as packed binary data\",\n     \
+        \ \"upstream_url\": \"https://pypi.python.org/pypi/bitstruct\"\n    },\n \
+        \   {\n      \"acls\": [],\n      \"creation_date\": 1477334158.0,\n     \
+        \ \"description\": \"USB programmer for devices based on the Joyetech Evic\
+        \ VTC Mini.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-evic\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1387834\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"USB programmer for devices based on\
+        \ the Joyetech Evic VTC Mini\",\n      \"upstream_url\": \"https://github.com/Ban3/python-evic\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"\\nGensim is a Python library for topic modelling,\
+        \ document indexing\\nand similarity retrieval with large corpora.  Target\
+        \ audience is\\nthe natural language processing (NLP) and information retrieval\\\
+        n(IR) community.\\n\\nFeatures:\\n\\n  * All algorithms are memory-independent\
+        \ w.r.t. the corpus size\\n(can process input larger than RAM).\\n  * Intuitive\
+        \ interfaces\\n    - easy to plug in your own input corpus/datastream (trivial\\\
+        nstreaming API)\\n    - easy to extend with other Vector Space algorithms\
+        \ (trivial\\ntransformation API)\\n  * Efficient implementations of popular\
+        \ algorithms, such as online\\nLatent Semantic Analysis (LSA/LSI), Latent\
+        \ Dirichlet Allocation (LDA),\\nRandom Projections (RP), Hierarchical Dirichlet\
+        \ Process (HDP) or\\nword2vec deep learning.\\n  * Distributed computing:\
+        \ can run Latent Semantic Analysis and Latent\\nDirichlet Allocation on a\
+        \ cluster of computers, and word2vec on\\nmultiple cores.\\n  * Extensive\
+        \ HTML documentation and tutorials.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-gensim\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Python framework for fast Vector Space Modelling\",\n\
+        \      \"upstream_url\": \"http://radimrehurek.com/gensim/\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1477313192.0,\n      \"\
+        description\": \"Interface to the hidapi library.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-hidapi\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1387837\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Interface to the\
+        \ hidapi library\",\n      \"upstream_url\": \"https://pypi.python.org/pypi/hidapi\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1475502137.0,\n\
+        \      \"description\": \"\\nJapaneseCharacterCONVerter - inter-convert hiragana,\
+        \ katakana,\\nhalf-width kana.\",\n      \"koschei_monitor\": true,\n    \
+        \  \"monitor\": true,\n      \"name\": \"python-jcconv\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1380671\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"JapaneseCharacterCONVerter\"\
+        ,\n      \"upstream_url\": \"https://pypi.python.org/pypi/jcconv\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"\\nThe NGram class extends the Python 'set' class with\
+        \ efficient fuzzy\\nsearch for members by means of an N-gram similarity measure.\
+        \  It\\nalso has static methods to compare a pair of strings.\\n\\nThe N-grams\
+        \ are character based not word-based, and the class does\\nnot implement a\
+        \ language model, merely searching for members by\\nstring similarity.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-ngram\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Set-based subclass\
+        \ providing fuzzy search based on N-grams\",\n      \"upstream_url\": \"https://github.com/gpoulter/python-ngram\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"python-pathtools is a Python API library for common\
+        \ path\\nand pattern functionality.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"python-pathtools\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Pattern matching and various utilities for\
+        \ file systems paths\",\n      \"upstream_url\": \"https://github.com/gorakhargosh/pathtools\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1475011230.0,\n\
+        \      \"description\": \"\\nThe psycogreen package enables psycopg2 to work\
+        \ with co-routine libraries,\\nusing asynchronous calls internally but offering\
+        \ a blocking interface so\\nthat regular code can run unmodified.  Psycopg\
+        \ offers co-routines support\\nsince release 2.2.  Because the main module\
+        \ is a C extension it cannot be\\nmonkey-patched to become co-routine-friendly.\
+        \  Instead it exposes a hook\\nthat co-routine libraries can use to install\
+        \ a function integrating with\\ntheir event scheduler.  Psycopg will call\
+        \ the function whenever it\\nexecutes a libpq call that may block.  Psycogreen\
+        \ is a collection of \\u201cwait\\ncallbacks\\u201d useful to integrate Psycopg\
+        \ with different co-routine libraries.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-psycogreen\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1379421\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Psycopg2 integration\
+        \ with co-routine libraries\",\n      \"upstream_url\": \"https://pypi.python.org/pypi/psycogreen\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490794685.0,\n\
+        \      \"description\": \"This library allows you to create a system tray\
+        \ icon.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n \
+        \     \"name\": \"python-pystray\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": \"https://bugzilla.redhat.com/1436347\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Provides system tray integration\",\n\
+        \      \"upstream_url\": \"https://github.com/moses-palmer/pystray\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1487685729.0,\n\
+        \      \"description\": \"Command line interface for testing internet bandwidth\
+        \ using speedtest.net.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-speedtest-cli\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1425203\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Command line interface\
+        \ for testing internet bandwidth using speedtest.net\",\n      \"upstream_url\"\
+        : \"https://pypi.python.org/pypi/speedtest-cli\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"python-sphinx-theme-flask contains\\nSphinx Themes for Flask related projects\
+        \ and Flask itself.\\n\\nThe following themes exist:\\n\\n * flask - the standard\
+        \ flask documentation theme for large projects\\n * flask_small - small one-page\
+        \ theme.  Intended to be used by very small\\naddon libraries for flask.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-sphinx-theme-flask\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Sphinx Themes for Flask related projects and Flask itself\",\n      \"\
+        upstream_url\": \"https://github.com/mitsuhiko/flask-sphinx-themes\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This extension adds directives for easy linking\
+        \ to Cheese Shop\\n(Python Package Index) packages.  It supports a directive\
+        \ and a\\nrole, as well as a new config value.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-sphinxcontrib-cheeseshop\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Sphinx extension cheeseshop\",\n   \
+        \   \"upstream_url\": \"https://pypi.python.org/pypi/sphinxcontrib-cheeseshop\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package provides numeric types of twice the\
+        \ precision of IEEE\\ndouble (106 mantissa bits, or approximately 32 decimal\
+        \ digits) and\\nfour times the precision of IEEE double (212 mantissa bits,\
+        \ or\\napproximately 64 decimal digits).  Due to features such as operator\\\
+        nand function overloading, these facilities can be utilized\\nwith only minor\
+        \ modifications to conventional C++ and Fortran-90\\nprograms.\\n\\nIn addition\
+        \ to the basic arithmetic operations (add, subtract,\\nmultiply, divide, square\
+        \ root), common transcendental functions such\\nas the exponential, logarithm,\
+        \ trigonometric and hyperbolic functions\\nare also included.\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\": \"qd\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Double-Double and Quad-Double Arithmetic\"\
+        ,\n      \"upstream_url\": \"http://crd.lbl.gov/~dhbailey/mpdist/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"These scripts allow one to manage a series of patches\
+        \ by keeping track of the\\nchanges each patch makes. Patches can be applied,\
+        \ un-applied, refreshed, etc.\\n\\nThe scripts are heavily based on Andrew\
+        \ Morton's patch scripts found at\\nhttp://www.zip.com.au/~akpm/linux/patches/\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"quilt\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Scripts for working\
+        \ with series of patches\",\n      \"upstream_url\": \"http://savannah.nongnu.org/projects/quilt\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1407355660.0,\n\
+        \      \"description\": \"\\nRapidJSON is a fast JSON parser and generator\
+        \ for C++.  It was\\ninspired by RapidXml.\\n\\n  RapidJSON is small but complete.\
+        \  It supports both SAX and DOM style\\n  API. The SAX parser is only a half\
+        \ thousand lines of code.\\n\\n  RapidJSON is fast.  Its performance can be\
+        \ comparable to strlen().\\n  It also optionally supports SSE2/SSE4.1 for\
+        \ acceleration.\\n\\n  RapidJSON is self-contained.  It does not depend on\
+        \ external\\n  libraries such as BOOST.  It even does not depend on STL.\\\
+        n\\n  RapidJSON is memory friendly.  Each JSON value occupies exactly\\n \
+        \ 16/20 bytes for most 32/64-bit machines (excluding text string).  By\\n\
+        \  default it uses a fast memory allocator, and the parser allocates\\n  memory\
+        \ compactly during parsing.\\n\\n  RapidJSON is Unicode friendly.  It supports\
+        \ UTF-8, UTF-16, UTF-32\\n  (LE & BE), and their detection, validation and\
+        \ transcoding\\n  internally.  For example, you can read a UTF-8 file and\
+        \ let RapidJSON\\n  transcode the JSON strings into UTF-16 in the DOM.  It\
+        \ also supports\\n  surrogates and \\\"u0000\\\" (null character).\\n\\nJSON(JavaScript\
+        \ Object Notation) is a light-weight data exchange\\nformat.  RapidJSON should\
+        \ be in fully compliance with RFC4627/ECMA-404.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"rapidjson\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1127380\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast JSON parser\
+        \ and generator for C++\",\n      \"upstream_url\": \"http://miloyip.github.io/rapidjson\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1471968490.0,\n\
+        \      \"description\": \"Colorize your text in the terminal.  There are a\
+        \ bunch of gems that\\nprovide functionality like this, but none have as simple\
+        \ an API as\\nthis.  Just call \\\"string\\\".color and your text will be\
+        \ colorized.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"rubygem-colorator\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/1368844\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Colorize your text in the terminal\"\
+        ,\n      \"upstream_url\": \"https://github.com/octopress/colorator\"\n  \
+        \  },\n    {\n      \"acls\": [],\n      \"creation_date\": 1471973841.0,\n\
+        \      \"description\": \"Extends forwardable with delegation to hashes and\
+        \ instance variables.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"rubygem-forwardable-extended\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1368845\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Forwardable with\
+        \ hash, and instance variable extensions\",\n      \"upstream_url\": \"https://github.com/envygeeks/forwardable-extended\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1471987565.0,\n\
+        \      \"description\": \"Jekyll is a simple, blog-aware, static site generator\
+        \ perfect\\nfor personal, project, or organization sites.  Think of it like\\\
+        na file-based CMS, without all the complexity.  Jekyll takes your\\ncontent,\
+        \ renders Markdown and Liquid templates, and spits out a\\ncomplete, static\
+        \ website ready to be served by Apache, Nginx or\\nanother web server.  Jekyll\
+        \ is the engine behind GitHub Pages,\\nwhich you can use to host sites right\
+        \ from your GitHub repositories.\\nJekyll does what you tell it to do \\u2014\
+        \ no more, no less.  It doesn't\\ntry to outsmart users by making bold assumptions,\
+        \ nor does it\\nburden them with needless complexity and configuration.  Put\
+        \ simply,\\nJekyll gets out of your way and allows you to concentrate on what\\\
+        ntruly matters: your content.\",\n      \"koschei_monitor\": true,\n     \
+        \ \"monitor\": true,\n      \"name\": \"rubygem-jekyll\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1368851\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Transform your plain\
+        \ text into static websites and blogs\",\n      \"upstream_url\": \"https://jekyllrb.com\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1471971836.0,\n\
+        \      \"description\": \"Let Jekyll build your Sass and SCSS!\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"rubygem-jekyll-sass-converter\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1368846\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Basic Sass converter\
+        \ for Jekyll\",\n      \"upstream_url\": \"https://github.com/jekyll/jekyll-sass-converter\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1471971879.0,\n\
+        \      \"description\": \"Rebuild your Jekyll site when a file changes with\
+        \ the `--watch` switch!\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"rubygem-jekyll-watch\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1368847\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Rebuild your Jekyll\
+        \ site when a file changes\",\n      \"upstream_url\": \"https://github.com/jekyll/jekyll-watch\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1471971911.0,\n\
+        \      \"description\": \"Lightweight and flexible library for writing command-line\
+        \ apps in Ruby.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"rubygem-mercenary\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/1368848\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"An easier way to build your\
+        \ command-line scripts in Ruby\",\n      \"upstream_url\": \"https://github.com/jekyll/mercenary\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"NArray is a Numerical N-dimensional Array class.\
+        \  Supported element types are\\n1/2/4-byte Integer, single/double-precision,\
+        \ Real/Complex and Ruby Object.\\nThis extension library incorporates fast\
+        \ calculation and easy manipulation of\\nlarge numerical arrays into the Ruby\
+        \ language.  NArray has features similar to\\nNumPy, but NArray has vector\
+        \ and matrix sub-classes.\",\n      \"koschei_monitor\": false,\n      \"\
+        monitor\": true,\n      \"name\": \"rubygem-narray\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"N-dimensional Numerical Array class for Ruby\",\n  \
+        \    \"upstream_url\": \"http://narray.rubyforge.org\"\n    },\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1471977511.0,\n      \"description\"\
+        : \"Pathutil tries to be a faster pure Ruby implementation of Pathname.\\\
+        nIt arose out of a need to fix basic problems with Pathname, such as\\nsusceptibility\
+        \ to join overrides, need for automatic encoding, and\\nnormalization (for\
+        \ stuff like Jekyll) and the ability to do other\\nsafe-style operations in\
+        \ an encapsulated format, like copying files\\nand folders with symbolic links\
+        \ but only if they originate from the\\ngiven root.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"rubygem-pathutil\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1368849\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Faster pure Ruby\
+        \ implementation of Pathname with extra bits\",\n      \"upstream_url\": \"\
+        https://github.com/envygeeks/pathutil\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1471977458.0,\n      \"description\": \"Rouge is\
+        \ a pure-ruby syntax highlighter.  It can highlight 100\\ndifferent languages,\
+        \ and output HTML or ANSI 256-color text.\\nIts HTML output is compatible\
+        \ with style-sheets designed for pygments.\",\n      \"koschei_monitor\":\
+        \ true,\n      \"monitor\": true,\n      \"name\": \"rubygem-rouge\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1368850\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Simple, easy-to-extend\
+        \ drop-in replacement for pygments\",\n      \"upstream_url\": \"http://rouge.jneen.net\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"RSpec is a fine unit-testing framework, but is also\
+        \ handy for acceptance\\nand integration tests.  But the default report formatters\
+        \ make it difficult\\nto track progress of such long-running tests.\\n\\nThe\
+        \ RSpec::Longrun::Formatter outputs the name of each test as it starts,\\\
+        nrather than waiting until it passes or fails.  It also provides a mechanism\\\
+        nfor reporting on progress of a test while it is still executing.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"rubygem-rspec-longrun\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"RSpec formatter\
+        \ for long-running specs\",\n      \"upstream_url\": \"http://github.com/mdub/rspec-longrun\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"\\nThe Shogun Machine learning toolbox provides\
+        \ a wide range of unified and\\nefficient Machine Learning (ML) methods. \
+        \ The toolbox seamlessly allows to\\neasily combine multiple data representations,\
+        \ algorithm classes, and general\\npurpose tools.  This enables both rapid\
+        \ prototyping of data pipelines and\\nextensibility in terms of new algorithms.\
+        \  We combine modern software\\narchitecture in C++ with both efficient low-level\
+        \ computing back-ends and\\ncutting edge algorithm implementations to solve\
+        \ large-scale Machine Learning\\nproblems (yet) on single machines.\\n\\nOne\
+        \ of Shogun's most exciting features is that you can use the toolbox through\\\
+        na unified interface from C++, Python(3), Octave, R, Java, Lua, etc.  This\
+        \ not\\njust means that we are independent of trends in computing languages,\
+        \ but it\\nalso lets you use Shogun as a vehicle to expose your algorithm\
+        \ to multiple\\ncommunities.  We use SWIG to enable bidirectional communication\
+        \ between C++\\nand target languages.  Shogun runs under Linux/Unix, MacOS,\
+        \ Windows.\\n\\nOriginally focusing on large-scale kernel methods and bioinformatics\
+        \ (for a\\nlist of scientific papers mentioning Shogun, see here), the toolbox\
+        \ saw\\nmassive extensions to other fields in recent years.  It now offers\
+        \ features\\nthat span the whole space of Machine Learning methods, including\
+        \ many\\nclassical methods in classification, regression, dimensionality reduction,\\\
+        nclustering, but also more advanced algorithm classes such as metric,\\nmulti-task,\
+        \ structured output, and online learning, as well as feature\\nhashing, ensemble\
+        \ methods, and optimization, just to name a few.  Shogun in\\naddition contains\
+        \ a number of exclusive state-of-the art algorithms such as\\na wealth of\
+        \ efficient SVM implementations, Multiple Kernel Learning, kernel\\nhypothesis\
+        \ testing, Krylov methods, etc.  All algorithms are supported by a\\ncollection\
+        \ of general purpose methods for evaluation, parameter tuning,\\npreprocessing,\
+        \ serialization & I/O, etc;  the resulting combinatorial\\npossibilities are\
+        \ huge.\\n\\nThe wealth of ML open-source software allows us to offer bindings\
+        \ to other\\nsophisticated libraries including:  LibSVM, LibLinear, LibOCAS,\
+        \ libqp,\\nVowpalWabbit, Tapkee, SLEP, GPML and more.\\n\\nShogun got initiated\
+        \ in 1999 by Soeren Sonnenburg and Gunnar Raetsch (that's\\nwhere the name\
+        \ ShoGun originates from).  It is now developed by a larger team\\nof authors,\
+        \ and would not have been possible without the patches and bug\\nreports by\
+        \ various people.  See contributions for a detailed list.  Statistics\\non\
+        \ Shogun's development activity can be found on ohloh.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"shogun\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Large Scale Machine Learning Toolbox\",\n      \"upstream_url\"\
+        : \"http://shogun-toolbox.org\"\n    },\n    {\n      \"acls\": [],\n    \
+        \  \"creation_date\": 1400070978.0,\n      \"description\": \"This package\
+        \ contains data-files needed for running the test-suite\\nand examples of\
+        \ the SHOGUN machine learning toolbox.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"shogun-data\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Data-files for the SHOGUN machine learning toolbox\"\
+        ,\n      \"upstream_url\": \"http://shogun-toolbox.org\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1405021344.0,\n      \"description\"\
+        : \"SoundKonverter is a front-end to various audio converters.\\n\\nThe key\
+        \ features are:\\n  * Audio conversion\\n  * Replay Gain calculation\\n  *\
+        \ CD ripping\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"soundkonverter\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": \"https://bugzilla.redhat.com/1114547\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Audio file converter, CD ripper and\
+        \ Replay Gain tool\",\n      \"upstream_url\": \"http://kde-apps.org/content/show.php?content=29024\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The Google SparseHash project contains several C++\
+        \ template hash-map\\nimplementations with different performance characteristics,\
+        \ including\\nan implementation that optimizes for space and one that optimizes\
+        \ for\\nspeed.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"sparsehash\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Extremely memory-efficient C++ hash_map implementation\",\n      \"upstream_url\"\
+        : \"http://code.google.com/p/sparsehash\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ script tries to export ssh public keys to a specified site. It will\\nwalk\
+        \ you through generating key pairs if it doesn't find any to export.\\nIt\
+        \ handles all the fiddly details like making sure local and remote\\npermissions\
+        \ are correct, and tells you what it's doing if it has to change\\nanything.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"ssh-installkeys\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A tool for\
+        \ installing ssh keys on remote sites\",\n      \"upstream_url\": \"http://www.catb.org/~esr/ssh-installkeys/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"\\nStichwort is a simple tool for C++ keyword arguments.\
+        \  The library\\nprovides rather clean and simple API for creating keywords\
+        \ and handling\\nthem as function parameters.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"stichwort\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Simple library for named parameters\
+        \ in C++\",\n      \"upstream_url\": \"https://github.com/lisitsyn/stichwort\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Tapkee is a C++ template library for dimensionality\
+        \ reduction with\\nsome bias on spectral methods.  The Tapkee origins from\
+        \ the code\\ndeveloped during GSoC 2011 as the part of the Shogun machine\
+        \ learning\\ntoolbox.  The project aim is to provide efficient and flexible\\\
+        nstandalone library for dimensionality reduction which can be easily\\nintegrated\
+        \ to existing codebases.  Tapkee leverages capabilities of\\neffective Eigen3\
+        \ linear algebra library and optionally makes use of\\nthe ARPACK eigensolver.\
+        \  The library uses CoverTree and VP-tree\\ndata-structures to compute nearest\
+        \ neighbors.  To achieve greater\\nflexibility we provide a callback interface\
+        \ which decouples dimension\\nreduction algorithms from the data representation\
+        \ and storage schemes.\\n\\nTapkee provides implementations of the following\
+        \ dimension reduction\\nmethods:\\n\\n  * Locally Linear Embedding and Kernel\
+        \ Locally Linear Embedding\\n    (LLE/KLLE)\\n  * Neighborhood Preserving\
+        \ Embedding (NPE)\\n  * Local Tangent Space Alignment (LTSA)\\n  * Linear\
+        \ Local Tangent Space Alignment (LLTSA)\\n  * Hessian Locally Linear Embedding\
+        \ (HLLE)\\n  * Laplacian eigenmaps\\n  * Locality Preserving Projections\\\
+        n  * Diffusion map\\n  * Isomap and landmark Isomap\\n  * Multidimensional\
+        \ scaling and landmark Multidimensional scaling\\n    (MDS/lMDS)\\n  * Stochastic\
+        \ Proximity Embedding (SPE)\\n  * PCA and randomized PCA\\n  * Kernel PCA\
+        \ (kPCA)\\n  * Random projection\\n  * Factor analysis\\n  * t-SNE\\n  * Barnes-Hut-SNE\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"tapkee\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"C++ template\
+        \ library for efficient dimension reduction\",\n      \"upstream_url\": \"\
+        http://tapkee.lisitsyn.me/\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"TextCat is an implementation\
+        \ of the text categorization algorithm\\npresented in Cavnar, W. B. and J.\
+        \ M. Trenkle, \\\"N-Gram-Based Text\\nCategorization\\\".  TextCat uses this\
+        \ the technique to implement a\\nwritten language identification.  At the\
+        \ moment, it knows about 69\\nnatural languages (counting Esperanto as a natural\
+        \ language).\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"textcat\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Written language\
+        \ identification\",\n      \"upstream_url\": \"http://www.let.rug.nl/~vannoord/TextCat/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1482877532.0,\n\
+        \      \"description\": \"\\nLightweight, portable and easy to integrate C\
+        \ directory\\tand file reader.\\nTinyDir wraps dirent for POSIX and FindFirstFile\
+        \ for Windows.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"tinydir\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1408852\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Portable and easy to integrate C directory and file\
+        \ reader\",\n      \"upstream_url\": \"https://github.com/cxong/tinydir\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1476187100.0,\n\
+        \      \"description\": \"GTK+ module for exporting old-style menus as GMenuModels.\\\
+        nMany applications implement menus as GtkMenuShells and GtkMenuItems\\nand\
+        \ aren't looking to migrate to the newer GMenuModel API.\\nThis GTK+ module\
+        \ watches for these types of menus and exports the\\nappropriate GMenuModel\
+        \ implementation.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"unity-gtk-module\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1382813\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"GTK+ module for exporting old-style\
+        \ menus as GMenuModels\",\n      \"upstream_url\": \"https://launchpad.net/unity-gtk-module\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"\\nAny C structure can be stored in a hash table\
+        \ using uthash.  Just\\nadd a UT_hash_handle to the structure and choose one\
+        \ or more fields\\nin your structure to act as the key.  Then use these macros\
+        \ to store,\\nretrieve or delete items from the hash table.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"uthash\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"A hash table for C structures\",\n      \"upstream_url\"\
+        : \"http://troydhanson.github.io/uthash\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"WordNet\
+        \ is a large lexical database of English, developed under the direction\\\
+        nof George A. Miller. Nouns, verbs, adjectives and adverbs are grouped into\
+        \ sets\\nof cognitive synonyms (synsets), each expressing a distinct concept.\
+        \ Synsets\\nare interlinked by means of conceptual-semantic and lexical relations.\
+        \ The\\nresulting network of meaningfully related words and concepts can be\
+        \ navigated\\nwith the browser. WordNet is also freely and publicly available\
+        \ for download.\\nWordNet's structure makes it a useful tool for computational\
+        \ linguistics and\\nnatural language processing.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"wordnet\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"A lexical database for the English language\"\
+        ,\n      \"upstream_url\": \"http://wordnet.princeton.edu/\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1487684865.0,\n      \"\
+        description\": \"Xed is a small, but powerful text editor.  It has most standard\
+        \ text\\neditor functions and fully supports international text in Unicode.\\\
+        nAdvanced features include syntax highlighting and automatic indentation\\\
+        nof source code, printing and editing of multiple documents in one window.\\\
+        n\\nXed is extensible through a plugin system, which currently includes\\\
+        nsupport for spell checking, comparing files, viewing CVS ChangeLogs, and\\\
+        nadjusting indentation levels.\",\n      \"koschei_monitor\": true,\n    \
+        \  \"monitor\": true,\n      \"name\": \"xed\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1424798\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"X-Apps [Text] Editor (Cross-DE,\
+        \ backward-compatible, GTK3, traditional UI)\",\n      \"upstream_url\": \"\
+        https://github.com/linuxmint/xed\"\n    },\n    {\n      \"acls\": [],\n \
+        \     \"creation_date\": 1487716215.0,\n      \"description\": \"Xplayer-pl-parser\
+        \ is a simple GObject-based library to\\nparse a host of play-list formats,\
+        \ as well as save those.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"xplayer-plparser\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1424851\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Xplayer play-list parser\",\n\
+        \      \"upstream_url\": \"https://github.com/linuxmint/xplayer-plparser\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1487684911.0,\n\
+        \      \"description\": \"Xviewer is a simple graphics viewer for the Cinnamon\
+        \ desktop and others\\nwhich uses the gdk-pixbuf library. It can deal with\
+        \ large images, and zoom\\nand scroll with constant memory usage. Its goals\
+        \ are simplicity and standards\\ncompliance.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"xviewer\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1424825\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast and functional\
+        \ graphics viewer\",\n      \"upstream_url\": \"https://github.com/linuxmint/xviewer\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1431104614.0,\n\
+        \      \"description\": \"Common scripts and templates for developing\\nand\
+        \ building YaST2 modules and components.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"yast2-devtools\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1218749\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"YaST Development\
+        \ Tools\",\n      \"upstream_url\": \"https://yast.github.io\"\n    },\n \
+        \   {\n      \"acls\": [],\n      \"creation_date\": 1431104648.0,\n     \
+        \ \"description\": \"\\nThis package holds the common filesystem-layout used\
+        \ by YaST2\\nand handles log-rotation for YaST2-logfiles.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"yast2-filesystem\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1218788\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"YaST filesystem layout\"\
+        ,\n      \"upstream_url\": \"https://en.opensuse.org/Portal:YaST\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1428851504.0,\n    \
+        \  \"description\": \"Graphical package tool for maintain packages on the\
+        \ system\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"yumex-dnf\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1210430\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Yum Extender graphical package management\
+        \ tool\",\n      \"upstream_url\": \"http://yumex.dk\"\n    }\n  ],\n  \"\
+        watch\": [\n    {\n      \"acls\": [],\n      \"creation_date\": 1401196663.0,\n\
+        \      \"description\": \"AntiMicro is a graphical program used to map keyboard\
+        \ keys and mouse controls\\nto a gamepad. This program is useful for playing\
+        \ PC games using a gamepad that\\ndo not have any form of built-in gamepad\
+        \ support. AntiMicro was inspired by\\nQJoyPad but has additional features.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"antimicro\",\n      \"namespace\": \"rpms\",\n      \"review_url\": \"\
+        https://bugzilla.redhat.com/1100961\",\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Graphical program used to map keyboard buttons and mouse\
+        \ controls to a gamepad\",\n      \"upstream_url\": \"https://github.com/AntiMicro/antimicro\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A simple OpenCL application that enumerates all\
+        \ possible platform and\\ndevice properties. Inspired by AMD's program of\
+        \ the same name, it is\\ncoded in pure C99 and it tries to output all possible\
+        \ information,\\nincluding that provided by platform-specific extensions,\
+        \ and not to\\ncrash on platform-unsupported properties (e.g. 1.2 properties\
+        \ on 1.1\\nplatforms).\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"clinfo\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Enumerate OpenCL platforms and devices\",\n      \"upstream_url\": \"\
+        https://github.com/Oblomov/clinfo\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"Gocl is\
+        \ a GLib/GObject based library that aims at simplifying the\\nuse of OpenCL\
+        \ in GNOME software. It is intended to be a lightweight\\nwrapper that adapts\
+        \ OpenCL programming patterns and boilerplate, and\\nexpose a simpler API\
+        \ that is known and comfortable to GNOME\\ndevelopers. Examples of such adaptations\
+        \ are the integration with\\nGLib\\u2019s main loop, exposing non-blocking\
+        \ APIs, GError based error\\nreporting and full gobject-introspection support.\
+        \ It will also be\\nincluding convenient API to simplify code for the most\
+        \ common use\\npatterns.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"gocl\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"GLib/GObject based library for OpenCL\",\n      \"upstream_url\": \"https://github.com/elima/gocl/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Fully functional Python wrapper for libarchive.\
+        \ Created using SWIG. The\\nlow-level API provides access to all of the functionality\
+        \ of libarchive.\\n\\nThe package also includes a high level python library\
+        \ which mimics the zipfile\\nand tarfile modules.\\n\\nLibarchive supports\
+        \ the following:\\n\\n- Reads a variety of formats, including tar, pax, cpio,\
+        \ zip, xar, lha, ar, cab,\\n  mtree, rar, and ISO images.\\n\\n- Writes tar,\
+        \ pax, cpio, zip, xar, ar, ISO, mtree, and shar archives.\\n\\n- Automatically\
+        \ handles archives compressed with gzip, bzip2, lzip, xz, lzma,\\n  or compress.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"python-libarchive\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Fully functional\
+        \ Python wrapper for libarchive\",\n      \"upstream_url\": \"http://code.google.com/p/python-libarchive/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is a tool that uses SQLAlchemy to execute SQL\
+        \ queries against a SQL\\ndatabase specified via a URL or an INI-style file\
+        \ (such as those used by most\\nof the OpenStack services).\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"sqlcli\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"A command-line SQL query utility\",\n  \
+        \    \"upstream_url\": \"http://github.com/larsks/sqlcli/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Vicious widget types are a framework for creating your own awesome widgets.\\\
+        nVicious contains modules that gather data about your system, and a few helper\\\
+        nfunctions that make it easier to register timers, suspend widgets and so\
+        \ on.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n  \
+        \    \"name\": \"vicious\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Modular widget\
+        \ library for awesome\",\n      \"upstream_url\": \"http://git.sysphere.org/vicious/\"\
+        \n    }\n  ]\n}"}
+    headers:
+      accept-ranges: [bytes]
+      age: ['0']
+      appserver: [proxy14.fedoraproject.org]
+      apptime: [D=992847]
+      connection: [Keep-Alive]
+      content-length: ['102398']
+      content-type: [application/json]
+      date: ['Wed, 29 Mar 2017 20:21:18 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['pkgdb=eyJfcGVybWFuZW50Ijp0cnVlfQ.C72ovg.z9xucNAb-AmAfX6J1CtdHryCBxw;
+          Expires=Wed, 29-Mar-2017 21:21:18 GMT; Secure; HttpOnly; Path=/pkgdb/']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['7643800']
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_generic.UserPackageFilterTests.test_namespaces
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_generic.UserPackageFilterTests.test_namespaces
@@ -1,0 +1,2393 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.12.5]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/packager/package/ralph
+  response:
+    body: {string: !!python/unicode "{\n  \"co-maintained\": [\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1490708185.0,\n      \"description\": \"A\
+        \ client/server for the Network Time Protocol, this program keeps your computer's\
+        \ clock accurate. It was specially designed to support systems with intermittent\
+        \ internet connections, but it also works well in permanently connected environments.\
+        \ It can use also hardware reference clocks, system real-time clock or manual\
+        \ input as time references.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": false,\n      \"name\": \"chronyd\",\n      \"namespace\": \"modules\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"An NTP client/server\",\n  \
+        \    \"upstream_url\": \"\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1489496670.0,\n      \"description\": \"The container-runtime\
+        \ module.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"container-runtime\",\n      \"namespace\": \"modules\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"The container-runtime module\"\
+        ,\n      \"upstream_url\": \"https://github.com/container-images/container-runtime\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A webapp to retrieve historical information about\
+        \ messages on the fedmsg\\nbus.  It is a JSON api for the datanommer message\
+        \ store.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"datagrepper\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        A webapp to query fedmsg history\",\n      \"upstream_url\": \"https://github.com/fedora-infra/datagrepper\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is datanommer.  It is comprised of only a fedmsg\
+        \ consumer that\\nstuffs every message in a sqlalchemy database.\\n\\nThere\
+        \ are also a handful of CLI tools to dump information from the\\ndatabase.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"datanommer\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A storage consumer\
+        \ for the Fedora Message Bus (fedmsg)\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/datanommer\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Console commands for datanommer.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"datanommer-commands\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Console commands for datanommer\",\n\
+        \      \"upstream_url\": \"https://pypi.io/project/datanommer.commands\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490713995.0,\n\
+        \      \"description\": \"The list of minimal set of debugging tools except\
+        \ base-runtime.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"debugging-tools\",\n      \"namespace\": \"modules\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/1419506\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Set of debugging tools so I\
+        \ can troubleshoot my running server.\",\n      \"upstream_url\": \"\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490708638.0,\n\
+        \      \"description\": \"DHCP (Dynamic Host Configuration Protocol) is a\
+        \ protocol which allows individual devices on an IP network to get their own\
+        \ network configuration information (IP address, subnetmask, broadcast address,\
+        \ etc.) from a DHCP server. The overall purpose of DHCP is to make it easier\
+        \ to administer a large network.\",\n      \"koschei_monitor\": true,\n  \
+        \    \"monitor\": false,\n      \"name\": \"dhcp\",\n      \"namespace\":\
+        \ \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Provides the ISC\
+        \ DHCP server\",\n      \"upstream_url\": \"\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1490729345.0,\n      \"description\": \"DHCP\
+        \ (Dynamic Host Configuration Protocol) is a protocol which allows individual\
+        \ devices on an IP network to get their own network configuration information\
+        \ (IP address, subnetmask, broadcast address, etc.) from a DHCP server. The\
+        \ overall purpose of DHCP is to make it easier to administer a large network.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"dhcp-server\",\n      \"namespace\": \"modules\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1419506\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Provides the ISC DHCP server\",\n      \"upstream_url\"\
+        : \"\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490713980.0,\n\
+        \      \"description\": \"Dovecot is an IMAP server for Linux/UNIX-like systems,\
+        \ written with security primarily in mind.  It also contains a small POP3\
+        \ server.  It supports mail in either of maildir or mbox formats.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"dovecot\",\n      \"namespace\": \"modules\",\n      \"review_url\": \"\
+        https://bugzilla.redhat.com/1419506\",\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Secure imap and pop3 server\",\n      \"upstream_url\"\
+        : \"\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Python API used around Fedora Infrastructure to\
+        \ send and receive messages with\\nzeromq.  Includes some CLI tools.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"fedmsg\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Tools for Fedora Infrastructure\
+        \ real-time messaging\",\n      \"upstream_url\": \"http://github.com/fedora-infra/fedmsg\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The GeoLite databases are free IP geolocation databases.\\\
+        n\\nThe GeoLite databases are distributed under the Creative Commons\\nAttribution-ShareAlike\
+        \ 3.0 Unported License. The attribution requirement may\\nbe met by including\
+        \ the following in all advertising and documentation\\nmentioning features\
+        \ of or use of this database: \\\"This product includes\\nGeoLite data created\
+        \ by MaxMind, available from http://www.maxmind.com\\\".\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"geoip-geolite\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Free IP geolocation databases\",\n \
+        \     \"upstream_url\": \"http://dev.maxmind.com/geoip/geolite\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1441891053.0,\n    \
+        \  \"description\": \"gilmsg layers a reliability check in-band on top of\
+        \ the existing PUB-SUB fedmsg\\nframework.\\n\\nHere's how it works, broadly:\\\
+        n\\n- When ``gilmsg.publish(...)`` is invoked, you must declare a list of\
+        \ required\\n  recipients.\\n- A background thread is started that listens\
+        \ for ACK messages on\\n  the whole bus.\\n- If an ACK is not received from\
+        \ all ``recipients`` within a given timeout,\\n  then a ``Timeout`` exception\
+        \ is raised.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"gilmsg\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1261547\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A reliability layer on top of fedmsg\",\n      \"\
+        upstream_url\": \"http://pypi.python.org/pypi/gilmsg\"\n    },\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"A collection of Git extensions to provide high-level repository operations\\\
+        nfor Vincent Driessen's [branching model](http://nvie.com/git-model \\\"original\\\
+        nblog post\\\").\\n\\nFor the best introduction to get started with `git flow`,\
+        \ please read Jeff\\nKreeftmeijer's blog post:\\n\\n  http://jeffkreeftmeijer.com/2010/why-arent-you-using-git-flow/\\\
+        n\\nOr have a look at one of these screen casts:\\n\\n* [A short introduction\
+        \ to git-flow]\\n  (http://vimeo.com/16018419) (by Mark Derricutt)\\n* [On\
+        \ the path with git-flow]\\n  (http://codesherpas.com/screencasts/on_the_path_gitflow.mov)\
+        \ (by Dave Bock)\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"gitflow\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Extensions providing operations for V. Driessen's branching model\",\n\
+        \      \"upstream_url\": \"https://github.com/nvie/gitflow\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1404216091.0,\n      \"\
+        description\": \"It is a web application that monitors GitHub repositories\
+        \ you subscribe it to.\\nWhen new actions (commits, pull-request, tickets)\
+        \ are made, it broadcasts a\\nmessage on the fedmsg message bus.\\n\\nIt is\
+        \ written in Python on the Pyramid framework, and uses velruse to talk with\\\
+        nGitHub.  It adds a webhook callback back to itself on repositories you ask\
+        \ it\\nto monitor.  When one of those callbacks fire, github2fedmsg republishes\
+        \ the\\nmessage it receives to the fedmsg bus.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"github2fedmsg\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1078327\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Pubsubhubbub app\
+        \ that rebroadcasts GH events over fedmsg\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/github2fedmsg\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490707824.0,\n\
+        \      \"description\": \"HAProxy is a TCP/HTTP reverse proxy which is particularly\
+        \ suited for high availability environments.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"haproxy\",\n      \"\
+        namespace\": \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"HAProxy reverse proxy\
+        \ for high availability environments\",\n      \"upstream_url\": \"\"\n  \
+        \  },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"HTTPie is a CLI HTTP utility built out of frustration\
+        \ with existing tools. The\\ngoal is to make CLI interaction with HTTP-based\
+        \ services as human-friendly as\\npossible.\\n\\nHTTPie does so by providing\
+        \ an http command that allows for issuing arbitrary\\nHTTP requests using\
+        \ a simple and natural syntax and displaying colorized\\nresponses.\",\n \
+        \     \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"httpie\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"A Curl-like tool for\
+        \ humans\",\n      \"upstream_url\": \"http://httpie.org/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This program is an \\\"inotify cron\\\" system.\\nIt consists of a daemon\
+        \ and a table manipulator.\\nYou can use it a similar way as the regular cron.\\\
+        nThe difference is that the inotify cron handles\\nfilesystem events rather\
+        \ than time periods.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : \"nobuild\",\n      \"name\": \"incron\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Inotify cron system\",\n      \"upstream_url\": \"https://github.com/ar-/incron\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Publish notifications about mails to the fedmsg\
+        \ bus.\\n\\nEnable this by adding the following to your mailman.cfg file::\\\
+        n\\n    [archiver.fedmsg]\\n    \\n    class: mailman_fedmsg_plugin.Archiver\\\
+        n    enable: yes\\n\\nYou can exclude certain lists from fedmsg publication\
+        \ by\\nadding them to a 'mailman.excluded_lists' list in /etc/fedmsg.d/::\\\
+        n\\n    config = {\\n        'mailman.excluded_lists': ['bugzilla', 'commits'],\\\
+        n    }\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"mailman3-fedmsg-plugin\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Emit fedmsg messages from mailman3\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/mailman3-fedmsg-plugin\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1490713384.0,\n      \"description\"\
+        : \"MariaDB is a multi-user, multi-threaded SQL database server. It is a client/server\
+        \ implementation consisting of a server daemon (mysqld) and many different\
+        \ client programs and libraries. The base package contains the standard MariaDB/MySQL\
+        \ client programs and generic MySQL files.\",\n      \"koschei_monitor\":\
+        \ true,\n      \"monitor\": false,\n      \"name\": \"mariadb\",\n      \"\
+        namespace\": \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"MariaDB is a community\
+        \ developed branch of MySQL.\",\n      \"upstream_url\": \"\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1490707343.0,\n      \"\
+        description\": \"memcached is a high-performance, distributed memory object\
+        \ caching system, generic in nature, but intended for use in speeding up dynamic\
+        \ web applications by alleviating database load.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"memcached\",\n     \
+        \ \"namespace\": \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"High Performance,\
+        \ Distributed Memory Object Cache\",\n      \"upstream_url\": \"\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1479303094.0,\n    \
+        \  \"description\": \"A python library for manipulation of the proposed module\
+        \ metadata format.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"modulemd\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/1376035\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Module metadata manipulation library\"\
+        ,\n      \"upstream_url\": \"https://pagure.io/modulemd\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Moksha is a platform for creating real-time collaborative web applications.\
+        \  It\\nprovides a set of Python and JavaScript API's that make it simple\
+        \ to create\\nrich applications that can acquire, manipulate, and visualize\
+        \ data from\\nexternal services. It is a unified framework build using the\
+        \ best available\\nopen source technologies such as TurboGears2, jQuery, AMQP,\
+        \ and Orbited.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"moksha\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A platform\
+        \ for creating real-time web applications\",\n      \"upstream_url\": \"https://fedorahosted.org/moksha\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490713285.0,\n\
+        \      \"description\": \"Mongo (from \\\"humongous\\\") is a high-performance,\
+        \ open source, schema-free document-oriented database.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"mongodb\",\n      \"\
+        namespace\": \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"High-performance,\
+        \ schema-free document-oriented database\",\n      \"upstream_url\": \"\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1433305549.0,\n\
+        \      \"description\": \"A Meetbot log wrangler, providing a user-friendly\
+        \ interface for\\nFedora Project's logs. mote allows contributors to the Fedora\
+        \ Project to\\nquickly search and find logs beneficial in keeping up to date\
+        \ with the\\nproject's activities.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"mote\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1225249\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A MeetBot log wrangler,\
+        \ providing a user-friendly interface for Fedora's logs\",\n      \"upstream_url\"\
+        : \"https://github.com/fedora-infra/mote\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1490708490.0,\n      \"description\": \"The\
+        \ nfs-utils package provides a daemon for the kernel NFS server and related\
+        \ tools, which provides a much higher level of performance than the traditional\
+        \ Linux NFS server used by most users.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"nfs-server\",\n      \"namespace\"\
+        : \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"NFS utilities and\
+        \ supporting clients and daemons for the kernel NFS server\",\n      \"upstream_url\"\
+        : \"\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490709247.0,\n\
+        \      \"description\": \"Node.js is a platform built on Chrome's JavaScript\
+        \ runtime for easily building fast, scalable network applications. Node.js\
+        \ uses an event-driven, non-blocking I/O model that makes it lightweight and\
+        \ efficient, perfect for data-intensive real-time applications that run across\
+        \ distributed devices.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"nodejs\",\n      \"namespace\": \"modules\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/1419506\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"JavaScript runtime\",\n    \
+        \  \"upstream_url\": \"\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\"\
+        : 1400070978.0,\n      \"description\": \"Fast system for indexing, searching,\
+        \ and tagging email.  Even if you\\nreceive 12000 messages per month or have\
+        \ on the order of millions of\\nmessages that you've been saving for decades,\
+        \ Notmuch will be able to\\nquickly search all of it.\\n\\nNotmuch is not\
+        \ much of an email program. It doesn't receive messages\\n(no POP or IMAP\
+        \ support). It doesn't send messages (no mail composer,\\nno network code\
+        \ at all). And for what it does do (email search) that\\nwork is provided\
+        \ by an external library, Xapian. So if Notmuch\\nprovides no user interface\
+        \ and Xapian does all the heavy lifting, then\\nwhat's left here? Not much.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"notmuch\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"System for indexing,\
+        \ searching, and tagging email\",\n      \"upstream_url\": \"http://notmuchmail.org/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490714018.0,\n\
+        \      \"description\": \"The Network Time Protocol (NTP) is used to synchronize\
+        \ a computer's time with another reference time source. This package includes\
+        \ ntpd (a daemon which continuously adjusts system time) and utilities used\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"ntp\",\n      \"namespace\": \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"The NTP daemon and\
+        \ utilities\",\n      \"upstream_url\": \"\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1490709000.0,\n      \"description\": \"Perl\
+        \ is a high-level programming language with roots in C, sed, awk and shell\
+        \ scripting.  Perl is good at handling processes and files, and is especially\
+        \ good at handling text. Perl's hallmarks are practicality and efficiency.\
+        \ While it is used to do a lot of different things, Perl's most common applications\
+        \ are system administration utilities and web programming.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"perl\",\n      \"namespace\"\
+        : \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Practical Extraction\
+        \ and Report Language\",\n      \"upstream_url\": \"\"\n    },\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1490707940.0,\n      \"description\"\
+        : \"PHP is an HTML-embedded scripting language. PHP attempts to make it easy\
+        \ for developers to write dynamically generated web pages. PHP also offers\
+        \ built-in database integration for several commercial and non-commercial\
+        \ database management systems, so writing a database-enabled webpage with\
+        \ PHP is fairly simple. The most common use of PHP coding is probably as a\
+        \ replacement for CGI scripts.\",\n      \"koschei_monitor\": true,\n    \
+        \  \"monitor\": false,\n      \"name\": \"php\",\n      \"namespace\": \"\
+        modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"PHP scripting language\
+        \ for creating dynamic web sites\",\n      \"upstream_url\": \"\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"ZeroMQ is a software library that lets you quickly design\
+        \ and implement\\na fast message-based applications.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"php-zmq\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"ZeroMQ messaging\",\n      \"upstream_url\"\
+        : \"http://pecl.php.net/package/zmq\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"Pronounced\
+        \ \\\"package WAT\\\", pkgwat is a fast CLI tool for querying the fedora\\\
+        npackages webapp.  https://apps.fedoraproject.org/packages/\\n\\nYou can make\
+        \ its search even better by helping us tag packages.\\nhttps://apps.fedoraproject.org/tagger\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"pkgwat\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"CLI tool for querying\
+        \ the fedora packages webapp\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/pkgwat.cli\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490708041.0,\n\
+        \      \"description\": \"Postfix is a Mail Transport Agent (MTA).\",\n  \
+        \    \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"postfix\",\n      \"namespace\": \"modules\",\n      \"review_url\": \"\
+        https://bugzilla.redhat.com/1419506\",\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Postfix Mail Transport Agent\",\n      \"upstream_url\"\
+        : \"\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490708752.0,\n\
+        \      \"description\": \"PostgreSQL is an advanced Object-Relational database\
+        \ management system (DBMS). The base postgresql package contains the client\
+        \ programs that you'll need to access a PostgreSQL DBMS server, as well as\
+        \ HTML documentation for the whole system. These client programs can be located\
+        \ on the same machine as the PostgreSQL server, or on a remote machine that\
+        \ accesses a PostgreSQL server over a network connection. The PostgreSQL server\
+        \ can be found in the postgresql-server sub-package.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"postgresql\",\n    \
+        \  \"namespace\": \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"PostgreSQL client\
+        \ programs\",\n      \"upstream_url\": \"\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1490709389.0,\n      \"description\": \"Python\
+        \ is an interpreted, interactive, object-oriented programming language often\
+        \ compared to Tcl, Perl, Scheme or Java. Python includes modules, classes,\
+        \ exceptions, very high level dynamic data types and dynamic typing. Python\
+        \ supports interfaces to many system calls and libraries, as well as to various\
+        \ windowing systems (X11, Motif, Tk, Mac and MFC).\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"python\",\n      \"\
+        namespace\": \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An interpreted, interactive,\
+        \ object-oriented programming language\",\n      \"upstream_url\": \"\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Alembic is a new database migrations tool, written\
+        \ by the author of\\nSQLAlchemy.  A migrations tool offers the following functionality:\\\
+        n\\n* Can emit ALTER statements to a database in order to change the structure\\\
+        n  of tables and other constructs.\\n* Provides a system whereby \\\"migration\
+        \ scripts\\\" may be constructed; each script\\n  indicates a particular series\
+        \ of steps that can \\\"upgrade\\\" a target database\\n  to a new version,\
+        \ and optionally a series of steps that can \\\"downgrade\\\"\\n  similarly,\
+        \ doing the same steps in reverse.\\n* Allows the scripts to execute in some\
+        \ sequential manner.\\n\\nDocumentation and status of Alembic is at http://readthedocs.org/docs/alembic/\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-alembic\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Database migration\
+        \ tool for SQLAlchemy\",\n      \"upstream_url\": \"https://pypi.io/project/alembic\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A generic interface wrapping multiple different\
+        \ backends to provide a\\nconsistent key-value storage API. This library is\
+        \ intended to be used by\\nother libraries that require some form of generic\
+        \ storage.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-anykeystore\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"A key-value store supporting multiple backends\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/anykeystore\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1446824272.0,\n      \"description\": \"If\
+        \ you want to parse AppStream files in Python you probably should\\njust install\
+        \ libappstream-glib, and use the GObjectIntrospection bindings\\nfor that.\
+        \ AppStreamGlib is a much better library than this and handles\\nmany more\
+        \ kinds of component.\\n\\nIf AppStreamGlib is not available to you (e.g.\
+        \ you're trying to run in an\\nOpenShift instance on RHEL 6.2), this project\
+        \ might be somewhat useful.\",\n      \"koschei_monitor\": false,\n      \"\
+        monitor\": true,\n      \"name\": \"python-appstream\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1275057\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Parse AppStream files\
+        \ when you don't have libappstream-glib\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/python-appstream\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"\\nThe argparse module is an optparse-inspired command\
+        \ line parser that\\nimproves on optparse by:\\n * handling both optional\
+        \ and positional arguments\\n * supporting parsers that dispatch to sub-parsers\\\
+        n * producing more informative usage messages\\n * supporting actions that\
+        \ consume any number of command-line args\\n * allowing types and actions\
+        \ to be specified with simple callables\\n    instead of hacking class attributes\
+        \ like STORE_ACTIONS or CHECK_METHODS\\n\\nas well as including a number of\
+        \ other more minor improvements on the\\noptparse API.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-argparse\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Optparse inspired command line parser\
+        \ for Python\",\n      \"upstream_url\": \"http://code.google.com/p/argparse/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Arrow is a Python library that offers a sensible,\
+        \ human-friendly approach to\\ncreating, manipulating, formatting and converting\
+        \ dates, times, and timestamps.\\n\\nIt implements and updates the datetime\
+        \ type, plugging gaps in functionality,\\nand provides an intelligent module\
+        \ API that supports many common creation\\nscenarios.\\n\\nSimply put, it\
+        \ helps you work with dates and times with fewer imports and a lot\\nless\
+        \ code.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-arrow\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Better dates and times for Python\",\n      \"upstream_url\": \"https://pypi.io/project/arrow\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"An askbot plugin for sending messages across the\
+        \ Fedora Infrastructure\\nmessage bus.  This plugin hooks itself up to django\
+        \ signals sent by askbot\\nand simply republishes information to the fedmsg\
+        \ bus.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n \
+        \     \"name\": \"python-askbot-fedmsg\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Askbot plugin for emitting events to the Fedora message bus\",\n     \
+        \ \"upstream_url\": \"http://pypi.python.org/pypi/askbot-fedmsg\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"backlash is a standalone version of the Werkzeug Debugger\
+        \ based on WebOb\\nadapted to support for Python3.\\n\\nbacklash has born\
+        \ as a future replacement for WebError in upcoming TurboGears2\\nversions.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-backlash\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Standalone\
+        \ WebOb port of the Werkzeug Debugger\",\n      \"upstream_url\": \"https://pypi.io/project/backlash\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is a backport of the \\\"lzma\\\" module included\
+        \ in Python 3.3 or later by\\nNadeem Vawda and Per Oyvind Karlsen, which provides\
+        \ a Python wrapper for XZ\\nUtils (aka LZMA Utils v2) by Igor Pavlov.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"python-backports-lzma\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Backport of\
+        \ Python 3.3's lzma module\",\n      \"upstream_url\": \"https://github.com/peterjc/backports.lzma\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The Secure Sockets layer is only actually secure\
+        \ if you check the hostname in\\nthe certificate returned by the server to\
+        \ which you are connecting, and verify\\nthat it matches to hostname that\
+        \ you are trying to reach.\\n\\nBut the matching logic, defined in RFC2818,\
+        \ can be a bit tricky to implement on\\nyour own. So the ssl package in the\
+        \ Standard Library of Python 3.2 now includes\\na match_hostname() function\
+        \ for performing this check instead of requiring\\nevery application to implement\
+        \ the check separately.\\n\\nThis backport brings match_hostname() to users\
+        \ of earlier versions of Python.\\nThe actual code is only slightly modified\
+        \ from Python 3.5.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"python-backports-ssl_match_hostname\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"The ssl.match_hostname() function from\
+        \ Python 3\",\n      \"upstream_url\": \"https://bitbucket.org/brandon/backports.ssl_match_hostname\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Beautiful Soup is a Python HTML/XML parser designed\
+        \ for quick\\nturnaround projects like screen-scraping. Three features make\
+        \ it\\npowerful:\\n\\nBeautiful Soup won't choke if you give it bad markup.\\\
+        n\\nBeautiful Soup provides a few simple methods and Pythonic idioms for\\\
+        nnavigating, searching, and modifying a parse tree.\\n\\nBeautiful Soup automatically\
+        \ converts incoming documents to Unicode\\nand outgoing documents to UTF-8.\\\
+        n\\nBeautiful Soup parses anything you give it.\\n\\nValuable data that was\
+        \ once locked up in poorly-designed websites is\\nnow within your reach. Projects\
+        \ that would have taken hours take only\\nminutes with Beautiful Soup.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-beautifulsoup4\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"HTML/XML parser\
+        \ for quick-turnaround applications like screen-scraping\",\n      \"upstream_url\"\
+        : \"http://www.crummy.com/software/BeautifulSoup/\"\n    },\n    {\n     \
+        \ \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"A moksha consumer that listens to bugzilla over STOMP and reproduces messages\\\
+        non a fedmsg bus.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"python-bugzilla2fedmsg\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Consume BZ messages over STOMP and republish to fedmsg\"\
+        ,\n      \"upstream_url\": \"http://pypi.python.org/pypi/bugzilla2fedmsg\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Chai provides a very easy to use api for mocking/stubbing\
+        \ your python\\nobjects, patterned after the `Mocha <http://mocha.rubyforge.org/>`_\
+        \ library\\nfor Ruby.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-chai\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Easy to use mocking/stub/spy framework\",\n      \"upstream_url\": \"\
+        http://pypi.python.org/pypi/chai\"\n    },\n    {\n      \"acls\": [],\n \
+        \     \"creation_date\": 1400070978.0,\n      \"description\": \"Chameleon\
+        \ is an XML attribute language template compiler. It comes with\\nimplementations\
+        \ for the Zope Page Templates (ZPT) and Genshi templating\\nlanguages.\\n\\\
+        nThe engine compiles templates into Python byte-code. This results in\\nperformance\
+        \ which is on average 10-15 times better than implementations which\\nuse\
+        \ run-time interpretation.\",\n      \"koschei_monitor\": false,\n      \"\
+        monitor\": true,\n      \"name\": \"python-chameleon\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"XML-based template compiler\",\n      \"upstream_url\"\
+        : \"https://github.com/malthe/chameleon\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ is a small package containing a Sphinx theme named \\\"Cloud\\\",\\nalong\
+        \ with some related Sphinx extensions. To see an example\\nof the theme in\
+        \ action, check out it's documentation\\nat http://packages.python.org/cloud_sptheme.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-cloud-sptheme\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        A nice sphinx theme named 'Cloud', and some related extensions\",\n      \"\
+        upstream_url\": \"http://pypi.python.org/pypi/cloud_sptheme\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"Enhancements for standard library's cmd module.\\n\\nDrop-in\
+        \ replacement adds several features for command-prompt tools:\\n\\n * Searchable\
+        \ command history (commands: \\\"hi\\\", \\\"li\\\", \\\"run\\\")\\n * Load\
+        \ commands from file, save to file, edit commands in file\\n * Multi-line\
+        \ commands\\n * Case-insensitive commands\\n * Special-character shortcut\
+        \ commands (beyond cmd's \\\"@\\\" and \\\"!\\\")\\n * Settable environment\
+        \ parameters\\n * Parsing commands with flags\\n * > (filename), >> (filename)\
+        \ redirect output to file\\n * < (filename) gets input from file\\n * bare\
+        \ >, >>, < redirect to/from paste buffer\\n * accepts abbreviated commands\
+        \ when unambiguous\\n * `py` enters interactive Python console\\n * test apps\
+        \ against sample session transcript (see example/example.py)\\n\\nUsable without\
+        \ modification anywhere cmd is used; simply import cmd2.Cmd\\nin place of\
+        \ cmd.Cmd.\\n\\nSee docs at http://packages.python.org/cmd2/\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\": \"python-cmd2\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Extra features for standard library's\
+        \ cmd module\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/cmd2\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"An extensible package which can be used to:\\n\\\
+        n- deserialize and validate a data structure composed of strings, mappings,\\\
+        n  and lists.\\n- serialize an arbitrary data structure to a data structure\
+        \ composed of\\n  strings, mappings, and lists.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-colander\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A simple schema-based serialization\
+        \ and deserialization library\",\n      \"upstream_url\": \"https://pypi.python.org/pypi/colander\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Generalization of dispatch mechanism for use across\
+        \ frameworks.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-crank\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Generalization of dispatch mechanism for use across frameworks\",\n  \
+        \    \"upstream_url\": \"https://pypi.io/project/crank\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Cssselect parses CSS3 Selectors and translates them to XPath 1.0 expressions.\\\
+        nSuch expressions can be used in lxml or another XPath engine to find the\\\
+        nmatching elements in an XML or HTML document.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-cssselect\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Parses CSS3 Selectors and translates\
+        \ them to XPath 1.0\",\n      \"upstream_url\": \"https://github.com/scrapy/cssselect\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This library implements the well-behaved daemon\
+        \ specification of PEP 3143,\\n\\\"Standard daemon process library\\\".\\\
+        n\\nThis is the python2 version of the library.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-daemon\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Library to implement a well-behaved\
+        \ Unix daemon process\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/python-daemon/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Hub consumer plugin for datanommer.\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\": \"python-datanommer-consumer\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Hub consumer plugin for datanommer\"\
+        ,\n      \"upstream_url\": \"https://pypi.io/project/datanommer.consumer\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"SQLAlchemy models for datanommer.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-datanommer-models\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"SQLAlchemy models for datanommer\",\n\
+        \      \"upstream_url\": \"https://pypi.io/project/datanommer.models\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The aim of the decorator module is to simplify the\
+        \ usage of decorators for\\nthe average programmer, and to popularize decorators\
+        \ usage giving examples\\nof useful decorators, such as memoize, tracing,\
+        \ redirecting_stdout, locked,\\netc.  The core of this module is a decorator\
+        \ factory called decorator.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": true,\n      \"name\": \"python-decorator\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Module to simplify usage of decorators\",\n      \"\
+        upstream_url\": \"https://github.com/micheles/decorator\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1477580690.0,\n      \"description\"\
+        : \"django-jsonfield is a reusable Django field that allows you to store validated\\\
+        nJSON in your model. It silently takes care of serialization. To use, simply\\\
+        nadd the field to one of your models.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-django-jsonfield\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1375222\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A reusable Django\
+        \ field that allows you to store validated JSON in your model\",\n      \"\
+        upstream_url\": \"https://github.com/bradjasper/django-jsonfield\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"django-longerusername provides a migration and a monkeypatch\
+        \ to make\\nthe django auth.user username field longer, instead of the arbitrarily\\\
+        nshort 30 characters.\\n\\nIt's designed to be a simple include-and-forget\
+        \ project that makes a\\nlittle headache go away.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-django-longerusername\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Make django auth.user username field\
+        \ longer\",\n      \"upstream_url\": \"https://github.com/GoodCloud/django-longer-username\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"django-tinymce is a Django application that contains\
+        \ a widget to render\\na form field as a TinyMCE editor.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-django-tinymce\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Django widget to render a form field\
+        \ as a TinyMCE editor\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/django-tinymce\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Dogpile consists of two subsystems, one building\
+        \ on top of the other.\\n\\ndogpile provides the concept of a \\\"dogpile\
+        \ lock\\\", a control structure\\nwhich allows a single thread of execution\
+        \ to be selected as the\\n\\\"creator\\\" of some resource, while allowing\
+        \ other threads of execution to\\nrefer to the previous version of this resource\
+        \ as the creation proceeds;\\nif there is no previous version, then those\
+        \ threads block until the\\nobject is available.\\n\\ndogpile.cache is a caching\
+        \ API which provides a generic interface to\\ncaching backends of any variety,\
+        \ and additionally provides API hooks\\nwhich integrate these cache backends\
+        \ with the locking mechanism of\\ndogpile.\\n\\nOverall, dogpile.cache is\
+        \ intended as a replacement to the Beaker\\ncaching system, the internals\
+        \ of which are written by the same author.\\nAll the ideas of Beaker which\
+        \ \\\"work\\\" are re- implemented in\\ndogpile.cache in a more efficient\
+        \ and succinct manner, and all the cruft\\n(Beaker's internals were first\
+        \ written in 2005) relegated to the trash\\nheap.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-dogpile-cache\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A caching front-end based on the Dogpile\
+        \ lock\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/dogpile.cache\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A \\\"dogpile\\\" lock, one which allows a single\
+        \ thread to generate an expensive\\nresource while other threads use the \\\
+        \"old\\\" value, until the \\\"new\\\" value is\\nready.\\n\\nDogpile is basically\
+        \ the locking code extracted from the Beaker package,\\nfor simple and generic\
+        \ usage.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-dogpile-core\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"A 'dogpile' lock, typically used as a component of a larger caching solution\"\
+        ,\n      \"upstream_url\": \"http://pypi.python.org/pypi/dogpile.core\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"dtopts adds options to doctest examples while they\
+        \ are running. When\\nusing the doctest module it is often convenient to use\
+        \ the ELLIPSIS\\noption, which allows you to use ... as a wildcard. But you\
+        \ either have\\nto setup the test runner to use this option, or you must put\
+        \ #doctest:\\n+ELLIPSIS on every example that uses this feature. dtopt lets\
+        \ you enable\\nthis option globally from within a doctest, by doing:\\n>>>\
+        \ from dtopt import ELLIPSIS\",\n      \"koschei_monitor\": false,\n     \
+        \ \"monitor\": true,\n      \"name\": \"python-dtopt\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Add options to doctest examples while they are running\"\
+        ,\n      \"upstream_url\": \"http://pypi.python.org/pypi/dtopt/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1440603647.0,\n    \
+        \  \"description\": \"Programmatically open an editor, capture the result.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-editor\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1256353\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Programmatically open an editor, capture the result.\"\
+        ,\n      \"upstream_url\": \"https://github.com/fmoo/python-editor\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"fedbadges is the python module necessary to award\
+        \ Open Badges from\\nfedmsg bus activity.  It installs a 'consumer' for the\
+        \ fedmsg-hub.\\nEach message it receives is compared against any number of\
+        \ rules defined\\nin config files on disk.  If any match, badges are awarded\
+        \ to the\\nappropriate users.\",\n      \"koschei_monitor\": false,\n    \
+        \  \"monitor\": false,\n      \"name\": \"python-fedbadges\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"fedmsg consumer for awarding open badges\",\n      \"\
+        upstream_url\": \"http://pypi.python.org/pypi/fedbadges\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1410973073.0,\n      \"description\"\
+        : \"A service that listens to the Fedmsg bus and automatically uploads built\
+        \ Fedora\\ncloud images to internal and external cloud providers\",\n    \
+        \  \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\":\
+        \ \"python-fedimg\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1142446\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Automatically upload Fedora Cloud images to cloud\
+        \ providers\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/fedimg\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"An example of using fedmsg to monitor pkgdb for\
+        \ messages, but delaying action\\nfor a few seconds to accumulate messages\
+        \ and avoid pile-up.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"python-fedmsg-genacls\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"A fedmsg consumer that sets gitosis acls in response\
+        \ to pkgdb messages\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/fedmsg_genacls\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"fedmsg <http://fedmsg.com> is a set of tools for\
+        \ knitting together\\nservices and webapps into a realtime messaging net.\
+        \ This package contains\\nmetadata provider plugins for the Debian deployment\
+        \ of that system.\\n\\nIf you were to deploy fedmsg at another site, you would\
+        \ like want to write\\nyour own module like this one that could provide textual\
+        \ representations of\\nyour messages.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"python-fedmsg-meta-debian\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Metadata providers for Debian's fedmsg\
+        \ deployment\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/fedmsg_meta_debian\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"fedmsg <http://fedmsg.com> is a set of tools for\
+        \ knitting together\\nservices and webapps into a realtime messaging net.\
+        \  This package contains\\nmetadata provider plugins for the primary deployment\
+        \ of that system:\\nFedora Infrastructure <http://fedoraproject.org/wiki/Infrastructure>.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-fedmsg-meta-fedora-infrastructure\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Metadata providers for Fedora Infrastructure's fedmsg deployment\"\
+        ,\n      \"upstream_url\": \"http://pypi.python.org/pypi/fedmsg_meta_fedora_infrastructure\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This extension for the Flask micro web framework\
+        \ allows developers\\nto use Mako Templates instead of the default Jinja2\
+        \ templating engine.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-flask-mako\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Mako templating support for Flask applications\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/Flask-Mako\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1466010481.0,\n      \"description\": \"OpenID\
+        \ Connect support for Flask.\\nThis library should work with any standards\
+        \ compliant\\nOpenID Connect provider. It has been tested with:\\nGoogle+\
+        \ Login, Ipsilon\",\n      \"koschei_monitor\": true,\n      \"monitor\":\
+        \ true,\n      \"name\": \"python-flask-oidc\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1341839\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"An openID Connect support for\
+        \ Flask\",\n      \"upstream_url\": \"https://github.com/puiterwijk/flask-oidc\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1440041205.0,\n\
+        \      \"description\": \"Flask-RESTful is Python extension for Flask that\
+        \ adds support\\nfor quickly building REST APIs. It is a lightweight abstraction\\\
+        nthat works with your existing ORM/libraries.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-flask-restful\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1061732\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Simple framework\
+        \ for creating REST APIs for Flask\",\n      \"upstream_url\": \"https://www.github.com/flask-restful/flask-restful/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"fmn is a family of systems to manage end-user notifications\
+        \ triggered by\\nfedmsg, the Fedora FEDerated MESsage bus.\\n\\nThis module\
+        \ contains the backend worker daemon for Fedora Notifications.\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\": \"python-fmn-consumer\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Backend worker daemon for Fedora Notifications\"\
+        ,\n      \"upstream_url\": \"http://pypi.python.org/pypi/fmn.consumer\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"fmn is a family of systems to manage end-user notifications\
+        \ triggered by\\nfedmsg, the Fedora FEDerated MESsage bus.\\n\\nThis modules\
+        \ contains the internal API for components and data model for Fedora\\nNotifications\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-fmn-lib\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Internal API\
+        \ components and model for Fedora Notifications\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/fmn.lib\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"fmn\
+        \ is a family of systems to manage end-user notifications triggered by\\nfedmsg,\
+        \ the Fedora FEDerated MESsage bus.\\n\\nThis module contains the set of \\\
+        \"rules\\\" fmn uses to process messages.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-fmn-rules\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Message processing rules for Fedora Notifications\"\
+        ,\n      \"upstream_url\": \"http://pypi.python.org/pypi/fmn.rules\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"fmn is a family of systems to manage end-user notifications\
+        \ triggered by\\nfedmsg, the Fedora FEDerated MESsage bus.\\n\\nThis module\
+        \ contains the frontend web application for Fedora Notifications.\",\n   \
+        \   \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-fmn-web\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Frontend Web\
+        \ Application for Fedora Notifications\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/fmn.web\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"FormEncode validates and converts nested structures.\
+        \ It allows for a\\ndeclarative form of defining the validation, and decoupled\
+        \ processes\\nfor filling and generating forms.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-formencode\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"HTML form validation, generation, and\
+        \ convertion package\",\n      \"upstream_url\": \"http://formencode.org/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"freezegun is a library that allows your python tests\
+        \ to travel through time by\\nmocking the datetime module.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-freezegun\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Let your Python tests travel through\
+        \ time\",\n      \"upstream_url\": \"https://pypi.io/project/freezegun\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1449312264.0,\n\
+        \      \"description\": \"funcsigs is a backport of the PEP 362 function signature\
+        \ features from\\nPython 3.3's inspect module. The backport is compatible\
+        \ with Python 2.6, 2.7\\nas well as 3.2 and up.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-funcsigs\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1287899\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Python function signatures\
+        \ from PEP362 for Python 2.6, 2.7 and 3.2+\",\n      \"upstream_url\": \"\
+        https://github.com/testing-cabal/funcsigs?\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"gearbox\
+        \ is a paster command replacement for TurboGears2. It has been\\ncreated during\
+        \ the process of providing Python3 support to the TurboGears2\\nweb framework,\
+        \ while still being backward compatible with the existing\\nTurboGears projects.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-gearbox\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Command line\
+        \ toolkit born as a PasteScript replacement for TurboGears2\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/gearbox\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"HTTP\
+        \ request/response parser for Python compatible with Python 2.x\\n(>=2.5.4),\
+        \ Python 3 and Pypy. If possible a C parser based on\\nhttp-parser_ from Ryan\
+        \ Dahl will be used.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-http-parser\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n  \
+        \    \"summary\": \"HTTP request/response parser for Python\",\n      \"upstream_url\"\
+        : \"https://github.com/benoitc/http-parser/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1424771494.0,\n      \"description\": \"A\
+        \ Python implementation of JSON Web Token draft 01. This library provides\
+        \ a\\nmeans of representing signed content using JSON data structures, including\\\
+        nclaims to be transferred between two parties encoded as digitally signed\
+        \ and\\nencrypted JSON objects.\",\n      \"koschei_monitor\": false,\n  \
+        \    \"monitor\": true,\n      \"name\": \"python-jwt\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1194028\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"JSON Web Token implementation\
+        \ in Python\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/pyjwt\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Are you tired of the slow performance of Genshi?\
+        \ But you still long for the\\nassurance that your output is well-formed that\
+        \ you miss from all those\\nother templating engines? Do you wish you had\
+        \ Jinja's blocks with Genshi's\\nsyntax? Then look  no further, Kajiki is\
+        \ for you! Kajiki quickly compiles\\nGenshi-like syntax to *real python bytecode*\
+        \ that renders with blazing-fast\\nspeed! Don't delay! Pick up your copy of\
+        \ Kajiki today!\",\n      \"koschei_monitor\": false,\n      \"monitor\":\
+        \ true,\n      \"name\": \"python-kajiki\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Really fast well-formed xml templates\",\n      \"upstream_url\"\
+        : \"https://pypi.io/project/Kajiki\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"Lamson is\
+        \ a pure Python SMTP server designed to create robust and complex mail\\napplications\
+        \ in the style of modern web frameworks such as Django. Unlike\\ntraditional\
+        \ SMTP servers like Postfix or Sendmail, Lamson has all the features\\nof\
+        \ a web application stack (ORM, templates, routing, handlers, state machines,\\\
+        nPython) without needing to configure alias files, run new aliases, or juggle\\\
+        ntons of tiny fragile processes. Lamson also plays well with other web\\nframeworks\
+        \ and Python libraries.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-lamson\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"A modern Pythonic mail server\",\n      \"upstream_url\": \"\
+        http://pypi.python.org/pypi/lamson\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"The logutils\
+        \ package provides a set of handlers for the Python standard\\nlibrary's logging\
+        \ package.\\n\\nSome of these handlers are out-of-scope for the standard library,\
+        \ and so\\nthey are packaged here. Others are updated versions which have\
+        \ appeared in\\nrecent Python releases, but are usable with older versions\
+        \ of Python and so\\nare packaged here.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-logutils\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Logging utilities\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/logutils\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ package contains some extended functions which are not (yet)\\navailable\
+        \ in M2Crypto http://chandlerproject.org/Projects/MeTooCrypto>\\ntrunk.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"python-m2ext\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"M2Crypto Extensions\"\
+        ,\n      \"upstream_url\": \"http://pypi.python.org/pypi/m2ext\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Manuel lets you mix and match traditional doctests with\
+        \ custom test\\nsyntax.  Several plug-ins are included that provide new test\
+        \ syntax.\\nYou can also create your own plug-ins.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-manuel\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Build tested documentation\",\n    \
+        \  \"upstream_url\": \"https://pypi.python.org/pypi/manuel\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"minimock is a simple library for doing Mock objects with\
+        \ doctest.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-minimock\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"The simplest possible mock library\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/MiniMock\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Common components for Moksha.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-moksha-common\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Common components for Moksha\",\n  \
+        \    \"upstream_url\": \"http://pypi.python.org/pypi/moksha.common\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Hub components for Moksha.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-moksha-hub\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Hub components for Moksha\",\n     \
+        \ \"upstream_url\": \"https://pypi.io/project/moksha.hub\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"WSGI components for Moksha.\",\n      \"koschei_monitor\": false,\n  \
+        \    \"monitor\": true,\n      \"name\": \"python-moksha-wsgi\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"WSGI components for Moksha\",\n      \"\
+        upstream_url\": \"http://pypi.python.org/pypi/moksha.wsgi\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1428953153.0,\n      \"description\"\
+        : \"munch is a fork of David Schoonover's **Bunch** package, providing similar\\\
+        nfunctionality. 99% of the work was done by him, and the fork was made\\nmainly\
+        \ for lack of responsiveness for fixes and maintenance on the original\\ncode.\\\
+        n\\nMunch is a dictionary that supports attribute-style access, a la\\nJavaScript.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-munch\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1210969\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A dot-accessible dictionary (a la JavaScript objects)\"\
+        ,\n      \"upstream_url\": \"https://pypi.io/project/munch\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1435061746.0,\n      \"\
+        description\": \"This is a python client module for accessing resources protected\
+        \ by OAuth 2.0\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-oauth2client\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/1228230\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Python client library for OAuth\
+        \ 2.0\",\n      \"upstream_url\": \"https://github.com/google/oauth2client\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"OAuthLib is a generic utility which implements the\
+        \ logic of OAuth without\\nassuming a specific HTTP request object or web\
+        \ framework. Use it to graft\\nOAuth client support onto your favorite HTTP\
+        \ library, or provider support\\nonto your favourite web framework. If you're\
+        \ a maintainer of such a\\nlibrary, write a thin veneer on top of OAuthLib\
+        \ and get OAuth support for\\nvery little effort.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"python-oauthlib\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An implementation of the OAuth request-signing\
+        \ logic\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/oauthlib\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This tool provides code to load WSGI applications\
+        \ and servers from\\nURIs; these URIs can refer to Python Eggs for INI-style\
+        \ configuration\\nfiles.  PasteScript provides commands to serve applications\
+        \ based on\\nthis configuration file.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-paste-deploy\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Load, configure, and compose WSGI applications\
+        \ and servers\",\n      \"upstream_url\": \"http://pythonpaste.org/deploy\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Python API for pkgwat\\nhttp://pypi.python.org/pypi/pkgwat.cli\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-pkgwat-api\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Python API\
+        \ for querying the fedora packages webapp\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/pkgwat.api\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A python svg graph plotting library.\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\": \"python-pygal\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A python svg graph plotting library\"\
+        ,\n      \"upstream_url\": \"https://pypi.io/project/pygal\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"Pure Python GeoIP API based on MaxMind's C-based Python API\\\
+        nbut the code itself is ported from the Pure PHP GeoIP API.\\n\\nCreate your\
+        \ GeoIP instance with appropriate access flag. `STANDARD` reads\\ndata from\
+        \ disk when needed, `MEMORY_CACHE` loads database into memory on\\ninstantiation\
+        \ and `MMAP_CACHE` loads database into memory using mmap.\\n\\n    import\
+        \ pygeoip\\n    gi = pygeoip.GeoIP('/usr/share/geoip/GeoIP.dat', pygeoip.MEMORY_CACHE)\\\
+        n\\nCountry lookup\\n\\n    >>> gi.country_code_by_name('google.com')\\n \
+        \   'US'\\n    >>> gi.country_code_by_addr('64.233.161.99')\\n    'US'\\n\
+        \    >>> gi.country_name_by_addr('64.233.161.99')\\n    'United States'\\\
+        n\\nCity lookup\\n\\n    >>> gi = pygeoip.GeoIP('/usr/share/geoip/GeoLiteCity.dat')\\\
+        n    >>> gi.record_by_addr('64.233.161.99')\\n    {\\n        'city': 'Mountain\
+        \ View',\\n        'region_name': 'CA',\\n        'area_code': 650,\\n   \
+        \     'longitude': -122.0574,\\n        'country_code3': 'USA',\\n       \
+        \ 'latitude': 37.419199999999989,\\n        'postal_code': '94043',\\n   \
+        \     'dma_code': 807,\\n        'country_code': 'US',\\n        'country_name':\
+        \ 'United States'\\n    }\\n    >>> gi.time_zone_by_addr('64.233.161.99')\\\
+        n    'America/Los_Angeles'\\n\\nFor more information, check out the full API\
+        \ documentation at\\nhttp://packages.python.org/pygeoip.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-pygeoip\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Pure Python GeoIP API\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/pygeoip\"\n    },\n    {\n      \"acls\":\
+        \ [],\n      \"creation_date\": 1458773973.0,\n      \"description\": \"A\
+        \ Markdown lexer for Pygments to highlight Markdown code snippets\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"python-pygments-markdown-lexer\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/1318781\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A Markdown lexer for Pygments to highlight\
+        \ Markdown code snippets\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/pygments-markdown-lexer\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PyLibravatar is an easy way to make use of the federated\
+        \ Libravatar\\navatar hosting service from within your Python applications.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-pylibravatar\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Python module for Libravatar\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/pyLibravatar\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"PyPNG allows PNG image files to be read and written\
+        \ using pure Python.\\n\\nIt's available from github.com https://github.com/drj11/pypng\\\
+        n\\nDocumentation is kindly hosted by PyPI http://pythonhosted.org/pypng/\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-pypng\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Pure Python\
+        \ PNG image encoder/decoder\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/pypng\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"python-pyquery allows you to make jQuery queries\
+        \ on XML documents. The API is\\nas much as possible the similar to jQuery.\
+        \ python-pyquery uses lxml for fast\\nXML and HTML manipulation.\",\n    \
+        \  \"koschei_monitor\": false,\n      \"monitor\": \"nobuild\",\n      \"\
+        name\": \"python-pyquery\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A jQuery-like\
+        \ library for python\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/pyquery\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Pyramid is a small, fast, down-to-earth, open source\
+        \ Python web development\\nframework. It makes real-world web application\
+        \ development and deployment more\\nfun, more predictable, and more productive.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-pyramid\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"The Pyramid\
+        \ web application framework, a Pylons project\",\n      \"upstream_url\":\
+        \ \"http://pylonsproject.com\"\n    },\n    {\n      \"acls\": [],\n     \
+        \ \"creation_date\": 1429027525.0,\n      \"description\": \"pyramid_fas_openid\
+        \ provides a view for the Pyramid framework that acts as\\nan OpenID consumer\
+        \ for the Fedora Account System.\",\n      \"koschei_monitor\": false,\n \
+        \     \"monitor\": true,\n      \"name\": \"python-pyramid-fas-openid\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1211382\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A view for pyramid\
+        \ that functions as an OpenID consumer\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/pyramid_fas_openid\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"These are bindings for the Mako templating system\
+        \ for the Pyramid web\\nframework.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"python-pyramid-mako\",\n   \
+        \   \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Mako template bindings for the Pyramid\
+        \ web framework\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/pyramid_mako\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"pyramid_tm is a package which allows Pyramid requests\
+        \ to join the\\nactive transaction as provided by the transaction\\nhttp://pypi.python.org/pypi/transaction\\\
+        n\\nSee http://docs.pylonsproject.org/projects/pyramid_tm/dev/\\nor docs/index.rst\
+        \ in this distribution for detailed documentation.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"python-pyramid-tm\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A package which allows Pyramid requests\
+        \ to join the active transaction\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/pyramid_tm\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"If you have ever been frustrated trying to debug\
+        \ with print because a web\\napplication or a unittesting framework is swallowing\
+        \ your debugging output,\\nq will make you jump for joy.\\n\\n  import q\\\
+        n  variable = 'Hmmm... something happened here'\\n  q(variable)\\n\\ncat /tmp/q\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-q\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Quick and dirty python\
+        \ debugging output\",\n      \"upstream_url\": \"https://pypi.python.org/pypi/q\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1423765005.0,\n\
+        \      \"description\": \"python-re2 is a Python extension that wraps Google's\
+        \ RE2 regular expression\\nlibrary.\\n\\nThis is Facebook's pyre2 Python extension\
+        \ that wraps Google's RE2 regular\\nexpression library. It implements many\
+        \ of the features of Python's built-in re\\nmodule with compatible interfaces.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-re2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1191808\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Python wrapper for Google's RE2 library\",\n     \
+        \ \"upstream_url\": \"https://github.com/facebook/pyre2\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This is a Python 2 interface to the Redis key-value store.\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\": \"python-redis\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Python 2 interface to the Redis key-value\
+        \ store\",\n      \"upstream_url\": \"http://github.com/andymccurdy/redis-py\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"repoze.lru is a LRU (least recently used) cache\
+        \ implementation. Keys and values\\nthat are not used frequently will be evicted\
+        \ from the cache faster than keys\\nand values that are used frequently.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-repoze-lru\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A tiny LRU\
+        \ cache implementation and decorator\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/repoze.lru\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"`repoze.what` is an `authorization framework` for\
+        \ WSGI applications,\\nbased on `repoze.who` (which deals with `authentication`).\\\
+        n\\nOn the one hand, it enables an authorization system based on the groups\
+        \ to\\nwhich the `authenticated or anonymous` user belongs and the permissions\
+        \ granted\\nto such groups by loading these groups and permissions into the\
+        \ request on the\\nway in to the downstream WSGI application.\\n\\nAnd on\
+        \ the other hand, it enables you to manage your groups and permissions\\nfrom\
+        \ the application itself or another program, under a backend-independent\\\
+        nAPI. For example, it would be easy for you to switch from one back-end to\\\
+        nanother, and even use this framework to migrate the data.\\n\\nIt's highly\
+        \ extensible, so it's very unlikely that it will get in your way.\\nAmong\
+        \ other things, you can extend it to check for many other conditions (such\\\
+        nas checking that the user comes from a given country, based on her IP address,\\\
+        nfor example).\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-repoze-what\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Authorization for WSGI applications\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/repoze.what\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Most existing Python modules for sending HTTP requests\
+        \ are extremely verbose and\\ncumbersome. Python\\u2019s built-in urllib2\
+        \ module provides most of the HTTP\\ncapabilities you should need, but the\
+        \ API is thoroughly broken. This library is\\ndesigned to make HTTP requests\
+        \ easy for developers.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-requests\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"HTTP library, written in Python, for human beings\",\n      \"\
+        upstream_url\": \"https://pypi.io/project/requests\"\n    },\n    {\n    \
+        \  \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Restkit is a full HTTP client using pure socket calls and its own\\nHTTP\
+        \ parser. It's not based on httplib or urllib2.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-restkit\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Restkit is an HTTP resource kit for\
+        \ Python\",\n      \"upstream_url\": \"http://benoitc.github.com/restkit/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1473802976.0,\n\
+        \      \"description\": \"A fedmsg consumer that automatically signs artifacts.\\\
+        n\\nRoboSignatory is composed of multiple consumers:\\n- TagConsumer is a\
+        \ consumer that listens for tags into a specific koji tag,\\n  then signs\
+        \ the build and moves it to a different koji tag.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-robosignatory\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1374982\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A fedmsg consumer\
+        \ that automatically signs artifacts\",\n      \"upstream_url\": \"https://pagure.io/robosignatory/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"python-sanction is a lightweight, dead simple client\
+        \ implementation of\\nthe OAuth2 protocol.\\n\\n- Variations on OAuth2 client\
+        \ implementation range from a few hundred LOC\\n  to thousands. In a Pythonic\
+        \ world, there's absolutely no need for this when\\n  simply dealing with\
+        \ the client side of the spec. Currently, sanction sits\\n  at a whopping\
+        \ 65 LOC, one class. This makes the library tremendously easy\\n  to grok.\\\
+        n\\n- Most providers have varying levels of diversion from the official spec.\\\
+        n  The goal with this library is to either handle these diversions natively,\\\
+        n  or expose a method to allow client code to deal with it efficiently and\\\
+        n  effectively.\\n\\n- Three of the four OAuth2 flows should be supported\
+        \ by this library.\\n  Currently, only authorization code and client credential\
+        \ flows have been\\n  tested due to lack of other (known) implementations.\\\
+        n\\nsanction has been tested with the following OAuth2 providers:\\n\\n* Facebook\
+        \ (include the test API)\\n* Google\\n* Foursquare\\n* bitly\\n* GitHub\\\
+        n* StackExchange\\n* Instagram\\n* DeviantArt\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-sanction\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A simple, lightweight OAuth2 client\"\
+        ,\n      \"upstream_url\": \"http://pypi.python.org/pypi/sanction\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"A Python module to simplify calling shell commands.\\\
+        nAlso known as PBS, or Python Bash Scripting.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-sh\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Python module to simplify calling shell\
+        \ commands\",\n      \"upstream_url\": \"https://github.com/amoffat/sh/\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Ripped from FormEncode and strainer just to support\
+        \ Pythons 2 and 3.\\nIntended for use in your webapp test suites.\\n\\nExample\
+        \ usage::\\n\\n    >>> from sieve.operators import eq_xml, in_xml\\n    >>>\
+        \ a = \\\"<foo><bar>Value</bar></foo>\\\"\\n    >>> b = \\\"\\\"\\\"\\n  \
+        \  ... <foo>\\n    ...     <bar>\\n    ...         Value\\n    ...     </bar>\\\
+        n    ... </foo>\\n    ... \\\"\\\"\\\"\\n    >>> eq_xml(a, b)\\n    True\\\
+        n    >>> c = \\\"<html><body><foo><bar>Value</bar></foo></body></html\\\"\\\
+        n    >>> in_xml(a, c)  # 'needle' in a 'haystack'\\n    True\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\": \"python-sieve\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"XML Comparison Utils\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/sieve\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"The module\
+        \ simplemediawiki is an extremely low-level wrapper to the MediaWiki\\nAPI.\
+        \ It automatically handles cookies and g zip compression so that you can\\\
+        nmake basic calls to the API in the easiest way possible. It also provides\
+        \ a\\nfew functions to make day-to-day API access easier.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-simplemediawiki\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Extremely low-level wrapper to the MediaWiki\
+        \ API\",\n      \"upstream_url\": \"https://github.com/ianweller/python-simplemediawiki\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Socket pool is a simple socket pool that supports\
+        \ multiple factories and\\nbackends. It can easily be used by gevent, eventlet\
+        \ or any other library.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-socketpool\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"A simple Python socket pool\",\n      \"upstream_url\": \"https://github.com/benoitc/socketpool\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"SQLAlchemy is an Object Relational Mappper (ORM)\
+        \ that provides a flexible,\\nhigh-level interface to SQL databases.  Database\
+        \ and domain concepts are\\ndecoupled, allowing both sides maximum flexibility\
+        \ and power. SQLAlchemy\\nprovides a powerful mapping layer that can work\
+        \ as automatically or as manually\\nas you choose, determining relationships\
+        \ based on foreign keys or letting you\\ndefine the join conditions explicitly,\
+        \ to bridge the gap between database and\\ndomain.\\n\\nThis package includes\
+        \ the python 2 version of the module.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"python-sqlalchemy0.8\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Modular and flexible ORM library for\
+        \ python\",\n      \"upstream_url\": \"http://www.sqlalchemy.org/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"This is a python client implementation of the STOMP\
+        \ protocol. The client is\\nattempting to be transport layer neutral. This\
+        \ module provides functions to\\ncreate and parse STOMP messages in a programatic\
+        \ fashion.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-stomper\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"A python client implementation of the STOMP protocol\",\n      \"upstream_url\"\
+        : \"https://pypi.io/project/stomper\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"Provides\
+        \ middleware for detecting and correcting errors in web pages that are\\nserved\
+        \ via the standard WSGI protocol used by most Python web frameworks. By\\\
+        ndefault, validation errors are logged to the \\\"strainer.middleware\\\"\
+        \ channel\\nusing the standard Python logging module.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-strainer\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Tools to allow developers to cleanup\
+        \ web serialization objects\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/strainer\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1449065747.0,\n\
+        \      \"description\": \"A collection of Python dictionary types that support\
+        \ attribute-style\\naccess. Includes *defaultdict*,  *OrderedDict*, restricted,\
+        \ *ChainMap*,\\n*Counter*, and frozen implementations plus miscellaneous utilities\
+        \ for\\nwriting Python software.\",\n      \"koschei_monitor\": false,\n \
+        \     \"monitor\": true,\n      \"name\": \"python-stuf\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1281998\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fancy python dictionary\
+        \ types\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/stuf\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"svg.path is a collection of objects that implement\
+        \ the different path\\ncommands in SVG, and a parser for SVG path definitions.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-svg-path\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"SVG path objects\
+        \ and parser\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/svg.path\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Tablib is a format-agnostic tabular dataset library,\
+        \ written in Python.\\n\\nOutput formats supported:\\n\\n - Excel (Sets +\
+        \ Books)\\n - JSON (Sets + Books)\\n - YAML (Sets + Books)\\n - HTML (Sets)\\\
+        n - TSV (Sets)\\n - CSV (Sets)\",\n      \"koschei_monitor\": false,\n   \
+        \   \"monitor\": false,\n      \"name\": \"python-tablib\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Format agnostic tabular data library (XLS, JSON, YAML,\
+        \ CSV)\",\n      \"upstream_url\": \"http://github.com/kennethreitz/tablib\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A module & command-line tool for extracting Python\
+        \ tracebacks from text.\\n\\n    $ tbgrep file1 file2 file3\\n    $ tail -f\
+        \ logfile | tbgrep\\n\\ntbgrep can extract tracebacks from logs of various\
+        \ formats. For example,\\nCherryPy starts the traceback on a line with other\
+        \ details (like module,\\ntimestamp, etc), but the rest of the trace starts\
+        \ at the beginning of the\\nline. Apache logs, on the other hand, will prefix\
+        \ each line of the\\ntraceback with this information. tbgrep is designed to\
+        \ these kinds of\\nsituations\",\n      \"koschei_monitor\": false,\n    \
+        \  \"monitor\": false,\n      \"name\": \"python-tbgrep\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Extract Python Tracebacks from text\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/tbgrep\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"This scheduler\
+        \ package is based on the TurboGears 1 built-in scheduler\\nwhich is based\
+        \ on Kronos by Irmen de Jong. The scheduler makes it easy to\\nhave one-time\
+        \ or recurring tasks run as needed.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-tgscheduler\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Turbogears2 Scheduler\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/TGScheduler\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ package contains a generic transaction implementation for Python. It is\\\
+        nmainly used by the ZODB, though.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-transaction\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Transaction management for Python\"\
+        ,\n      \"upstream_url\": \"https://pypi.io/project/transaction\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"A library used by various Pylons Project packages for\\\
+        ninternationalization (i18n) duties related to translation.\\n\\nThis package\
+        \ provides a translation string class, a translation string factory\\nclass,\
+        \ translation and pluralization primitives, and a utility that helps\\nChameleon\
+        \ templates use translation facilities of this package. It does not\\ndepend\
+        \ on Babel, but its translation and pluralization services are meant to\\\
+        nwork best when provided with an instance of the babel.support.Translations\
+        \ class.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"python-translationstring\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Library used for internationalization (i18n) duties related to\
+        \ translation\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/translationstring\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Twiggy is a Pythonic logger.\\n\\nYou should use\
+        \ Twiggy because it is awesome. For more information, read the\\n`documentation\
+        \ <http://twiggy.wearpants.org>`_ or `see this blog post\\n<http://blog.wearpants.org/meet-twiggy>`_.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-twiggy\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A Pythonic\
+        \ logger\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/Twiggy\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1415218324.0,\n\
+        \      \"description\": \"This is a small add-on for the python requests HTTP\
+        \ library.  It makes use\\ntwisted's ThreadPool, so that requests' API returns\
+        \ deferreds.\\n\\nThe additional API and changes are minimal and strive to\
+        \ avoid surprises.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"python-txrequests\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1160447\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Asynchronous Python\
+        \ HTTP for Humans\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/txrequests\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"txWS (pronounced \\\"Twisted WebSockets\\\") is\
+        \ a small, short, simple library\\nfor adding WebSockets server support to\
+        \ your favorite Twisted applications.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-txws\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Twisted WebSockets wrapper\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/txWS\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"txZMQ allows\
+        \ to integrate easily ZeroMQ sockets into Twisted event loop\\n(reactor).\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-txzmq\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Twisted bindings\
+        \ for ZeroMQ\",\n      \"upstream_url\": \"https://github.com/smira/txZMQ\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Python HTTP module with connection pooling and file\
+        \ POST abilities.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-urllib3\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Python HTTP library with thread-safe connection pooling and file\
+        \ post\",\n      \"upstream_url\": \"https://github.com/shazow/urllib3\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1431104802.0,\n\
+        \      \"description\": \"Simplify and speed up testing HTTP by recording\
+        \ all HTTP interactions and\\nsaving them to \\\"cassette\\\" files, which\
+        \ are yaml files containing the contents\\nof your requests and responses.\
+        \  Then when you run your tests again, they all\\njust hit the text files\
+        \ instead of the internet.  This speeds up your tests and\\nlets you work\
+        \ offline.\\n\\nIf the server you are testing against ever changes its API,\
+        \ all you need to do\\nis delete your existing cassette files, and run your\
+        \ tests again.  All of the\\nmocked responses will be updated with the new\
+        \ API.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n \
+        \     \"name\": \"python-vcrpy\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/show_bug.cgi?id=1210983\",\n \
+        \     \"status\": \"Approved\",\n      \"summary\": \"Automatically mock your\
+        \ HTTP interactions to simplify and speed up testing\",\n      \"upstream_url\"\
+        : \"https://pypi.io/project/vcrpy\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"Velruse\
+        \ is a set of authentication routines that provide a unified way\\nto have\
+        \ a website user authenticate to a variety of different identity\\nproviders\
+        \ and/or a variety of different authentication schemes.\\n\\nIt is similar\
+        \ in some ways to Janrain Engage with the exception of being\\nopen-source,\
+        \ locally installable, and easily pluggable for custom identity\\nproviders\
+        \ and authentication schemes.\\n\\nYou can run Velruse as a stand-alone service\
+        \ for use with your websites\\nregardless of the language they\\u2019re written\
+        \ in. While Velruse itself is\\nwritten in Python, since it can interact with\
+        \ your website purely via HTTP\\nPOST\\u2019s.\\n\\nVelruse can:\\n\\n - Normalize\
+        \ identity information from varying provider sources (OpenID,\\n   Google,\
+        \ Facebook, etc.) to Portable Contacts.\\n - Simplify complex authentication\
+        \ protocols by providing a simple\\n   consistent API\\n - Provide extension\
+        \ points for other authentication systems, write your\\n   own auth provider\
+        \ to handle CAS, LDAP, and use it with ease\\n - Integrate with most web applications\
+        \ regardless of the language used to\\n   write the website\\n\\nVelruse aims\
+        \ to simplify authenticating a user. It provides auth provider\\u2018s\\nthat\
+        \ handle authenticating to a variety of identity providers with multiple\\\
+        nauthentication schemes (LDAP, SAML, etc.). Eventually, Velruse will include\\\
+        nwidgets similar to RPXNow that allow one to customize a login/registration\\\
+        nwidget so that a website user can select a preferred identity provider to\\\
+        nuse to sign-in. In the mean-time, effort is focused on increasing the\\navailable\
+        \ auth provider\\u2018s for the commonly used authentication schemes and\\\
+        nidentity providers (Facebook, Google, OpenID, etc). Unlike other\\nauthentication\
+        \ libraries for use with web applications, a website using\\nVelruse for authentication\
+        \ does not have to be written in any particular\\nlanguage.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-velruse\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Simplify third-party authentication\
+        \ for web applications\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/velruse\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Venusian is a library which allows framework authors\
+        \ to defer decorator\\nactions.  Instead of taking actions when a function\
+        \ (or class) decorator is\\nexecuted at import time, you can defer the action\
+        \ usually taken by the\\ndecorator until a separate \\\"scan\\\" phase.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-venusian\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A library for\
+        \ deferring decorator actions\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/venusian\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A script for cloning a non-relocatable virtualenv.\\\
+        n\\nVirtualenv provides a way to make virtualenv's relocatable which could\
+        \ then\\nbe copied as we wanted. However making a virtualenv relocatable this\
+        \ way\\nbreaks the no-site-packages isolation of the virtualenv as well as\
+        \ other\\naspects that come with relative paths and '/usr/bin/env' shebangs\
+        \ that may\\nbe undesirable.\\n\\nAlso, the .pth and .egg-link rewriting doesn't\
+        \ seem to work as intended.\\nThis attempts to overcome these issues and provide\
+        \ a way to easily clone an\\nexisting virtualenv.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-virtualenv-clone\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Script to clone virtualenvs\",\n   \
+        \   \"upstream_url\": \"http://pypi.python.org/pypi/virtualenv-clone\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Waitress is meant to be a production-quality pure-Python\
+        \ WSGI server with\\nvery acceptable performance. It has no dependencies except\
+        \ ones which live\\nin the Python standard library. It runs on CPython on\
+        \ Unix and Windows under\\nPython 2.6+ and Python 3.3+. It is also known to\
+        \ run on PyPy 1.6.0+ on UNIX.\\nIt supports HTTP/1.0 and HTTP/1.1.\",\n  \
+        \    \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-waitress\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Waitress WSGI\
+        \ server\",\n      \"upstream_url\": \"https://github.com/Pylons/waitress\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"WebError is WSGI middleware that performs error\
+        \ handling and exception\\ncatching.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-weberror\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Web Error handling and exception catching\
+        \ middleware\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/WebError\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"WebOb provides wrappers around the WSGI request\
+        \ environment, and an object to\\nhelp create WSGI responses. The objects\
+        \ map much of the specified behavior of\\nHTTP, including header parsing and\
+        \ accessors for other standard parts of the\\nenvironment.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-webob\",\n   \
+        \   \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"WSGI request and response object\",\n\
+        \      \"upstream_url\": \"http://pythonpaste.org/webob/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"WebOb provides wrappers around the WSGI request environment, and an object\
+        \ to\\nhelp create WSGI responses. The objects map much of the specified behavior\
+        \ of\\nHTTP, including header parsing and accessors for other standard parts\
+        \ of the\\nenvironment.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"python-webob1.2\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"WSGI request and response object\",\n      \"upstream_url\":\
+        \ \"http://pythonpaste.org/webob/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1429188035.0,\n      \"description\": \"WebOb provides\
+        \ wrappers around the WSGI request environment, and an object to\\nhelp create\
+        \ WSGI responses. The objects map much of the specified behavior of\\nHTTP,\
+        \ including header parsing and accessors for other standard parts of the\\\
+        nenvironment.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"python-webob1.4\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/1212228\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"WSGI request and response object\",\n\
+        \      \"upstream_url\": \"http://pythonpaste.org/webob/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"WebTest wraps any WSGI application and makes it easy to send test\\nrequests\
+        \ to that application, without starting up an HTTP server.\\n\\nThis provides\
+        \ convenient full-stack testing of applications written\\nwith any WSGI-compatible\
+        \ framework.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"python-webtest1.3\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Helper to test WSGI applications\",\n      \"upstream_url\": \"http://pythonpaste.org/webtest/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1427470332.0,\n\
+        \      \"description\": \"The aim of the wrapt module is to provide a transparent\
+        \ object proxy\\nfor Python, which can be used as the basis for the construction\
+        \ of\\nfunction wrappers and decorator functions.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-wrapt\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1200955\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A Python module for\
+        \ decorators, wrappers and monkey patching\",\n      \"upstream_url\": \"\
+        https://github.com/GrahamDumpleton/wrapt\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"xmltodict\
+        \ is a Python module that makes working with XML feel like you are\\nworking\
+        \ with JSON.  It's very fast (Expat-based) and has a streaming mode\\nwith\
+        \ a small memory footprint, suitable for big XML dumps like Discogs or\\nWikipedia.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-xmltodict\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"A Python to\
+        \ transform XML to JSON\",\n      \"upstream_url\": \"https://github.com/martinblech/xmltodict\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1456704189.0,\n\
+        \      \"description\": \"A web app bridging zanata webhooks to fedmsg\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-zanata2fedmsg\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1310869\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A web app bridging zanata webhooks to fedmsg\",\n\
+        \      \"upstream_url\": \"http://pypi.python.org/pypi/zanata2fedmsg\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The 0MQ lightweight messaging kernel is a library\
+        \ which extends the\\nstandard socket interfaces with features traditionally\
+        \ provided by\\nspecialized messaging middle-ware products. 0MQ sockets provide\
+        \ an\\nabstraction of asynchronous message queues, multiple messaging\\npatterns,\
+        \ message filtering (subscriptions), seamless access to\\nmultiple transport\
+        \ protocols and more.\\n\\nThis package contains the python bindings.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-zmq\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Software library for\
+        \ fast, message-based applications\",\n      \"upstream_url\": \"http://www.zeromq.org/bindings:python\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package represents the core of the Zope Component\
+        \ Architecture.\\nTogether with the 'zope.interface' package, it provides\
+        \ facilities for\\ndefining, registering and looking up components.\",\n \
+        \     \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-zope-component\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Zope Component\
+        \ Architecture\",\n      \"upstream_url\": \"https://pypi.io/project/zope.component\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The zope configuration system provides an extensible\
+        \ system for supporting\\nvarious kinds of configurations.\\n\\nIt is based\
+        \ on the idea of configuration directives. Users of the configuration\\nsystem\
+        \ provide configuration directives in some language that express\\nconfiguration\
+        \ choices. The intent is that the language be pluggable. An XML\\nlanguage\
+        \ is provided by default.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-zope-configuration\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Zope Configuration Markup Language (ZCML)\",\n     \
+        \ \"upstream_url\": \"https://github.com/zopefoundation/zope.configuration\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package provides a simple function called 'deprecated(names,\
+        \ reason)' to\\ndeprecate the previously mentioned Python objects.\",\n  \
+        \    \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"python-zope-deprecation\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Zope 3 Deprecation\
+        \ Infrastructure\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/zope.deprecation\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package contains exception interfaces and implementations\
+        \ which are so\\ngeneral purpose that they don't belong in Zope application-specific\
+        \ packages.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-zope-exceptions\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Zope Exceptions\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/zope.exceptions\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The aim of this package is to unify the plethora\
+        \ of existing packages\\nintegrating SQLAlchemy with Zope's transaction management.\
+        \ As such it seeks\\nonly to provide a data manager and makes no attempt to\
+        \ define a zopeish way to\\nconfigure engines.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-zope-sqlalchemy\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Minimal Zope/SQLAlchemy transaction\
+        \ integration\",\n      \"upstream_url\": \"https://github.com/zopefoundation/zope.sqlalchemy\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package provides a number of testing frameworks.\
+        \ It includes a\\nflexible test runner, and supports both doctest and unittest.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-zope-testing\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Zope Testing\
+        \ Framework\",\n      \"upstream_url\": \"https://pypi.io/project/zope.testing\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Python 3 bindings for the cairo library.\",\n  \
+        \    \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python3-cairo\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Python 3 bindings\
+        \ for the cairo library\",\n      \"upstream_url\": \"http://cairographics.org/pycairo\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This Python 3 module provides a DNS API for looking\
+        \ up DNS entries from\\nwithin Python 3 modules and applications. This module\
+        \ is a simple,\\nlightweight implementation.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python3-py3dns\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Python3 DNS library\",\n      \"upstream_url\"\
+        : \"https://launchpad.net/py3dns/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"Fixers for\
+        \ Zope Component Architecture and the frameworks built with it.\\n\\nCurrently,\
+        \ there is only one fixer, fix_implements. This fixer will change\\nall uses\
+        \ of implements(IFoo) in a class body to the class decorator\\n@implementer(IFoo),\
+        \ which is the most likely Python 3 syntax for\\nzope.interfaces implements\
+        \ statements.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python3-zope-fixers\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"2to3 fixers for Zope\",\n      \"upstream_url\": \"http://svn.zope.org/zope.fixers/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1490709111.0,\n\
+        \      \"description\": \"Ruby is the interpreted scripting language for quick\
+        \ and easy object-oriented programming.  It has many features to process text\
+        \ files and to do system management tasks (as in Perl).  It is simple, straight-forward,\
+        \ and extensible.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : false,\n      \"name\": \"ruby\",\n      \"namespace\": \"modules\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/1419506\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An interpreter of object-oriented scripting\
+        \ language\",\n      \"upstream_url\": \"\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1490713705.0,\n      \"description\": \"Samba\
+        \ is the standard Windows interoperability suite of programs for Linux and\
+        \ Unix.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"samba\",\n      \"namespace\": \"modules\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1419506\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Server and Client software to interoperate with Windows\
+        \ machines\",\n      \"upstream_url\": \"\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1490279991.0,\n      \"description\": \"A\
+        \ module which provides binaries and libraries that can be used by the other\
+        \ modules\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"shared-userspace\",\n      \"namespace\": \"modules\",\n\
+        \      \"review_url\": \"https://bugzilla.redhat.com/1419506\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Shared Userspace Module\",\n\
+        \      \"upstream_url\": \"\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1440077689.0,\n      \"description\": \"Statscache is a plugin\
+        \ to the fedmsg-hub that sits listening in our\\ninfrastructure.  When new\
+        \ messages arrive, it will pass them off to `plugins\\n<https://github.com/fedora-infra/statscache_plugins>`_\
+        \ that will calculate and\\nstore various statistics.  If we want a new kind\
+        \ of statistic to be kept, we\\nwrite a new plugin for it.  It will come with\
+        \ a tiny flask frontend, much like\\ndatagrepper, that allows you to query\
+        \ for this or that stat in this or that\\nformat (csv, json, maybe html or\
+        \ svg too but that might be overkill).  The idea\\nbeing that we can then\
+        \ build neater smarter frontends that can render\\nfedmsg-based activity very\
+        \ quickly.. and perhaps later drill-down into the\\n*details* kept in datagrepper.\\\
+        n\\nIt is kind of like a data mart (http://en.wikipedia.org/wiki/Data_mart).\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"statscache\",\n      \"namespace\": \"rpms\",\n      \"review_url\": \"\
+        https://bugzilla.redhat.com/1234605\",\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"A daemon to build and keep fedmsg statistics\",\n  \
+        \    \"upstream_url\": \"http://github.com/fedora-infra/statscache\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1440077971.0,\n\
+        \      \"description\": \"Plugins for statscache daemon.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"statscache-plugins\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1235018\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Plugins for statscache\
+        \ daemon\",\n      \"upstream_url\": \"http://github.com/fedora-infra/statscache_plugins\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"A Supybot plugin for sending messages across the\
+        \ Fedora Infrastructure message\\nbus.  This plugin modifies other installed\
+        \ plugins during runtime,\\ninstrumenting them to send messages on certain\
+        \ events.\\n\\nCurrently supported target plugins are:\\n\\n - meetbot\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"supybot-fedmsg\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Plugin for\
+        \ supybot that enables meetbot with fedmsg output.\",\n      \"upstream_url\"\
+        : \"http://github.com/ralphbean/supybot-fedmsg\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"A Supybot plugin which provides access to Fedora information. Implements\
+        \ a\\nvariety of commands, such as:\\n\\n * fas\\n * fasinfo\\n * ext\\n *\
+        \ bug\\n * whoowns\\n\\nThese provide various information from the Fedora\
+        \ Package Database and\\nAccount System and provide it via IRC\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\": \"supybot-fedora\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Plugin for Supybot to interact with\
+        \ Fedora services\",\n      \"upstream_url\": \"https://github.com/fedora-infra/supybot-fedora\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Taskwarrior is a command-line TODO list manager.\
+        \ It is flexible, fast,\\nefficient, unobtrusive, does its job then gets out\
+        \ of your way.\\n\\nTaskwarrior scales to fit your workflow. Use it as a simple\
+        \ app that captures\\ntasks, shows you the list, and removes tasks from that\
+        \ list. Leverage its\\ncapabilities though, and it becomes a sophisticated\
+        \ data query tool that can\\nhelp you stay organized, and get through your\
+        \ work.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"task\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Taskwarrior\
+        \ - a command-line TODO list manager\",\n      \"upstream_url\": \"https://taskwarrior.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489496696.0,\n\
+        \      \"description\": \"A platform for building C and C++ applications.\
+        \ It is a Fedora alternative to Developer Toolset Toolchain from Red Hat Software\
+        \ Collections.\",\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n\
+        \      \"name\": \"toolchain\",\n      \"namespace\": \"modules\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1419506\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Platform for building C and C++ applications\"\
+        ,\n      \"upstream_url\": \"\"\n    },\n    {\n      \"acls\": [],\n    \
+        \  \"creation_date\": 1400070978.0,\n      \"description\": \"A trac plugin\
+        \ that emits fedmsg messages.\\n\\nMessages are emitted for ticket changes,\
+        \ wiki edits, and revision\\ncontrol events.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"trac-fedmsg-plugin\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Emit fedmsg messages\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/trac-fedmsg-plugin\"\n    },\n    {\n    \
+        \  \"acls\": [],\n      \"creation_date\": 1490713126.0,\n      \"description\"\
+        : \"This is Varnish Cache, a high-performance HTTP accelerator.\",\n     \
+        \ \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\": \"\
+        varnish\",\n      \"namespace\": \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"High-performance\
+        \ HTTP accelerator\",\n      \"upstream_url\": \"\"\n    }\n  ],\n  \"output\"\
+        : \"ok\",\n  \"point of contact\": [\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1488568064.0,\n      \"description\": \"A project closely\
+        \ linked to the Modularity Initiative, Base Runtime is about defining the\
+        \ common shared package and feature set of the operating system, providing\
+        \ both the hardware enablement layer and the minimal application runtime environment\
+        \ other modules can build upon.\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": false,\n      \"name\": \"base-runtime\",\n      \"namespace\"\
+        : \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1413528\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"The base application\
+        \ runtime and hardware abstraction layer\",\n      \"upstream_url\": \"\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"bitlyclip is just a script that:\\n\\n - Takes a\
+        \ url in your clipboard.\\n - Shortens it with the bit.ly url shortening service.\\\
+        n - Puts the new url back in your clipboard.\\n\\nIt makes a nice 'hotkey'\
+        \ in whatever window manager you're using.\",\n      \"koschei_monitor\":\
+        \ false,\n      \"monitor\": true,\n      \"name\": \"bitlyclip\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Shorten urls in the X clipboard with\
+        \ bit.ly\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/bitlyclip\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Boom! is a simple command line tool to send some\
+        \ load to a web app.\\n\\nIt is a script you can use to quickly smoke-test\
+        \ your web app\\ndeployment.  Boom! was specifically written to replace my\
+        \ Apache\\nBench usage, because I was annoyed by some bugs and some stupid\\\
+        nbehaviors.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"boom\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Simple HTTP\
+        \ Load tester\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/boom\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1488567911.0,\n\
+        \      \"description\": \"The purpose of this module is to provide a boostrapping\
+        \ mechanism for new distributions or architectures as well as the entire build\
+        \ environment for the Base Runtime module.\",\n      \"koschei_monitor\":\
+        \ true,\n      \"monitor\": false,\n      \"name\": \"bootstrap\",\n     \
+        \ \"namespace\": \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1413528\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Bootstrap the Modularity\
+        \ infrastructure\",\n      \"upstream_url\": \"\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"bugwarrior is a command line utility for updating your local taskwarrior\\\
+        ndatabase from your forge issue trackers.\\n\\nIt currently supports pulling\
+        \ issues from github, bitbucket, trac, bugzilla,\\nmegaplan, teamlab, redmine,\
+        \ and activecollab\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"bugwarrior\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Sync github, bitbucket, and trac issues with taskwarrior\",\n      \"\
+        upstream_url\": \"http://pypi.python.org/pypi/bugwarrior\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"The merge of convenience and cool!\\n\\nHovercraft is a tool to make impress.js\
+        \ presentations from\\nreStructuredText.\\n\\n- Write your presentations in\
+        \ a text markup language. No slow, limiting\\n  GUI, no annoying HTML!\\n-\
+        \ Pan, rotate and zoom in 3D, with automatic repositioning of slides!\\n-\
+        \ A presenter console with notes and slide previews!\\n- The slide show generated\
+        \ is in HTML, so you only need a web browser to\\n  show it.\\n- Easy sharing,\
+        \ as it can be put up on a website for anyone to see!\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"hovercraft\",\n   \
+        \   \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Makes impress.js presentations from\
+        \ reStructuredText\",\n      \"upstream_url\": \"https://pypi.io/project/hovercraft\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489440702.0,\n\
+        \      \"description\": \"A module for apache httpd\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"httpd\",\n      \"namespace\"\
+        : \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A module for apache\
+        \ httpd\",\n      \"upstream_url\": \"\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1401272913.0,\n      \"description\": \"hub is a\
+        \ command line tool that wraps `git` in order to extend it with extra\\nfeatures\
+        \ and commands that make working with GitHub easier.\\n\\n    $ hub clone\
+        \ rtomayko/tilt\\n\\n    \\n    $ git clone git://github.com/rtomayko/tilt.git\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"hub\",\n      \"namespace\": \"rpms\",\n      \"review_url\": \"\
+        https://bugzilla.redhat.com/1083344\",\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"A command-line wrapper for git with github shortcuts\"\
+        ,\n      \"upstream_url\": \"http://hub.github.com/\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"It's a presentation framework based on the power of CSS3 transforms and\\\
+        ntransitions in modern browsers and inspired by the idea behind prezi.com.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"impressjs\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Javascript presentation\
+        \ framework\",\n      \"upstream_url\": \"http://bartaz.github.io/impress.js\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484067796.0,\n\
+        \      \"description\": \"The Module Build Service (MBS) coordinates module\
+        \ builds and is responsible\\nfor a number of tasks:\\n\\n- Providing an interface\
+        \ for module client-side tooling via which module build\\n  submission and\
+        \ build state queries are possible.\\n- Verifying the input data (modulemd,\
+        \ RPM SPEC files and others) is available\\n  and correct.\\n- Preparing the\
+        \ build environment in the supported build systems, such as koji.\\n- Scheduling\
+        \ and building of the module components and tracking the build\\n  state.\\\
+        n- Emitting bus messages about all state changes so that other infrastructure\\\
+        n  services can pick up the work.\",\n      \"koschei_monitor\": true,\n \
+        \     \"monitor\": true,\n      \"name\": \"module-build-service\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1404012\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"The Module Build\
+        \ Service for Modularity\",\n      \"upstream_url\": \"https://pagure.io/fm-orchestrator\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489440724.0,\n\
+        \      \"description\": \"A module for nginx\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"nginx\",\n      \"namespace\"\
+        : \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A module for nginx\"\
+        ,\n      \"upstream_url\": \"\"\n    },\n    {\n      \"acls\": [],\n    \
+        \  \"creation_date\": 1460475569.0,\n      \"description\": \"pag is a command\
+        \ line tool for interacting with the git repository hosting\\nservice https://pagure.io.\
+        \  It provides support for cloning projects and\\nopening new ones.\\n\\nIt\
+        \ is under active development and will be gaining new features over time.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"pag\",\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1325414\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Commandline interaction\
+        \ with pagure.io\",\n      \"upstream_url\": \"https://pagure.io/pag\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1480694751.0,\n\
+        \      \"description\": \"Fedmsg consumer that listens to activity on the\
+        \ Fedora message bus, and updates\\nthe Product Definition Center database\
+        \ in response.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"pdc-updater\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1379830\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Update the product definition center\
+        \ in response to fedmsg\",\n      \"upstream_url\": \"https://pypi.io/project/pdc-updater\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489440737.0,\n\
+        \      \"description\": \"A module for proftpd.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": false,\n      \"name\": \"proftpd\",\n      \"\
+        namespace\": \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1419506\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A module for proftpd\"\
+        ,\n      \"upstream_url\": \"\"\n    },\n    {\n      \"acls\": [],\n    \
+        \  \"creation_date\": 1400070978.0,\n      \"description\": \"Python bindings\
+        \ for the cairo library.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"pycairo\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Python bindings for the cairo library\",\n      \"upstream_url\": \"http://cairographics.org/pycairo\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"ZConfig is a configuration library intended for\
+        \ general use. It supports\\na hierarchical schema-driven configuration model\
+        \ that allows a schema to\\nspecify data conversion routines written in Python.\
+        \ ZConfig's model is\\nvery different from the model supported by the ConfigParser\
+        \ module found\\nin Python's standard library, and is more suitable to\\nconfiguration-intensive\
+        \ applications.\",\n      \"koschei_monitor\": false,\n      \"monitor\":\
+        \ true,\n      \"name\": \"python-ZConfig\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Structured Configuration Library\",\n      \"upstream_url\":\
+        \ \"http://www.zope.org/Members/fdrake/zconfig/\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"The ansi2html module can convert text with ANSI color codes to HTML.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-ansi2html\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Python module\
+        \ that converts text with ANSI color to HTML\",\n      \"upstream_url\": \"\
+        http://github.com/ralphbean/ansi2html\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1475677326.0,\n      \"description\": \"Sometimes\
+        \ you just want to draw ascii trees in your terminal.\\n\\nRead the documentation\
+        \ at http://pythonhosted.org/asciitree\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-asciitree\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1375735\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Draws ASCII trees\"\
+        ,\n      \"upstream_url\": \"http://pypi.python.org/pypi/asciitree\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is a thin Python wrapper for the bit.ly API.\
+        \  Basic usage looks\\nlike this:\\n\\n    >>> import bitlyapi\\n    >>> b\
+        \ = bitlyapi.BitLy(api_user, api_key)\\n    >>> res = b.shorten(longUrl='http://www.google.com/')\\\
+        n    >>> print(res['url'])\\n    'http://bit.ly/6Hwstb'\\n    >>> print(res['long_url'])\\\
+        n    'http://www.google.com/'\",\n      \"koschei_monitor\": false,\n    \
+        \  \"monitor\": true,\n      \"name\": \"python-bitlyapi\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"A thin python wrapper for the bit.ly REST API\",\n \
+        \     \"upstream_url\": \"http://pypi.python.org/pypi/bitlyapi\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"CairoSVG is a SVG converter based on Cairo. It can export\
+        \ SVG files to PDF,\\nPostScript and PNG files.\\n\\nFor further information,\
+        \ please visit the CairoSVG Website\\nhttp://www.cairosvg.org\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\": \"python-cairosvg\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A Simple SVG Converter for Cairo\",\n\
+        \      \"upstream_url\": \"http://pypi.python.org/pypi/CairoSVG\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1430239258.0,\n    \
+        \  \"description\": \"contextlib2 is a backport of the standard library's\
+        \ contextlib module to\\nearlier Python versions.\\n\\nIt also serves as a\
+        \ real world proving ground for possible future\\nenhancements to the standard\
+        \ library version.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-contextlib2\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1210978\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Backports and enhancements\
+        \ for the contextlib module\",\n      \"upstream_url\": \"https://pypi.io/project/contextlib2\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1458224951.0,\n\
+        \      \"description\": \"detox is the distributed version of the \\\"tox\\\
+        \" python testing tool.  It makes\\nefficient use of multiple CPUs by running\
+        \ all possible activities in parallel.\\nIt has the same options and configuration\
+        \ that tox has so after installation\\ncan just run::\\n\\n    $ detox\\n\\\
+        nin the same way and with the same options with which you would run ``tox``.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-detox\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1318328\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Distributing activities of the tox tool\",\n     \
+        \ \"upstream_url\": \"http://pypi.python.org/pypi/detox\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1488823158.0,\n      \"description\"\
+        : \"django-cors-headers is a Django application for handling the server headers\\\
+        nrequired for Cross-Origin Resource Sharing (CORS).\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-django-cors-headers\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1420329\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A Django application\
+        \ for handling CORS headers\",\n      \"upstream_url\": \"https://pypi.io/project/django-cors-headers\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1488290159.0,\n\
+        \      \"description\": \"A simple way to define complex permissions for django-rest-framework.\\\
+        n\\nhttps://djangorestframework-composed-permissions.readthedocs.org/en/latest/\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-django-rest-framework-composed-permissions\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1420124\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Composed permissions\
+        \ for django-rest-framework\",\n      \"upstream_url\": \"https://pypi.io/project/djangorestframework-composed-permissions\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Digital Ocean API Python Wrapper\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-dopy\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Python client for the Digital Ocean\
+        \ API\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/dopy\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"fabulous is a python module for producing fabulously\
+        \ colored terminal output.\\n\\nRun the demo to see what's available::\\n\\\
+        n    $ python -m fabulous.demo\",\n      \"koschei_monitor\": false,\n   \
+        \   \"monitor\": true,\n      \"name\": \"python-fabulous\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Makes your terminal output totally fabulous\",\n   \
+        \   \"upstream_url\": \"https://pypi.io/project/fabulous\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1471270810.0,\n      \"description\"\
+        : \"SQLAlchemy database migrations for Flask applications using Alembic.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-flask-migrate\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1366028\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"SQLAlchemy database migrations for Flask applications\
+        \ using Alembic\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/flask-migrate\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The Flask-Script extension provides support for\
+        \ writing external scripts in\\nFlask.This includes running a development\
+        \ server, a customized Python shell,\\nscripts to set up your database, cronjobs,\
+        \ and other command-line tasks that\\nbelong outside the web application itself.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-flask-script\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Scripting support for Flask\",\n      \"upstream_url\": \"http://flask-script.readthedocs.org/en/latest/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Geojson provides geometry, feature, and collection\
+        \ classes, and supports\\npickle-style dump and load of objects that provide\
+        \ the lab's Python geo\\ninterface.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"python-geojson\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Encoder/decoder for simple GIS features\"\
+        ,\n      \"upstream_url\": \"http://pypi.python.org/pypi/geojson\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"A library to ease use of the JIRA 5 REST APIs.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"python-jira\",\n      \"namespace\": \"rpms\",\n      \"review_url\":\
+        \ null,\n      \"status\": \"Approved\",\n      \"summary\": \"A library to\
+        \ ease use of the JIRA 5 REST APIs\",\n      \"upstream_url\": \"https://pypi.io/project/jira\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"kitchen includes functions to make gettext easier\
+        \ to use, handling unicode\\ntext easier (conversion with bytes, outputting\
+        \ xml, and calculating how many\\ncolumns a string takes), and compatibility\
+        \ modules for writing code that uses\\npython-2.7 modules but needs to run\
+        \ on python-2.3.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-kitchen\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Small, useful pieces of code to make python coding easier\",\n\
+        \      \"upstream_url\": \"https://pypi.python.org/pypi/kitchen/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"Introspection for the ``logging`` logger tree in the\
+        \ Standard Library.\\n\\nWhile you can write programs that call this package's\
+        \ ``tree()``\\nfunction and examine the hierarchy of logger objects that it\
+        \ finds\\ninside of the Standard Library ``logging`` module, the simplest\
+        \ use of\\nthis package for debugging is to call ``printout()`` to print the\\\
+        nloggers, filters, and handlers that your application has configured::\\n\\\
+        n    >>> logging.getLogger('a')\\n    >>> logging.getLogger('a.b').setLevel(logging.DEBUG)\\\
+        n    >>> logging.getLogger('x.c')\\n    >>> from logging_tree import printout\\\
+        n    >>> printout()\\n       \\\"\\\"\\n       Level WARNING\\n       |\\\
+        n       o<--\\\"a\\\"\\n       |   |\\n       |   o<--\\\"a.b\\\"\\n     \
+        \  |       Level DEBUG\\n       |\\n       o<--[x]\\n           |\\n     \
+        \      o<--\\\"x.c\\\"\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-logging-tree\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n  \
+        \    \"summary\": \"Introspect and display the logger tree inside \\\"logging\\\
+        \"\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/logging_tree\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package contains the wsgi components for narcissus.\
+        \  Narcissus\\nis a web application that visualizes web server hits as they\
+        \ happen\\nin real time.\\n\\nFeatures:\\n\\n * IP addresses converted to\
+        \ latitude/longitude, then streamed via\\n   WebSockets to `polymaps <http://polymaps.org/>`_.\\\
+        n * Realtime graphs of what countries are downloading what content\\n   with\
+        \ `d3 <http://d3js.org>`_.\\n * `\\u00d8mq (zeromq) <http://www.zeromq.org/>`_\
+        \ on the backend.\\n * **Fast**.  No polling.\\n\\nYou can see a demo running\
+        \ live at http://narcissus.rc.rit.edu\\nIt is visualizing the logs of http://mirror.rit.edu\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-narcissus-app\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        WSGI components for Narcissus, realtime log visualization\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/narcissus.app\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ package contains the commons components for narcissus.  Narcissus\\nis a\
+        \ web application that visualizes web server hits as they happen\\nin real\
+        \ time.\\n\\nFeatures:\\n\\n * IP addresses converted to latitude/longitude,\
+        \ then streamed via\\n   WebSockets to `polymaps <http://polymaps.org/>`_.\\\
+        n * Realtime graphs of what countries are downloading what content\\n   with\
+        \ `d3 <http://d3js.org>`_.\\n * `\\u00d8mq (zeromq) <http://www.zeromq.org/>`_\
+        \ on the backend.\\n * **Fast**.  No polling.\\n\\nYou can see a demo running\
+        \ live at http://narcissus.rc.rit.edu\\nIt is visualizing the logs of http://mirror.rit.edu\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-narcissus-common\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Common components for Narcissus, realtime log visualization\",\n     \
+        \ \"upstream_url\": \"http://pypi.python.org/pypi/narcissus.common\"\n   \
+        \ },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package contains the \\\"hub\\\" components\
+        \ for narcissus.  Narcissus is a web\\napplication that visualizes web server\
+        \ hits as they happen in real time.\\n\\nFeatures:\\n\\n* IP addresses converted\
+        \ to latitude/longitude, then streamed via\\n  WebSockets to `polymaps <http://polymaps.org/>`_.\\\
+        n* Realtime graphs of what countries are downloading what content with `d3\\\
+        n  <http://d3js.org>`_.\\n* `\\u00d8mq (zeromq) <http://www.zeromq.org/>`_\
+        \ on the backend.\\n* **Fast**.  No polling.\\n\\nYou can see a demo running\
+        \ live at http://narcissus.rc.rit.edu\\nIt is visualizing the logs of http://mirror.rit.edu\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-narcissus-hub\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Hub components for Narcissus, realtime log visualization\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/narcissus.hub\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1421081779.0,\n      \"description\": \"Let's\
+        \ write Python 3 right now!\\n\\nWhen the best Python 2/Python 3 compatibility\
+        \ modules -- especially the\\nfamous `*six* library invented by Benjamin Peterson\\\
+        n<https://pypi.python.org/pypi/six>`_ -- were created, they were written\\\
+        nfrom the point of view of a Python 2 programmer starting to grok Python 3.\\\
+        n\\nWhen thou writeth Python, thou shalt write Python 3 and, just for a while,\\\
+        nensure that the thing worketh on Python 2.7 and, possibly, even 2.6.\\n\\\
+        nJust before Python 2 is finally phased out, thine codebase shall look more\\\
+        nlike 3 than like 2.\\n\\nnine facilitates this new point of view. You can\
+        \ write code that is as\\n3ish as possible while still supporting 2.6. Very\
+        \ comfortable for writing\\nnew projects.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"python-nine\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1179804\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Python 2 / 3 compatibility,\
+        \ like six, but favouring Python 3\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/nine\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"There is the offtrac python library which offers\
+        \ the TracServer class. This\\nobject is how one interacts with a Trac instance\
+        \ via xmlrpc.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-offtrac\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Trac xmlrpc library\",\n      \"upstream_url\": \"http://fedorahosted.org/offtrac\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Pump.io is a socially oriented federated network.\
+        \ It provides a way to post\\nnotes and images as well and subscribe to other\
+        \ people to get updates on\\nwhat they post.\\n\\nPyPump provides an interface\
+        \ to the pump.io API's. The aim is to provide\\nvery natural pythonic representations\
+        \ of Notes, Images, People, etc...\\nallowing you to painlessly interact with\
+        \ them.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"python-pypump\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Python Pump.io library\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/PyPump\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1462278195.0,\n\
+        \      \"description\": \"A fork of SocksiPy with bug fixes and extra features.\\\
+        n\\nActs as a drop-in replacement to the socket module. Featuring:\\n\\n-\
+        \ SOCKS proxy client for Python 2.6 - 3.x\\n- TCP and UDP both supported\\\
+        n- HTTP proxy client included but not supported or recommended (you should\
+        \ use\\n  urllib2's or requests' own HTTP proxy interface)\\n- urllib2 handler\
+        \ included.\",\n      \"koschei_monitor\": true,\n      \"monitor\": \"nobuild\"\
+        ,\n      \"name\": \"python-pysocks\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/1332206\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A Python SOCKS client module\",\n  \
+        \    \"upstream_url\": \"https://github.com/Anorov/PySocks\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"Takes series data via stdin, command line, or API and prints\
+        \ a sparkline\\nrepresentation.\",\n      \"koschei_monitor\": false,\n  \
+        \    \"monitor\": false,\n      \"name\": \"python-sparklines\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"A unicode sparkline generation library\"\
+        ,\n      \"upstream_url\": \"http://pypi.python.org/pypi/pysparklines\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is a pyramid extension that allows you to use\
+        \ traversal with SQLAlchemy\\nobjects\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"python-sqlalchemy-traversal\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A pyramid extension for traversal with\
+        \ SQLAlchemy objects\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/sqlalchemy_traversal\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1466515955.0,\n\
+        \      \"description\": \"This is a process that listens to activity on upstream\
+        \ repos on pagure and\\ngithub via fedmsg, and syncs new issues there to a\
+        \ Jira instance elsewhere.\\n\\nConfiguration is in /etc/fedmsg.d/. You can\
+        \ maintain a mapping there that\\nallows you to match one upstream repo (say,\
+        \ 'pungi' on pagure) to a downstream\\nproject/component pair in Jira (say,\
+        \ 'COMPOSE', and 'Pungi').\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": true,\n      \"name\": \"python-sync2jira\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1334894\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Sync pagure and github\
+        \ issues to jira, via fedmsg\",\n      \"upstream_url\": \"https://pypi.io/pypi/sync2jira\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This is a python API for the `taskwarrior <http://taskwarrior.org>`_\\\
+        ncommand line tool.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"python-taskw\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Python bindings for your taskwarrior database\",\n      \"upstream_url\"\
+        : \"https://pypi.io/project/taskw\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1400070978.0,\n      \"description\": \"ToscaWidgets\
+        \ is a web widget toolkit for Python to aid in the creation,\\npackaging and\
+        \ distribution of common view elements normally used in the web.\\n\\nThe\
+        \ tw2.core package is lightweight and intended for run-time use only;\\ndevelopment\
+        \ tools are in tw2.devtools.\",\n      \"koschei_monitor\": false,\n     \
+        \ \"monitor\": true,\n      \"name\": \"python-tw2-core\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Web widget creation toolkit based on TurboGears widgets\"\
+        ,\n      \"upstream_url\": \"http://toscawidgets.org\"\n    },\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"ToscaWidgets is a web widget toolkit for Python to aid in the creation,\\\
+        npackaging and distribution of common view elements normally used in the web.\\\
+        n\\ntw2.d3 is a wrapper for the d3 javascript library.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-tw2-d3\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Data-Driven Documents for ToscaWidgets2\"\
+        ,\n      \"upstream_url\": \"http://toscawidgets.org\"\n    },\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"ToscaWidgets is a web widget toolkit for Python to aid in the creation,\\\
+        npackaging and distribution of common view elements normally used in the web.\\\
+        n\\ntw2.dynforms includes dynamic form building widgets that use JavaScript.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-tw2-dynforms\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Dynamic forms for ToscaWidgets2\",\n      \"upstream_url\": \"http://toscawidgets.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Simple excanvas resource wrapper for ToscaWidgets2.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-tw2-excanvas\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Excanvas for ToscaWidgets2\",\n      \"upstream_url\": \"http://toscawidgets.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"ToscaWidgets is a web widget toolkit for Python\
+        \ to aid in the creation,\\npackaging and distribution of common view elements\
+        \ normally used in the web.\\n\\ntw2.forms contains the basic form widgets.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-tw2-forms\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Forms for ToscaWidgets2\"\
+        ,\n      \"upstream_url\": \"http://toscawidgets.org\"\n    },\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"toscawidgets2 (tw2) aims to be a practical and useful widgets framework\\\
+        nthat helps people build interactive websites with compelling features, faster\\\
+        nand easier. Widgets are re-usable web components that can include a template,\\\
+        nserver-side code and JavaScripts/CSS resources. The library aims to be:\\\
+        nflexible, reliable, documented, performant, and as simple as possible.\\\
+        n\\nThe JavaScript InfoVis Toolkit (thejit) is a javascript library that\\\
+        nprovides web standard based tools to create interactive data visualizations\\\
+        nfor the Web.  It is pretty, interactive, and fast.\\n\\nThis module, tw2.jit,\
+        \ provides toscawidgets2 (tw2) widgets that render\\nthejit data visualizations.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-tw2-jit\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Javascript\
+        \ Infovis Toolkit (JIT) for ToscaWidgets2\",\n      \"upstream_url\": \"http://toscawidgets.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"toscawidgets2 (tw2) aims to be a practical and useful\
+        \ widgets framework\\nthat helps people build interactive websites with compelling\
+        \ features, faster\\nand easier. Widgets are re-usable web components that\
+        \ can include a template,\\nserver-side code and JavaScripts/CSS resources.\
+        \ The library aims to be:\\nflexible, reliable, documented, performant, and\
+        \ as simple as possible.\\n\\nflot is a pure Javascript plotting library for\
+        \ jQuery. It produces graphical\\nplots of arbitrary data sets on-the-fly\
+        \ client-side.\\n\\nThis module, tw2.jqplugins.flot, provides toscawidgets2\
+        \ (tw2) access\\nto flot widgets.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"python-tw2-jqplugins-flot\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"jQuery flot (plotting) for ToscaWidgets2\"\
+        ,\n      \"upstream_url\": \"http://toscawidgets.org\"\n    },\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This module provides growl like pop-ups with the gritter plugin for\\\
+        npython-tw2-jqplugins-ui.\",\n      \"koschei_monitor\": false,\n      \"\
+        monitor\": false,\n      \"name\": \"python-tw2-jqplugins-gritter\",\n   \
+        \   \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"jQuery gritter (growl-like pop-ups)\
+        \ for ToscaWidgets2\",\n      \"upstream_url\": \"http://toscawidgets.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"tw2.jqplugins.jqplot is a toscawidgets2 wrapper\
+        \ for jqPlot.\\n\\nToscawidgets2 aims to be a practical and useful widgets\
+        \ framework\\nthat helps people build interactive websites with compelling\
+        \ features,\\nfaster and easier. Widgets are re-usable web components that\
+        \ can include a\\ntemplate, server-side code and JavaScripts/CSS resources.\
+        \ The library aims\\nto be: flexible, reliable, documented, performant, and\
+        \ as simple as\\npossible.\\n\\njqPlot is a plotting and charting plugin for\
+        \ the jQuery Javascript\\nframework. jqPlot produces beautiful line, bar and\
+        \ pie charts.\\n\\nThis module, tw2.jqplugins.jqplot, provides toscawidgets2\
+        \ (tw2) access\\nto jqPlot widgets.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": false,\n      \"name\": \"python-tw2-jqplugins-jqplot\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Toscawidgets2 wrapper for the jqPlot\
+        \ jQuery plugin\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/tw2.jqplugins.jqplot\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"toscawidgets2 (tw2) aims to be a practical and useful\
+        \ widgets framework\\nthat helps people build interactive websites with compelling\
+        \ features, faster\\nand easier. Widgets are re-usable web components that\
+        \ can include a template,\\nserver-side code and JavaScripts/CSS resources.\
+        \ The library aims to be:\\nflexible, reliable, documented, performant, and\
+        \ as simple as possible.\\n\\njQuery is a fast and concise JavaScript Library\
+        \ that simplifies HTML\\ndocument traversing, event handling, animating, and\
+        \ Ajax interactions\\nfor rapid web development. jQuery is designed to change\
+        \ the way that\\nyou write JavaScript.\\n\\njQuery UI provides abstractions\
+        \ for low-level interaction and animation,\\nadvanced effects and high-level,\
+        \ themeable widgets, built on top of the\\njQuery JavaScript Library, that\
+        \ you can use to build highly interactive\\nweb applications.\\n\\nThis module,\
+        \ tw2.jqplugins.ui, provides toscawidgets2 (tw2) access to\\njQuery UI widgets.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-tw2-jqplugins-ui\",\n      \"namespace\": \"rpms\",\n   \
+        \   \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"jQuery UI for ToscaWidgets2\",\n      \"upstream_url\": \"http://toscawidgets.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"toscawidgets2 (tw2) aims to be a practical and useful\
+        \ widgets framework\\nthat helps people build interactive websites with compelling\
+        \ features, faster\\nand easier. Widgets are re-usable web components that\
+        \ can include a template,\\nserver-side code and JavaScripts/CSS resources.\
+        \ The library aims to be:\\nflexible, reliable, documented, performant, and\
+        \ as simple as possible.\\n\\njQuery is a fast and concise JavaScript Library\
+        \ that simplifies HTML\\ndocument traversing, event handling, animating, and\
+        \ Ajax interactions\\nfor rapid web development. jQuery is designed to change\
+        \ the way that\\nyou write JavaScript.\\n\\nThis module, tw2.jquery, provides\
+        \ toscawidgets2 (tw2) access to the\\njQuery library, a namespace package\
+        \ for jQuery plugins, and convenience\\nclasses for creating these plugins.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-tw2-jquery\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"jQuery for\
+        \ ToscaWidgets2\",\n      \"upstream_url\": \"http://toscawidgets.org\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"tw2.polymaps is a toscawidgets2 (tw2) wrapper for\
+        \ polymaps.\\n\\ntoscawidgets2 (tw2) aims to be a practical and useful widgets\
+        \ framework\\nthat helps people build interactive websites with compelling\
+        \ features,\\nfaster and easier. Widgets are re-usable web components that\
+        \ can include a\\ntemplate, server-side code and JavaScripts/CSS resources.\
+        \ The library aims\\nto be: flexible, reliable, documented, performant, and\
+        \ as simple as\\npossible.\\n\\npolymaps is a JavaScript library for image-\
+        \ and vector-tiled maps using\\nSVG.\\n\\nThis module, tw2.polymaps, provides\
+        \ toscawidgets2 (tw2) widgets that\\nrender polymaps maps!\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-tw2-polymaps\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Toscawidgets2 wrapper for polymaps -\
+        \ amazing javascript maps\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/tw2.polymaps\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"tw2.slideymenu is a toscawidgets2 package with \\\
+        \"slidey\\\" menu.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"python-tw2-slideymenu\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Toscawidgets2 wrapper for a \\\"slidey\\\" menu\",\n\
+        \      \"upstream_url\": \"http://pypi.python.org/pypi/tw2.slideymenu\"\n\
+        \    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"tw2.sqla is a database layer for ToscaWidgets 2\
+        \ and SQLAlchemy. It allows common\\ndatabase tasks to be achieved with minimal\
+        \ code.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"python-tw2-sqla\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"SQLAlchemy database layer for ToscaWidgets2\",\n      \"upstream_url\"\
+        : \"http://toscawidgets.org\"\n    },\n    {\n      \"acls\": [],\n      \"\
+        creation_date\": 1400070978.0,\n      \"description\": \"Switch virtualenvs\
+        \ with a python context manager:\\n\\n>>> from virtualenvcontext import VirtualenvContext\\\
+        n\\n>>> try:\\n>>>     import kitchen\\n>>> except ImportError as e:\\n>>>\
+        \     print \\\"kitchen is definitely not installed in system-python\\\"\\\
+        n\\n>>> with VirtaulenvContext(\\\"my-venv\\\"):\\n>>>     import kitchen\\\
+        n>>>     print \\\"But it *is* installed in my virtualenv\\\"\\n\\n>>> try:\\\
+        n>>>     import kitchen\\n>>> except ImportError as e:\\n>>>     print \\\"\
+        But once I exit that block, I lose my powers again...\\\"\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-virtualenvcontext\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Switch virtualenvs with a python context\
+        \ manager\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/virtualenvcontext\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"python-websocket-client module is WebSocket client\
+        \ for python. This\\nprovides the low level APIs for WebSocket. All APIs are\
+        \ the synchronous\\nfunctions.\\n\\npython-websocket-client supports only\
+        \ hybi-13.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-websocket-client\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"WebSocket client for python\",\n      \"upstream_url\": \"https://pypi.io/project/websocket-client\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The Buildout project provides support for creating\
+        \ applications,\\nespecially Python applications.  It provides tools for assembling\\\
+        napplications from multiple parts, Python or otherwise.  An application\\\
+        nmay actually contain multiple programs, processes, and configuration\\nsettings.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-zc-buildout\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"System for\
+        \ managing development buildouts\",\n      \"upstream_url\": \"http://buildout.org\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"doctest (and recently manuel) provide hooks for\
+        \ using custom doctest\\nparsers.  `zc.customdoctests` helps to leverage this\
+        \ to support other\\nlanguages, such as JavaScript::\\n\\njs> function double\
+        \ (x) { ...     return x*2; ... } js> double(2) 4\\n\\nAnd with manuel, it\
+        \ facilitates doctests that mix multiple languages,\\nsuch as Python, JavaScript,\
+        \ and sh.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"python-zc-customdoctests\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Use doctest with other languages\",\n      \"upstream_url\":\
+        \ \"http://pypi.python.org/pypi/zc.customdoctests\"\n    },\n    {\n     \
+        \ \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"The zc.lockfile package provides a basic portable implementation of\\\
+        ninterprocess locks using lock files. The purpose if not specifically\\nto\
+        \ lock files, but to simply provide locks with an implementation based\\non\
+        \ file-locking primitives. Of course, these locks could be used to\\nmediate\
+        \ access to other files. For example, the ZODB file storage\\nimplementation\
+        \ uses file locks to mediate access to file-storage\\ndatabase files. The\
+        \ database files and lock file files are separate files.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": true,\n      \"name\": \"python-zc-lockfile\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Basic Inter-Process Locks\",\n     \
+        \ \"upstream_url\": \"https://pypi.io/project/zc.lockfile/\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"Daemon process control library and tools for Unix-bases systems.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-zdaemon\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Python Daemon\
+        \ Process Control Library\",\n      \"upstream_url\": \"https://pypi.io/project/zdaemon/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package represents the core of the Zope Component\
+        \ Architecture.\\nTogether with the 'zope.interface' package, it provides\
+        \ facilities for\\ndefining, registering and looking up components.\",\n \
+        \     \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-zope-component\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Zope Component\
+        \ Architecture\",\n      \"upstream_url\": \"https://pypi.io/project/zope.component\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The zope configuration system provides an extensible\
+        \ system for supporting\\nvarious kinds of configurations.\\n\\nIt is based\
+        \ on the idea of configuration directives. Users of the configuration\\nsystem\
+        \ provide configuration directives in some language that express\\nconfiguration\
+        \ choices. The intent is that the language be pluggable. An XML\\nlanguage\
+        \ is provided by default.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-zope-configuration\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Zope Configuration Markup Language (ZCML)\",\n     \
+        \ \"upstream_url\": \"https://github.com/zopefoundation/zope.configuration\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package provides a utility module for content-type\
+        \ handling.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-zope-contenttype\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Content-Type Handling Utility\",\n      \"upstream_url\": \"\
+        http://pypi.python.org/pypi/zope.contenttype\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ package provides commonly used date and time related utility functions.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-zope-datetime\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Zope datetime utilities\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/zope.datetime\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package provides a simple function called 'deprecated(names,\
+        \ reason)' to\\ndeprecate the previously mentioned Python objects.\",\n  \
+        \    \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\"\
+        : \"python-zope-deprecation\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Zope 3 Deprecation\
+        \ Infrastructure\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/zope.deprecation\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The zope.dottedname module provides one function,\
+        \ 'resolve' that\\nresolves strings containing dotted names into the appropriate\
+        \ Python\\nobject.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"python-zope-dottedname\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Resolver for Python dotted names\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/zope.dottedname\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"The zope.event package provides a simple event system. It provides\\nan\
+        \ event publishing system and a very simple event-dispatching system\\non\
+        \ which more sophisticated event dispatching systems can be built.\\n(For\
+        \ example, a type-based event dispatching system that builds on\\nzope.event\
+        \ can be found in zope.component.)\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-zope-event\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\": \"\
+        Approved\",\n      \"summary\": \"Zope Event Publication\",\n      \"upstream_url\"\
+        : \"http://pypi.python.org/pypi/zope.event/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"This\
+        \ package contains exception interfaces and implementations which are so\\\
+        ngeneral purpose that they don't belong in Zope application-specific packages.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-zope-exceptions\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Zope Exceptions\"\
+        ,\n      \"upstream_url\": \"http://pypi.python.org/pypi/zope.exceptions\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"The interfaces defined here are used for file-system\
+        \ and file-system-like\\nrepresentations of objects, such as file-system synchronization,\
+        \ FTP, PUT, and\\nWebDAV.\",\n      \"koschei_monitor\": false,\n      \"\
+        monitor\": true,\n      \"name\": \"python-zope-filerepresentation\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"File-system Representation Interfaces\"\
+        ,\n      \"upstream_url\": \"http://pypi.python.org/pypi/zope.filerepresentation\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package implements several APIs related to\
+        \ internationalization and\\nlocalization and also provides:\\n\\n* Locale\
+        \ objects for all locales maintained by the ICU project.\\n\\n* Gettext-based\
+        \ message catalogs for message strings.\\n\\n* Locale discovery for Web-based\
+        \ requests.\",\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n\
+        \      \"name\": \"python-zope-i18n\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Zope Internationalization Support\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/zope.i18n\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This module provides message identifiers for internationalization.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-zope-i18nmessageid\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\": \"\
+        Message Identifiers for internationalization\",\n      \"upstream_url\": \"\
+        http://pypi.python.org/pypi/zope.i18nmessageid\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Interfaces are a mechanism for labeling objects as conforming to a given\
+        \ API\\nor contract.\\n\\nThis is a separate distribution of the zope.interface\
+        \ package used in Zope 3.\",\n      \"koschei_monitor\": false,\n      \"\
+        monitor\": true,\n      \"name\": \"python-zope-interface\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"Zope 3 Interface Infrastructure\",\n      \"upstream_url\"\
+        : \"https://pypi.io/project/zope.interface\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Interfaces\
+        \ are a mechanism for labeling objects as conforming to a given API\\nor contract.\\\
+        n\\nThis is a separate distribution of the zope.interface package used in\
+        \ Zope 3.\\n\\nThis is a forwards compatible package for epel6.\",\n     \
+        \ \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"name\":\
+        \ \"python-zope-interface4\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Forward compatible\
+        \ package for Zope 3 Interface Infrastructure\",\n      \"upstream_url\":\
+        \ \"http://pypi.python.org/pypi/zope.interface\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This package provides interfaces / implementations for events relative\
+        \ to\\nthe lifetime of a server process (startup, database opening, etc.)\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python-zope-processlifetime\",\n      \"namespace\": \"rpms\",\n\
+        \      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"Zope process lifetime events\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/zope.processlifetime\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package provides convenient functions for dealing\
+        \ with proxies.\",\n      \"koschei_monitor\": false,\n      \"monitor\":\
+        \ true,\n      \"name\": \"python-zope-proxy\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Generic Transparent Proxies\",\n      \"upstream_url\": \"https://github.com/zopefoundation/zope.proxy\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package is a zope.interface extension for defining\
+        \ data schemas.\",\n      \"koschei_monitor\": false,\n      \"monitor\":\
+        \ true,\n      \"name\": \"python-zope-schema\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n  \
+        \    \"summary\": \"Zope 3 schemas\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/zope.schema\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package provides a very advanced sequence sorting\
+        \ feature.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"python-zope-sequencesort\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Sequence Sorting\",\n      \"upstream_url\": \"http://cheeseshop.python.org/pypi/zope.sequencesort\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This package provides a parser and renderers for\
+        \ the classic Zope\\n\\\"structured text\\\" markup dialect (STX).  STX is\
+        \ a plain text markup in\\nwhich document structure is signaled primarily\
+        \ by indentation\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : false,\n      \"name\": \"python-zope-structuredtext\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": null,\n      \"status\": \"Approved\",\n\
+        \      \"summary\": \"StructuredText parser\",\n      \"upstream_url\": \"\
+        http://pypi.python.org/pypi/zope.structuredtext\"\n    },\n    {\n      \"\
+        acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"This package provides a number of testing frameworks. It includes a\\\
+        nflexible test runner, and supports both doctest and unittest.\",\n      \"\
+        koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\": \"python-zope-testing\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Zope Testing Framework\",\n      \"\
+        upstream_url\": \"https://pypi.io/project/zope.testing\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"The dateutil module provides powerful extensions to the standard datetime\\\
+        nmodule available in Python 2.3+.\\n\\nThis is the version for Python 3.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n      \"\
+        name\": \"python3-dateutil\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Powerful extensions\
+        \ to the standard datetime module\",\n      \"upstream_url\": \"https://github.com/dateutil/dateutil\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Shell Flags (shFlags) is a library written to greatly\
+        \ simplify the handling of\\ncommand-line flags in Bourne based Unix shell\
+        \ scripts (bash, dash, ksh, sh, zsh)\\non many Unix OSes (Linux, Solaris,\
+        \ Mac OS X, etc.).\\n\\nMost shell scripts use getopt for flags processing,\
+        \ but the different versions\\nof getopt on various OSes make writing portable\
+        \ shell scripts difficult. shFlags\\ninstead provides an API that doesn't\
+        \ change across shell and OS versions so the\\nscript writer can be confident\
+        \ that the script will work.\\n\\nshFlags is a port of the google-gflags C++/Python\
+        \ library.\",\n      \"koschei_monitor\": false,\n      \"monitor\": false,\n\
+        \      \"name\": \"shflags\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"Simple handling\
+        \ of command-line flags in Bourne based Unix scripts\",\n      \"upstream_url\"\
+        : \"http://code.google.com/p/shflags/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1420481368.0,\n      \"description\": \"The Taskserver\
+        \ is a lightweight, secure server providing multi-user,\\nmulti-client access\
+        \ to task data.  This allows true syncing between desktop and\\nmobile clients.\\\
+        n\\nUsers want task list access from multiple devices running software of\
+        \ differing\\nsophistication levels to synchronize data seamlessly.  Synchronization\
+        \ requires\\nthe ability to exchange transactions between devices that may\
+        \ not have\\ncontinuous connectivity, and may not have feature parity.\\n\\\
+        nThe Taskserver provides this and builds a framework to go several steps beyond\\\
+        nmerely synchronizing data.\",\n      \"koschei_monitor\": false,\n      \"\
+        monitor\": true,\n      \"name\": \"taskd\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1066573\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Secure server providing multi-user,\
+        \ multi-client access to task data\",\n      \"upstream_url\": \"http://tasktools.org/projects/taskd.html\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1488405000.0,\n\
+        \      \"description\": \"A testmodule, meant to test the Module Build Service\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": false,\n      \"name\"\
+        : \"testmodule\",\n      \"namespace\": \"modules\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1397142\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A testmodule, meant to test the MBS\",\n      \"upstream_url\"\
+        : \"\"\n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1488568086.0,\n\
+        \      \"description\": \"This module demonstrates the modulemd format using\
+        \ a fairly uncommon fonts package set.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": false,\n      \"name\": \"testmodule2\",\n      \"namespace\"\
+        : \"modules\",\n      \"review_url\": \"https://bugzilla.redhat.com/1397142\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Another test module\
+        \ for the ModuleBuildService\",\n      \"upstream_url\": \"\"\n    }\n  ],\n\
+        \  \"watch\": [\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"This Python module allows you to create TCP connections\
+        \ through a SOCKS\\nproxy without any special effort.\",\n      \"koschei_monitor\"\
+        : false,\n      \"monitor\": false,\n      \"name\": \"python-SocksiPy\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"A Python SOCKS module\",\n      \"upstream_url\"\
+        : \"http://socksipy.sourceforge.net/\"\n    }\n  ]\n}"}
+    headers:
+      accept-ranges: [bytes]
+      age: ['0']
+      appserver: [proxy01.phx2.fedoraproject.org]
+      apptime: [D=1526953]
+      connection: [Keep-Alive]
+      content-length: ['168868']
+      content-type: [application/json]
+      date: ['Wed, 29 Mar 2017 20:40:06 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['pkgdb=eyJfcGVybWFuZW50Ijp0cnVlfQ.C72tJw.x-8BVLnRM-B8s9MpAyocKgQH-aI;
+          Expires=Wed, 29-Mar-2017 21:40:07 GMT; Secure; HttpOnly; Path=/pkgdb/']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['12951523']
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_generic.UserPackageFilterTests.test_no_matching_packages
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_generic.UserPackageFilterTests.test_no_matching_packages
@@ -1,0 +1,505 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.12.5]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/packager/package/jcline
+  response:
+    body: {string: !!python/unicode "{\n  \"co-maintained\": [\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Bodhi\
+        \ is a web application that facilitates the process of publishing\\nupdates\
+        \ for a software distribution.\\n\\nA modular piece of the Fedora Infrastructure\
+        \ stack\\n* Utilizes the Koji Buildsystem for tracking RPMs\\n* Creates the\
+        \ update repositories using Mash, which composes a repository based\\n  on\
+        \ tagged builds in Koji.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"bodhi\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"A modular framework that facilitates publishing software updates\",\n\
+        \      \"upstream_url\": \"https://github.com/fedora-infra/bodhi\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"ejabberd is a Free and Open Source distributed fault-tolerant\\\
+        nJabber/XMPP server. It is mostly written in Erlang, and runs on many\\nplatforms\
+        \ (tested on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"ejabberd\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"A distributed, fault-tolerant\
+        \ Jabber/XMPP server\",\n      \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1461430105.0,\n\
+        \      \"description\": \"ProcessOne SIP server component in Erlang.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"review_url\":\
+        \ \"https://bugzilla.redhat.com/1329441\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"ProcessOne SIP server component in Erlang\",\n   \
+        \   \"upstream_url\": \"https://github.com/processone/esip/\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1459274896.0,\n      \"\
+        description\": \"A native zlib driver for Erlang / Elixir, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1315134\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Native zlib driver for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/ezlib/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1460378527.0,\n      \"description\": \"TLS\
+        \ / SSL native driver for Erlang / Elixir. This is used by ejabberd.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316767\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"TLS / SSL native driver for Erlang / Elixir\",\n \
+        \     \"upstream_url\": \"https://github.com/processone/fast_tls/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1460475617.0,\n    \
+        \  \"description\": \"Fast Expat based Erlang XML parsing and manipulation\
+        \ library, with a strong\\nfocus on XML stream parsing from network. It supports\
+        \ full XML structure\\nparsing, suitable for small but complete XML chunks,\
+        \ and XML stream parsing\\nsuitable for large XML document, or infinite network\
+        \ XML stream like XMPP.\\nThis module can parse files much faster than built-in\
+        \ module xmerl. Depending\\non file complexity and size xml_stream:parse_element/1\
+        \ can be 8-18 times faster\\nthan calling xmerl_scan:string/2.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"erlang-fast_xml\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317182\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast Expat based\
+        \ Erlang XML parsing and manipulation library\",\n      \"upstream_url\":\
+        \ \"https://github.com/processone/fast_xml/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1459274717.0,\n      \"description\": \"P1\
+        \ YAML is an Erlang wrapper for libyaml \\\"C\\\" library.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-fast_yaml\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317184\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An Erlang wrapper\
+        \ for libyaml \\\"C\\\" library\",\n      \"upstream_url\": \"https://github.com/processone/fast_yaml/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1455917846.0,\n\
+        \      \"description\": \"A small Erlang app that provides fast event stream\
+        \ processing.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"erlang-goldrush\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/1309939\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Small, fast event processing and monitoring\
+        \ for Erlang/OTP applications\",\n      \"upstream_url\": \"https://github.com/DeadZen/goldrush\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1459968632.0,\n\
+        \      \"description\": \"Erlang bindings for libiconv. This is used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316762\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Fast encoding conversion library for Erlang / Elixir\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/iconv/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1458136455.0,\n    \
+        \  \"description\": \"An experimental implementation of Lua 5.2 written solely\
+        \ in pure Erlang.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"erlang-luerl\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1317345\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Lua in Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/rvirding/luerl\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1455034950.0,\n      \"description\": \"This library\
+        \ is designed to simplify the implementation of the server side of\\nOAuth2.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1294331\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"An Oauth2 implementation for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/kivra/oauth2\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1454706689.0,\n      \"description\": \"Erlang bindings\
+        \ for iconv. This is used by ejabberd.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-p1_iconv\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1294368\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast encoding conversion\
+        \ library for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/iconv/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454706783.0,\n\
+        \      \"description\": \"This is an Erlang MySQL driver, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295011\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Pure Erlang MySQL driver\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/p1_mysql/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1458568963.0,\n      \"description\": \"This\
+        \ library is designed to simplify the implementation of the server side of\\\
+        nOAuth2. It is a fork of erlang-oauth2 by processone, and is needed by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1317336\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"An Oauth2 implementation for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/p1_oauth2\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1454870042.0,\n      \"description\": \"An\
+        \ Erlang library for ejabberd that helps with PAM authentication.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295035\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Library for ejabberd for PAM authentication support\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/epam/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1454706762.0,\n    \
+        \  \"description\": \"Pure Erlang PostgreSQL driver.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_pgsql\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1294730\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Pure Erlang PostgreSQL\
+        \ driver\",\n      \"upstream_url\": \"https://github.com/processone/p1_pgsql\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1451836021.0,\n\
+        \      \"description\": \"p1_utils is an application containing ProcessOne\
+        \ modules and tools that are\\nleveraged in other development projects.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_utils\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1294587\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Erlang utility modules from ProcessOne\",\n      \"\
+        upstream_url\": \"https://github.com/processone/p1_utils/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1458659356.0,\n      \"description\"\
+        : \"This is an HTTP 1.1 compliant XML-RPC library for Erlang. It is designed\
+        \ to make\\nit easy to write XML-RPC Erlang clients and/or servers. The library\
+        \ is compliant\\nwith the XML-RPC specification published by http://www.xmlrpc.org/.\
+        \ It is a fork\\nof erlang-xmlrpc maintained by processone for ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1317341\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Erlang XMLRPC implementation with SSL, cookies, Authentication\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/p1_xmlrpc\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454870064.0,\n\
+        \      \"description\": \"A native zlib driver for Erlang, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295009\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Native zlib driver for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/ezlib/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1452180599.0,\n      \"description\": \"PropEr\
+        \ (PROPerty-based testing tool for ERlang) is a QuickCheck-inspired\\nopen-source\
+        \ property-based testing tool for Erlang.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-proper\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1295667\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A QuickCheck-inspired\
+        \ property-based testing tool for Erlang\",\n      \"upstream_url\": \"https://github.com/manopapad/proper\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460378560.0,\n\
+        \      \"description\": \"Stringprep is a framework for preparing Unicode\
+        \ test strings in order to\\nincrease the likelihood that string input and\
+        \ string comparison work. The\\nprinciple are defined in RFC-3454: Preparation\
+        \ of Internationalized Strings.\\nThis library is leverage Erlang native NIF\
+        \ mechanism to provide extremely fast\\nand efficient processing.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316772\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A framework for preparing Unicode strings to help\
+        \ input and comparison\",\n      \"upstream_url\": \"https://github.com/processone/stringprep/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460475644.0,\n\
+        \      \"description\": \"STUN and TURN library for Erlang / Elixir. Both\
+        \ STUN (Session Traversal\\nUtilities for NAT) and TURN standards are used\
+        \ as techniques to establish media\\nconnection between peers for VoIP (for\
+        \ example using SIP or Jingle) and WebRTC.\",\n      \"koschei_monitor\":\
+        \ true,\n      \"monitor\": true,\n      \"name\": \"erlang-stun\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317183\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"STUN and TURN library\
+        \ for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/stun/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483391539.0,\n\
+        \      \"description\": \"XMPP is an Erlang XMPP parsing and serialization\
+        \ library, built on top of Fast\\nXML.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-xmpp\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1409326\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Erlang/Elixir XMPP\
+        \ parsing and serialization library\",\n      \"upstream_url\": \"https://github.com/processone/xmpp/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484067733.0,\n\
+        \      \"description\": \"Fegistry is the container registry endpoint for\
+        \ Fedora's users. It will answer\\nthe initial requests when users docker\
+        \ pull Fedora containers.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"fegistry\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/1411462\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"The Fedora registry endpoint\",\n  \
+        \    \"upstream_url\": \"https://pagure.io/fegistry\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1453388826.0,\n      \"description\"\
+        : \"This WSGI application exposes a read-only API similar to\\ndocker-registry,\
+        \ which docker can use for \\\"docker pull\\\" operations.\\nRequests for\
+        \ actual image files are responded to with 302 redirects to\\na URL formed\
+        \ with per-repository settings.\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": true,\n      \"name\": \"python-crane\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297629\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A WSGI app providing\
+        \ a docker-registry-like API with redirection\",\n      \"upstream_url\":\
+        \ \"https://github.com/pulp/crane\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1419871778.0,\n      \"description\": \"A library\
+        \ to support the Internationalised Domain Names in Applications (IDNA)\\nprotocol\
+        \ as specified in RFC 5891 <http://tools.ietf.org/html/rfc5891>.  This\\nversion\
+        \ of the protocol is often referred to as \\\"IDNA2008\\\" and can produce\\\
+        ndifferent results from the earlier standard from 2003.\\n\\nThe library is\
+        \ also intended to act as a suitable drop-in replacement for the\\n\\\"encodings.idna\\\
+        \" module that comes with the Python standard library but\\ncurrently only\
+        \ supports the older 2003 specification.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-idna\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1119056\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Internationalized\
+        \ Domain Names in Applications (IDNA)\",\n      \"upstream_url\": \"https://github.com/kjd/idna\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"IPython features (tab completion, syntax highlighting,\
+        \ better tracebacks,\\nbetter introspection) right in pdb.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-ipdb\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"IPython enabled Python debugger\",\n\
+        \      \"upstream_url\": \"https://github.com/gotcha/ipdb/\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"This module implements ISO 8601 date, time and duration parsing.\
+        \ The\\nimplementation follows ISO8601:2004 standard, and implements only\
+        \ date/time\\nrepresentations mentioned in the standard. If something is not\
+        \ mentioned there,\\nthen it is treated as non existent, and not as an allowed\
+        \ option.\\n\\nFor instance, ISO8601:2004 never mentions 2 digit years. So,\
+        \ it is not intended\\nby this module to support 2 digit years. (while it\
+        \ may still be valid as ISO\\ndate, because it is not explicitly forbidden.)\
+        \ Another example is, when no time\\nzone information is given for a time,\
+        \ then it should be interpreted as local\\ntime, and not UTC.\\n\\nAs this\
+        \ module maps ISO 8601 dates/times to standard Python data types, like\\ndate,\
+        \ time, datetime and timedelta, it is not possible to convert all possible\\\
+        nISO 8601 dates/times. For instance, dates before 0001-01-01 are not allowed\
+        \ by\\nthe Python date and datetime classes. Additionally fractional seconds\
+        \ are\\nlimited to microseconds. That means if the parser finds for instance\\\
+        nnanoseconds it will round it to microseconds.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-isodate\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An ISO 8601 date/time/duration parser\
+        \ and formatter\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/isodate\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483389591.0,\n\
+        \      \"description\": \"configuration parser.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-kaptan\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1405742\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Configuration parser\"\
+        ,\n      \"upstream_url\": \"https://pypi.python.org/pypi/kaptan\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"The Python driver for MongoDB.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-pymongo\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Python driver for MongoDB\",\n     \
+        \ \"upstream_url\": \"http://api.mongodb.org/python\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Most existing Python modules for sending HTTP requests are extremely verbose\
+        \ and\\ncumbersome. Python\\u2019s built-in urllib2 module provides most of\
+        \ the HTTP\\ncapabilities you should need, but the API is thoroughly broken.\
+        \ This library is\\ndesigned to make HTTP requests easy for developers.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-requests\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"HTTP library,\
+        \ written in Python, for human beings\",\n      \"upstream_url\": \"https://pypi.io/project/requests\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1448383568.0,\n\
+        \      \"description\": \"A wrapper around pdb allowing remote debugging via\
+        \ netcat or telnet.\\nThis is especially useful in a Tomcat/Jython environment\
+        \ where little\\ndebugging tools are available.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-rpdb\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1284155\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A wrapper around\
+        \ pdb allowing remote debugging\",\n      \"upstream_url\": \"https://github.com/tamentis/rpdb\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Python HTTP module with connection pooling and file\
+        \ POST abilities.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-urllib3\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Python HTTP library with thread-safe connection pooling and file\
+        \ post\",\n      \"upstream_url\": \"https://github.com/shazow/urllib3\"\n\
+        \    }\n  ],\n  \"output\": \"ok\",\n  \"point of contact\": [\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1452379737.0,\n      \"description\"\
+        : \"This application is intended to proxy back-end operations for Key-Value\
+        \ insert,\\nlookup and delete and maintain a cache of those Key-Values in-memory,\
+        \ to save\\nback-end operations. Operations are intended to be atomic between\
+        \ back-end and\\ncache tables. The lifetime of the cache object and the max\
+        \ size of the cache\\ncan be defined as table parameters to limit the size\
+        \ of the in-memory tables.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": true,\n      \"name\": \"erlang-cache_tab\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1295075\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Erlang cache table\
+        \ application\",\n      \"upstream_url\": \"https://github.com/processone/cache_tab/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454421370.0,\n\
+        \      \"description\": \"ProcessOne SIP server component in Erlang.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1303434\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"ProcessOne SIP server component in Erlang\",\n   \
+        \   \"upstream_url\": \"https://github.com/processone/p1_sip/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1454521406.0,\n    \
+        \  \"description\": \"Stringprep is a framework for preparing Unicode test\
+        \ strings in order to\\nincrease the likelihood that string input and string\
+        \ comparison work. The\\nprinciple are defined in RFC-3454: Preparation of\
+        \ Internationalized Strings.\\nThis library is leverage Erlang native NIF\
+        \ mechanism to provide extremely fast\\nand efficient processing.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1296792\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A framework for preparing Unicode strings to help\
+        \ input and comparison\",\n      \"upstream_url\": \"https://github.com/processone/stringprep/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453840458.0,\n\
+        \      \"description\": \"STUN and TURN library for Erlang / Elixir. Both\
+        \ STUN (Session Traversal\\nUtilities for NAT) and TURN standards are used\
+        \ as techniques to establish media\\nconnection between peers for VoIP (for\
+        \ example using SIP or Jingle) and WebRTC.\",\n      \"koschei_monitor\":\
+        \ false,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_stun\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1301316\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"STUN and TURN library\
+        \ for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/stun/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453389245.0,\n\
+        \      \"description\": \"TLS / SSL native driver for Erlang / Elixir. This\
+        \ is used by ejabberd.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"erlang-p1_tls\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1299305\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"TLS / SSL native driver for\
+        \ Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/tls/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454593209.0,\n\
+        \      \"description\": \"Fast Expat based Erlang XML parsing and manipulation\
+        \ library, with a strong\\nfocus on XML stream parsing from network. It supports\
+        \ full XML structure\\nparsing, suitable for small but complete XML chunks,\
+        \ and XML stream parsing\\nsuitable for large XML document, or infinite network\
+        \ XML stream like XMPP.\\nThis module can parse files much faster than built-in\
+        \ module xmerl. Depending\\non file complexity and size xml_stream:parse_element/1\
+        \ can be 8-18 times faster\\nthan calling xmerl_scan:string/2.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_xml\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297150\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast Expat based\
+        \ Erlang XML parsing and manipulation library\",\n      \"upstream_url\":\
+        \ \"https://github.com/processone/xml/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1453730519.0,\n      \"description\": \"P1 YAML\
+        \ is an Erlang wrapper for libyaml \\\"C\\\" library.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_yaml\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297094\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An Erlang wrapper\
+        \ for libyaml \\\"C\\\" library\",\n      \"upstream_url\": \"https://github.com/processone/p1_yaml/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467902264.0,\n\
+        \      \"description\": \"Argument Parsing for Humans.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-args\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352993\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Argument Parsing\
+        \ for Humans\",\n      \"upstream_url\": \"https://github.com/kennethreitz/args\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468427737.0,\n\
+        \      \"description\": \"Clint is a module filled with a set of awesome tools\
+        \ for developing commandline\\napplications. It supports colors, but detects\
+        \ if the session is a TTY, so\\ndoesn't render the colors if you're piping\
+        \ stuff around. Automagically.\",\n      \"koschei_monitor\": true,\n    \
+        \  \"monitor\": true,\n      \"name\": \"python-clint\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1355871\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A set of awesome\
+        \ tools for developing commandline applications\",\n      \"upstream_url\"\
+        : \"https://github.com/kennethreitz/clint\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1452266443.0,\n      \"description\": \"A\
+        \ web based tool for monitoring and administrating Celery clusters. It offers\\\
+        nreal-time monitoring using Celery events, remote control of workers and tasks,\\\
+        nbroker monitoring, and an HTTP API.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-flower\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1285941\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A web based tool\
+        \ for monitoring and administrating Celery clusters\",\n      \"upstream_url\"\
+        : \"https://github.com/mher/flower\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1486055679.0,\n      \"description\": \"fmn is a\
+        \ family of systems to manage end-user notifications triggered by\\nfedmsg,\
+        \ the FEDerated MESsage bus. fmn provides a single place for all\\napplications\
+        \ using fedmsg to notify users of events. Notifications can be\\ndelivered\
+        \ by email, IRC, and server-sent events. Users can configure their\\nnotifications\
+        \ for all the applications they use in one place.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-fmn\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1410901\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A system for generic\
+        \ fedmsg-driven notifications for end users\",\n      \"upstream_url\": \"\
+        https://github.com/fedora-infra/fmn\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1485179561.0,\n      \"description\": \"fmn is a\
+        \ family of systems to manage end-user notifications triggered by\\nfedmsg,\
+        \ the FEDerated MESsage bus. The FMN Server-Sent Events server allows\\nusers\
+        \ to view their fedmsg feed in real-time using server-sent events. It relies\\\
+        non a service to populate the RabbitMQ message queues for it. Typically, this\
+        \ is\\ndone with the FMN core services.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-fmn-sse\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1412798\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A server-sent events\
+        \ server that integrates with FMN\",\n      \"upstream_url\": \"https://github.com/fedora-infra/fmn.sse\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467055928.0,\n\
+        \      \"description\": \"Invocations is a collection of reusable Invoke tasks/task\
+        \ modules, including\\n(but not limited to) Python project management tools\
+        \ such as documentation\\nbuilding and dependency organization. It has no\
+        \ stand-alone components and is\\ndesigned to be imported into your pre-existing\
+        \ Invoke task files.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-invocations\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1349121\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Invocations is a collection\
+        \ of reusable Invoke tasks/task modules\",\n      \"upstream_url\": \"https://github.com/pyinvoke/invocations\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489158551.0,\n\
+        \      \"description\": \"Allows synapse to use LDAP as a password provider.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-matrix-synapse-ldap3\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1430170\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Allows synapse to use LDAP as a password\
+        \ provider\",\n      \"upstream_url\": \"https://github.com/matrix-org/matrix-synapse-ldap3\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467054202.0,\n\
+        \      \"description\": \"This package provides an API for querying the distutils\
+        \ metadata written in the\\nPKG-INFO file inside a source distribution (an\
+        \ sdist) or a binary distribution\\n(e.g., created by running bdist_egg).\
+        \ It can also query the EGG-INFO directory\\nof an installed distribution,\
+        \ and the *.egg-info stored in a \\\"development\\ncheckout\\\" (e.g, created\
+        \ by running setup.py develop).\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": true,\n      \"name\": \"python-pkginfo\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1349026\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Query metadata from\
+        \ sdists / bdists / installed packages\",\n      \"upstream_url\": \"https://pypi.python.org/pypi/pkginfo\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489425664.0,\n\
+        \      \"description\": \"This is a Python re-implementation of the libmacaroons\
+        \ C library.\\nMacaroons, like cookies, are a form of bearer credential. Unlike\\\
+        nopaque tokens, macaroons embed caveats that define specific authorization\\\
+        nrequirements for the target service, the service that issued the root macaroon\\\
+        nand which is capable of verifying the integrity of macaroons it receives.\\\
+        n\\nMacaroons allow for delegation and attenuation of authorization. They\
+        \ are\\nsimple and fast to verify, and decouple authorization policy from\
+        \ the\\nenforcement of that policy.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-pymacaroons-pynacl\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1430107\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Library providing\
+        \ non-opaque cookies for authorization\",\n      \"upstream_url\": \"https://github.com/matrix-org/pymacaroons\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467389346.0,\n\
+        \      \"description\": \"Releases is a Sphinx extension designed to help\
+        \ you keep a source control\\nfriendly, merge friendly changelog file & turn\
+        \ it into useful, human readable\\nHTML output.\\n\\nSpecifically:\\n\\n*\
+        \ The source format (kept in your Sphinx tree as changelog.rst) is a stream-like\\\
+        ntimeline that plays well with source control & only requires one entry per\\\
+        nchange (even for changes that exist in multiple release lines).\\n* The output\
+        \ (when you have the extension installed and run your Sphinx build\\ncommand)\
+        \ is a traditional looking changelog page with a section for every\\nrelease;\
+        \ multi-release issues are copied automatically into each release.\\n* By\
+        \ default, feature and support issues are only displayed under feature\\nreleases,\
+        \ and bugs are only displayed under bugfix releases. This can be\\noverridden\
+        \ on a per-issue basis.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-releases\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1350943\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"A Sphinx extension for changelog\
+        \ manipulation\",\n      \"upstream_url\": \"https://github.com/bitprophet/releases\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1450359898.0,\n\
+        \      \"description\": \"sphinxcontrib-fulltoc is an extension for the Sphinx\
+        \ documentation system that\\nchanges the HTML output to include a more detailed\
+        \ table of contents in the\\nsidebar. By default Sphinx only shows the local\
+        \ headers for the current page.\\nWith the extension installed, all of the\
+        \ page titles are included, and the\\nlocal headers for the current page are\
+        \ also included in the appropriate place\\nwithin the document.\",\n     \
+        \ \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"\
+        python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1291007\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Include a full table of contents in\
+        \ your Sphinx HTML sidebar\",\n      \"upstream_url\": \"https://github.com/dreamhost/sphinxcontrib-fulltoc\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484077565.0,\n\
+        \      \"description\": \"Turn SQLAlchemy DB Model into a graph.\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"\
+        python-sqlalchemy_schemadisplay\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1409929\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Turn SQLAlchemy DB Model into a graph\"\
+        ,\n      \"upstream_url\": \"https://github.com/fschulze/sqlalchemy_schemadisplay\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1469020897.0,\n\
+        \      \"description\": \"Twine is a utility for interacting with PyPI.\\\
+        nCurrently it only supports registering projects and uploading distributions.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-twine\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1352972\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Collection of utilities for interacting with PyPI\"\
+        ,\n      \"upstream_url\": \"https://github.com/pypa/twine\"\n    }\n  ],\n\
+        \  \"watch\": [\n    {\n      \"acls\": [],\n      \"creation_date\": 1468428962.0,\n\
+        \      \"description\": \"A parser for TOML-0.4.0\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-pytoml\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1353606\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Parser for TOML\"\
+        ,\n      \"upstream_url\": \"https://github.com/avakar/pytoml\"\n    }\n \
+        \ ]\n}"}
+    headers:
+      accept-ranges: [bytes]
+      age: ['0']
+      appserver: [proxy04.fedoraproject.org]
+      apptime: [D=454922]
+      connection: [Keep-Alive]
+      content-length: ['33867']
+      content-type: [application/json]
+      date: ['Wed, 29 Mar 2017 20:21:20 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['pkgdb=eyJfcGVybWFuZW50Ijp0cnVlfQ.C72owA.Cjgj8SS93ni8NewU6PH0cpeUWBo;
+          Expires=Wed, 29-Mar-2017 21:21:20 GMT; Secure; HttpOnly; Path=/pkgdb/']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['8941123']
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagesForTests.test_all
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagesForTests.test_all
@@ -1,0 +1,505 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/packager/package/jcline
+  response:
+    body: {string: !!python/unicode "{\n  \"co-maintained\": [\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Bodhi\
+        \ is a web application that facilitates the process of publishing\\nupdates\
+        \ for a software distribution.\\n\\nA modular piece of the Fedora Infrastructure\
+        \ stack\\n* Utilizes the Koji Buildsystem for tracking RPMs\\n* Creates the\
+        \ update repositories using Mash, which composes a repository based\\n  on\
+        \ tagged builds in Koji.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"bodhi\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"A modular framework that facilitates publishing software updates\",\n\
+        \      \"upstream_url\": \"https://github.com/fedora-infra/bodhi\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"ejabberd is a Free and Open Source distributed fault-tolerant\\\
+        nJabber/XMPP server. It is mostly written in Erlang, and runs on many\\nplatforms\
+        \ (tested on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"ejabberd\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"A distributed, fault-tolerant\
+        \ Jabber/XMPP server\",\n      \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1461430105.0,\n\
+        \      \"description\": \"ProcessOne SIP server component in Erlang.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"review_url\":\
+        \ \"https://bugzilla.redhat.com/1329441\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"ProcessOne SIP server component in Erlang\",\n   \
+        \   \"upstream_url\": \"https://github.com/processone/esip/\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1459274896.0,\n      \"\
+        description\": \"A native zlib driver for Erlang / Elixir, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1315134\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Native zlib driver for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/ezlib/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1460378527.0,\n      \"description\": \"TLS\
+        \ / SSL native driver for Erlang / Elixir. This is used by ejabberd.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316767\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"TLS / SSL native driver for Erlang / Elixir\",\n \
+        \     \"upstream_url\": \"https://github.com/processone/fast_tls/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1460475617.0,\n    \
+        \  \"description\": \"Fast Expat based Erlang XML parsing and manipulation\
+        \ library, with a strong\\nfocus on XML stream parsing from network. It supports\
+        \ full XML structure\\nparsing, suitable for small but complete XML chunks,\
+        \ and XML stream parsing\\nsuitable for large XML document, or infinite network\
+        \ XML stream like XMPP.\\nThis module can parse files much faster than built-in\
+        \ module xmerl. Depending\\non file complexity and size xml_stream:parse_element/1\
+        \ can be 8-18 times faster\\nthan calling xmerl_scan:string/2.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"erlang-fast_xml\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317182\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast Expat based\
+        \ Erlang XML parsing and manipulation library\",\n      \"upstream_url\":\
+        \ \"https://github.com/processone/fast_xml/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1459274717.0,\n      \"description\": \"P1\
+        \ YAML is an Erlang wrapper for libyaml \\\"C\\\" library.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-fast_yaml\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317184\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An Erlang wrapper\
+        \ for libyaml \\\"C\\\" library\",\n      \"upstream_url\": \"https://github.com/processone/fast_yaml/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1455917846.0,\n\
+        \      \"description\": \"A small Erlang app that provides fast event stream\
+        \ processing.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"erlang-goldrush\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/1309939\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Small, fast event processing and monitoring\
+        \ for Erlang/OTP applications\",\n      \"upstream_url\": \"https://github.com/DeadZen/goldrush\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1459968632.0,\n\
+        \      \"description\": \"Erlang bindings for libiconv. This is used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316762\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Fast encoding conversion library for Erlang / Elixir\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/iconv/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1458136455.0,\n    \
+        \  \"description\": \"An experimental implementation of Lua 5.2 written solely\
+        \ in pure Erlang.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"erlang-luerl\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1317345\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Lua in Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/rvirding/luerl\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1455034950.0,\n      \"description\": \"This library\
+        \ is designed to simplify the implementation of the server side of\\nOAuth2.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1294331\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"An Oauth2 implementation for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/kivra/oauth2\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1454706689.0,\n      \"description\": \"Erlang bindings\
+        \ for iconv. This is used by ejabberd.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-p1_iconv\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1294368\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast encoding conversion\
+        \ library for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/iconv/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454706783.0,\n\
+        \      \"description\": \"This is an Erlang MySQL driver, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295011\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Pure Erlang MySQL driver\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/p1_mysql/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1458568963.0,\n      \"description\": \"This\
+        \ library is designed to simplify the implementation of the server side of\\\
+        nOAuth2. It is a fork of erlang-oauth2 by processone, and is needed by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1317336\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"An Oauth2 implementation for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/p1_oauth2\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1454870042.0,\n      \"description\": \"An\
+        \ Erlang library for ejabberd that helps with PAM authentication.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295035\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Library for ejabberd for PAM authentication support\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/epam/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1454706762.0,\n    \
+        \  \"description\": \"Pure Erlang PostgreSQL driver.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_pgsql\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1294730\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Pure Erlang PostgreSQL\
+        \ driver\",\n      \"upstream_url\": \"https://github.com/processone/p1_pgsql\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1451836021.0,\n\
+        \      \"description\": \"p1_utils is an application containing ProcessOne\
+        \ modules and tools that are\\nleveraged in other development projects.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_utils\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1294587\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Erlang utility modules from ProcessOne\",\n      \"\
+        upstream_url\": \"https://github.com/processone/p1_utils/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1458659356.0,\n      \"description\"\
+        : \"This is an HTTP 1.1 compliant XML-RPC library for Erlang. It is designed\
+        \ to make\\nit easy to write XML-RPC Erlang clients and/or servers. The library\
+        \ is compliant\\nwith the XML-RPC specification published by http://www.xmlrpc.org/.\
+        \ It is a fork\\nof erlang-xmlrpc maintained by processone for ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1317341\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Erlang XMLRPC implementation with SSL, cookies, Authentication\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/p1_xmlrpc\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454870064.0,\n\
+        \      \"description\": \"A native zlib driver for Erlang, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295009\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Native zlib driver for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/ezlib/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1452180599.0,\n      \"description\": \"PropEr\
+        \ (PROPerty-based testing tool for ERlang) is a QuickCheck-inspired\\nopen-source\
+        \ property-based testing tool for Erlang.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-proper\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1295667\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A QuickCheck-inspired\
+        \ property-based testing tool for Erlang\",\n      \"upstream_url\": \"https://github.com/manopapad/proper\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460378560.0,\n\
+        \      \"description\": \"Stringprep is a framework for preparing Unicode\
+        \ test strings in order to\\nincrease the likelihood that string input and\
+        \ string comparison work. The\\nprinciple are defined in RFC-3454: Preparation\
+        \ of Internationalized Strings.\\nThis library is leverage Erlang native NIF\
+        \ mechanism to provide extremely fast\\nand efficient processing.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316772\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A framework for preparing Unicode strings to help\
+        \ input and comparison\",\n      \"upstream_url\": \"https://github.com/processone/stringprep/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460475644.0,\n\
+        \      \"description\": \"STUN and TURN library for Erlang / Elixir. Both\
+        \ STUN (Session Traversal\\nUtilities for NAT) and TURN standards are used\
+        \ as techniques to establish media\\nconnection between peers for VoIP (for\
+        \ example using SIP or Jingle) and WebRTC.\",\n      \"koschei_monitor\":\
+        \ true,\n      \"monitor\": true,\n      \"name\": \"erlang-stun\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317183\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"STUN and TURN library\
+        \ for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/stun/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483391539.0,\n\
+        \      \"description\": \"XMPP is an Erlang XMPP parsing and serialization\
+        \ library, built on top of Fast\\nXML.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-xmpp\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1409326\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Erlang/Elixir XMPP\
+        \ parsing and serialization library\",\n      \"upstream_url\": \"https://github.com/processone/xmpp/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484067733.0,\n\
+        \      \"description\": \"Fegistry is the container registry endpoint for\
+        \ Fedora's users. It will answer\\nthe initial requests when users docker\
+        \ pull Fedora containers.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"fegistry\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/1411462\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"The Fedora registry endpoint\",\n  \
+        \    \"upstream_url\": \"https://pagure.io/fegistry\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1453388826.0,\n      \"description\"\
+        : \"This WSGI application exposes a read-only API similar to\\ndocker-registry,\
+        \ which docker can use for \\\"docker pull\\\" operations.\\nRequests for\
+        \ actual image files are responded to with 302 redirects to\\na URL formed\
+        \ with per-repository settings.\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": true,\n      \"name\": \"python-crane\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297629\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A WSGI app providing\
+        \ a docker-registry-like API with redirection\",\n      \"upstream_url\":\
+        \ \"https://github.com/pulp/crane\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1419871778.0,\n      \"description\": \"A library\
+        \ to support the Internationalised Domain Names in Applications (IDNA)\\nprotocol\
+        \ as specified in RFC 5891 <http://tools.ietf.org/html/rfc5891>.  This\\nversion\
+        \ of the protocol is often referred to as \\\"IDNA2008\\\" and can produce\\\
+        ndifferent results from the earlier standard from 2003.\\n\\nThe library is\
+        \ also intended to act as a suitable drop-in replacement for the\\n\\\"encodings.idna\\\
+        \" module that comes with the Python standard library but\\ncurrently only\
+        \ supports the older 2003 specification.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-idna\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1119056\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Internationalized\
+        \ Domain Names in Applications (IDNA)\",\n      \"upstream_url\": \"https://github.com/kjd/idna\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"IPython features (tab completion, syntax highlighting,\
+        \ better tracebacks,\\nbetter introspection) right in pdb.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-ipdb\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"IPython enabled Python debugger\",\n\
+        \      \"upstream_url\": \"https://github.com/gotcha/ipdb/\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"This module implements ISO 8601 date, time and duration parsing.\
+        \ The\\nimplementation follows ISO8601:2004 standard, and implements only\
+        \ date/time\\nrepresentations mentioned in the standard. If something is not\
+        \ mentioned there,\\nthen it is treated as non existent, and not as an allowed\
+        \ option.\\n\\nFor instance, ISO8601:2004 never mentions 2 digit years. So,\
+        \ it is not intended\\nby this module to support 2 digit years. (while it\
+        \ may still be valid as ISO\\ndate, because it is not explicitly forbidden.)\
+        \ Another example is, when no time\\nzone information is given for a time,\
+        \ then it should be interpreted as local\\ntime, and not UTC.\\n\\nAs this\
+        \ module maps ISO 8601 dates/times to standard Python data types, like\\ndate,\
+        \ time, datetime and timedelta, it is not possible to convert all possible\\\
+        nISO 8601 dates/times. For instance, dates before 0001-01-01 are not allowed\
+        \ by\\nthe Python date and datetime classes. Additionally fractional seconds\
+        \ are\\nlimited to microseconds. That means if the parser finds for instance\\\
+        nnanoseconds it will round it to microseconds.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-isodate\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An ISO 8601 date/time/duration parser\
+        \ and formatter\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/isodate\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483389591.0,\n\
+        \      \"description\": \"configuration parser.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-kaptan\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1405742\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Configuration parser\"\
+        ,\n      \"upstream_url\": \"https://pypi.python.org/pypi/kaptan\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"The Python driver for MongoDB.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-pymongo\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Python driver for MongoDB\",\n     \
+        \ \"upstream_url\": \"http://api.mongodb.org/python\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Most existing Python modules for sending HTTP requests are extremely verbose\
+        \ and\\ncumbersome. Python\\u2019s built-in urllib2 module provides most of\
+        \ the HTTP\\ncapabilities you should need, but the API is thoroughly broken.\
+        \ This library is\\ndesigned to make HTTP requests easy for developers.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-requests\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"HTTP library,\
+        \ written in Python, for human beings\",\n      \"upstream_url\": \"https://pypi.io/project/requests\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1448383568.0,\n\
+        \      \"description\": \"A wrapper around pdb allowing remote debugging via\
+        \ netcat or telnet.\\nThis is especially useful in a Tomcat/Jython environment\
+        \ where little\\ndebugging tools are available.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-rpdb\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1284155\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A wrapper around\
+        \ pdb allowing remote debugging\",\n      \"upstream_url\": \"https://github.com/tamentis/rpdb\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Python HTTP module with connection pooling and file\
+        \ POST abilities.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-urllib3\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Python HTTP library with thread-safe connection pooling and file\
+        \ post\",\n      \"upstream_url\": \"https://github.com/shazow/urllib3\"\n\
+        \    }\n  ],\n  \"output\": \"ok\",\n  \"point of contact\": [\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1452379737.0,\n      \"description\"\
+        : \"This application is intended to proxy back-end operations for Key-Value\
+        \ insert,\\nlookup and delete and maintain a cache of those Key-Values in-memory,\
+        \ to save\\nback-end operations. Operations are intended to be atomic between\
+        \ back-end and\\ncache tables. The lifetime of the cache object and the max\
+        \ size of the cache\\ncan be defined as table parameters to limit the size\
+        \ of the in-memory tables.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": true,\n      \"name\": \"erlang-cache_tab\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1295075\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Erlang cache table\
+        \ application\",\n      \"upstream_url\": \"https://github.com/processone/cache_tab/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454421370.0,\n\
+        \      \"description\": \"ProcessOne SIP server component in Erlang.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1303434\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"ProcessOne SIP server component in Erlang\",\n   \
+        \   \"upstream_url\": \"https://github.com/processone/p1_sip/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1454521406.0,\n    \
+        \  \"description\": \"Stringprep is a framework for preparing Unicode test\
+        \ strings in order to\\nincrease the likelihood that string input and string\
+        \ comparison work. The\\nprinciple are defined in RFC-3454: Preparation of\
+        \ Internationalized Strings.\\nThis library is leverage Erlang native NIF\
+        \ mechanism to provide extremely fast\\nand efficient processing.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1296792\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A framework for preparing Unicode strings to help\
+        \ input and comparison\",\n      \"upstream_url\": \"https://github.com/processone/stringprep/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453840458.0,\n\
+        \      \"description\": \"STUN and TURN library for Erlang / Elixir. Both\
+        \ STUN (Session Traversal\\nUtilities for NAT) and TURN standards are used\
+        \ as techniques to establish media\\nconnection between peers for VoIP (for\
+        \ example using SIP or Jingle) and WebRTC.\",\n      \"koschei_monitor\":\
+        \ false,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_stun\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1301316\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"STUN and TURN library\
+        \ for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/stun/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453389245.0,\n\
+        \      \"description\": \"TLS / SSL native driver for Erlang / Elixir. This\
+        \ is used by ejabberd.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"erlang-p1_tls\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1299305\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"TLS / SSL native driver for\
+        \ Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/tls/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454593209.0,\n\
+        \      \"description\": \"Fast Expat based Erlang XML parsing and manipulation\
+        \ library, with a strong\\nfocus on XML stream parsing from network. It supports\
+        \ full XML structure\\nparsing, suitable for small but complete XML chunks,\
+        \ and XML stream parsing\\nsuitable for large XML document, or infinite network\
+        \ XML stream like XMPP.\\nThis module can parse files much faster than built-in\
+        \ module xmerl. Depending\\non file complexity and size xml_stream:parse_element/1\
+        \ can be 8-18 times faster\\nthan calling xmerl_scan:string/2.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_xml\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297150\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast Expat based\
+        \ Erlang XML parsing and manipulation library\",\n      \"upstream_url\":\
+        \ \"https://github.com/processone/xml/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1453730519.0,\n      \"description\": \"P1 YAML\
+        \ is an Erlang wrapper for libyaml \\\"C\\\" library.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_yaml\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297094\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An Erlang wrapper\
+        \ for libyaml \\\"C\\\" library\",\n      \"upstream_url\": \"https://github.com/processone/p1_yaml/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467902264.0,\n\
+        \      \"description\": \"Argument Parsing for Humans.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-args\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352993\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Argument Parsing\
+        \ for Humans\",\n      \"upstream_url\": \"https://github.com/kennethreitz/args\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468427737.0,\n\
+        \      \"description\": \"Clint is a module filled with a set of awesome tools\
+        \ for developing commandline\\napplications. It supports colors, but detects\
+        \ if the session is a TTY, so\\ndoesn't render the colors if you're piping\
+        \ stuff around. Automagically.\",\n      \"koschei_monitor\": true,\n    \
+        \  \"monitor\": true,\n      \"name\": \"python-clint\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1355871\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A set of awesome\
+        \ tools for developing commandline applications\",\n      \"upstream_url\"\
+        : \"https://github.com/kennethreitz/clint\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1452266443.0,\n      \"description\": \"A\
+        \ web based tool for monitoring and administrating Celery clusters. It offers\\\
+        nreal-time monitoring using Celery events, remote control of workers and tasks,\\\
+        nbroker monitoring, and an HTTP API.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-flower\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1285941\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A web based tool\
+        \ for monitoring and administrating Celery clusters\",\n      \"upstream_url\"\
+        : \"https://github.com/mher/flower\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1486055679.0,\n      \"description\": \"fmn is a\
+        \ family of systems to manage end-user notifications triggered by\\nfedmsg,\
+        \ the FEDerated MESsage bus. fmn provides a single place for all\\napplications\
+        \ using fedmsg to notify users of events. Notifications can be\\ndelivered\
+        \ by email, IRC, and server-sent events. Users can configure their\\nnotifications\
+        \ for all the applications they use in one place.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-fmn\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1410901\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A system for generic\
+        \ fedmsg-driven notifications for end users\",\n      \"upstream_url\": \"\
+        https://github.com/fedora-infra/fmn\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1485179561.0,\n      \"description\": \"fmn is a\
+        \ family of systems to manage end-user notifications triggered by\\nfedmsg,\
+        \ the FEDerated MESsage bus. The FMN Server-Sent Events server allows\\nusers\
+        \ to view their fedmsg feed in real-time using server-sent events. It relies\\\
+        non a service to populate the RabbitMQ message queues for it. Typically, this\
+        \ is\\ndone with the FMN core services.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-fmn-sse\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1412798\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A server-sent events\
+        \ server that integrates with FMN\",\n      \"upstream_url\": \"https://github.com/fedora-infra/fmn.sse\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467055928.0,\n\
+        \      \"description\": \"Invocations is a collection of reusable Invoke tasks/task\
+        \ modules, including\\n(but not limited to) Python project management tools\
+        \ such as documentation\\nbuilding and dependency organization. It has no\
+        \ stand-alone components and is\\ndesigned to be imported into your pre-existing\
+        \ Invoke task files.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-invocations\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1349121\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Invocations is a collection\
+        \ of reusable Invoke tasks/task modules\",\n      \"upstream_url\": \"https://github.com/pyinvoke/invocations\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489158551.0,\n\
+        \      \"description\": \"Allows synapse to use LDAP as a password provider.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-matrix-synapse-ldap3\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1430170\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Allows synapse to use LDAP as a password\
+        \ provider\",\n      \"upstream_url\": \"https://github.com/matrix-org/matrix-synapse-ldap3\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467054202.0,\n\
+        \      \"description\": \"This package provides an API for querying the distutils\
+        \ metadata written in the\\nPKG-INFO file inside a source distribution (an\
+        \ sdist) or a binary distribution\\n(e.g., created by running bdist_egg).\
+        \ It can also query the EGG-INFO directory\\nof an installed distribution,\
+        \ and the *.egg-info stored in a \\\"development\\ncheckout\\\" (e.g, created\
+        \ by running setup.py develop).\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": true,\n      \"name\": \"python-pkginfo\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1349026\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Query metadata from\
+        \ sdists / bdists / installed packages\",\n      \"upstream_url\": \"https://pypi.python.org/pypi/pkginfo\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489425664.0,\n\
+        \      \"description\": \"This is a Python re-implementation of the libmacaroons\
+        \ C library.\\nMacaroons, like cookies, are a form of bearer credential. Unlike\\\
+        nopaque tokens, macaroons embed caveats that define specific authorization\\\
+        nrequirements for the target service, the service that issued the root macaroon\\\
+        nand which is capable of verifying the integrity of macaroons it receives.\\\
+        n\\nMacaroons allow for delegation and attenuation of authorization. They\
+        \ are\\nsimple and fast to verify, and decouple authorization policy from\
+        \ the\\nenforcement of that policy.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-pymacaroons-pynacl\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1430107\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Library providing\
+        \ non-opaque cookies for authorization\",\n      \"upstream_url\": \"https://github.com/matrix-org/pymacaroons\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467389346.0,\n\
+        \      \"description\": \"Releases is a Sphinx extension designed to help\
+        \ you keep a source control\\nfriendly, merge friendly changelog file & turn\
+        \ it into useful, human readable\\nHTML output.\\n\\nSpecifically:\\n\\n*\
+        \ The source format (kept in your Sphinx tree as changelog.rst) is a stream-like\\\
+        ntimeline that plays well with source control & only requires one entry per\\\
+        nchange (even for changes that exist in multiple release lines).\\n* The output\
+        \ (when you have the extension installed and run your Sphinx build\\ncommand)\
+        \ is a traditional looking changelog page with a section for every\\nrelease;\
+        \ multi-release issues are copied automatically into each release.\\n* By\
+        \ default, feature and support issues are only displayed under feature\\nreleases,\
+        \ and bugs are only displayed under bugfix releases. This can be\\noverridden\
+        \ on a per-issue basis.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-releases\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1350943\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"A Sphinx extension for changelog\
+        \ manipulation\",\n      \"upstream_url\": \"https://github.com/bitprophet/releases\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1450359898.0,\n\
+        \      \"description\": \"sphinxcontrib-fulltoc is an extension for the Sphinx\
+        \ documentation system that\\nchanges the HTML output to include a more detailed\
+        \ table of contents in the\\nsidebar. By default Sphinx only shows the local\
+        \ headers for the current page.\\nWith the extension installed, all of the\
+        \ page titles are included, and the\\nlocal headers for the current page are\
+        \ also included in the appropriate place\\nwithin the document.\",\n     \
+        \ \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"\
+        python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1291007\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Include a full table of contents in\
+        \ your Sphinx HTML sidebar\",\n      \"upstream_url\": \"https://github.com/dreamhost/sphinxcontrib-fulltoc\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484077565.0,\n\
+        \      \"description\": \"Turn SQLAlchemy DB Model into a graph.\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"\
+        python-sqlalchemy_schemadisplay\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1409929\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Turn SQLAlchemy DB Model into a graph\"\
+        ,\n      \"upstream_url\": \"https://github.com/fschulze/sqlalchemy_schemadisplay\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1469020897.0,\n\
+        \      \"description\": \"Twine is a utility for interacting with PyPI.\\\
+        nCurrently it only supports registering projects and uploading distributions.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-twine\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1352972\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Collection of utilities for interacting with PyPI\"\
+        ,\n      \"upstream_url\": \"https://github.com/pypa/twine\"\n    }\n  ],\n\
+        \  \"watch\": [\n    {\n      \"acls\": [],\n      \"creation_date\": 1468428962.0,\n\
+        \      \"description\": \"A parser for TOML-0.4.0\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-pytoml\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1353606\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Parser for TOML\"\
+        ,\n      \"upstream_url\": \"https://github.com/avakar/pytoml\"\n    }\n \
+        \ ]\n}"}
+    headers:
+      accept-ranges: [bytes]
+      age: ['0']
+      appserver: [proxy03.fedoraproject.org]
+      apptime: [D=1859033]
+      connection: [Keep-Alive]
+      content-length: ['33867']
+      content-type: [application/json]
+      date: ['Wed, 29 Mar 2017 16:06:53 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['pkgdb=eyJfcGVybWFuZW50Ijp0cnVlfQ.C71tHw.WqDCNKxccmoa2Q-WMLIc0Q1u1No;
+          Expires=Wed, 29-Mar-2017 17:06:55 GMT; Secure; HttpOnly; Path=/pkgdb/']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['4494910']
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagesForTests.test_bad_response
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagesForTests.test_bad_response
@@ -1,0 +1,31 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/packager/package/thisisnotausername123
+  response:
+    body: {string: !!python/unicode "{\n  \"co-maintained\": [],\n  \"error\": \"\
+        No ACLs found for that user\",\n  \"output\": \"notok\",\n  \"point of contact\"\
+        : [],\n  \"watch\": []\n}"}
+    headers:
+      age: ['0']
+      appserver: [proxy14.fedoraproject.org]
+      apptime: [D=315492]
+      connection: [Keep-Alive]
+      content-length: ['129']
+      content-type: [application/json]
+      date: ['Wed, 29 Mar 2017 16:06:56 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['pkgdb=eyJfcGVybWFuZW50Ijp0cnVlfQ.C71tIA.d-BCyNvycXXWHrD8lAnQQKZ6vMw;
+          Expires=Wed, 29-Mar-2017 17:06:56 GMT; Secure; HttpOnly; Path=/pkgdb/']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['6842355']
+    status: {code: 404, message: NOT FOUND}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagesForTests.test_comaintained
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagesForTests.test_comaintained
@@ -1,0 +1,505 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/packager/package/jcline
+  response:
+    body: {string: !!python/unicode "{\n  \"co-maintained\": [\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Bodhi\
+        \ is a web application that facilitates the process of publishing\\nupdates\
+        \ for a software distribution.\\n\\nA modular piece of the Fedora Infrastructure\
+        \ stack\\n* Utilizes the Koji Buildsystem for tracking RPMs\\n* Creates the\
+        \ update repositories using Mash, which composes a repository based\\n  on\
+        \ tagged builds in Koji.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"bodhi\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"A modular framework that facilitates publishing software updates\",\n\
+        \      \"upstream_url\": \"https://github.com/fedora-infra/bodhi\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"ejabberd is a Free and Open Source distributed fault-tolerant\\\
+        nJabber/XMPP server. It is mostly written in Erlang, and runs on many\\nplatforms\
+        \ (tested on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"ejabberd\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"A distributed, fault-tolerant\
+        \ Jabber/XMPP server\",\n      \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1461430105.0,\n\
+        \      \"description\": \"ProcessOne SIP server component in Erlang.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"review_url\":\
+        \ \"https://bugzilla.redhat.com/1329441\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"ProcessOne SIP server component in Erlang\",\n   \
+        \   \"upstream_url\": \"https://github.com/processone/esip/\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1459274896.0,\n      \"\
+        description\": \"A native zlib driver for Erlang / Elixir, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1315134\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Native zlib driver for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/ezlib/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1460378527.0,\n      \"description\": \"TLS\
+        \ / SSL native driver for Erlang / Elixir. This is used by ejabberd.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316767\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"TLS / SSL native driver for Erlang / Elixir\",\n \
+        \     \"upstream_url\": \"https://github.com/processone/fast_tls/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1460475617.0,\n    \
+        \  \"description\": \"Fast Expat based Erlang XML parsing and manipulation\
+        \ library, with a strong\\nfocus on XML stream parsing from network. It supports\
+        \ full XML structure\\nparsing, suitable for small but complete XML chunks,\
+        \ and XML stream parsing\\nsuitable for large XML document, or infinite network\
+        \ XML stream like XMPP.\\nThis module can parse files much faster than built-in\
+        \ module xmerl. Depending\\non file complexity and size xml_stream:parse_element/1\
+        \ can be 8-18 times faster\\nthan calling xmerl_scan:string/2.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"erlang-fast_xml\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317182\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast Expat based\
+        \ Erlang XML parsing and manipulation library\",\n      \"upstream_url\":\
+        \ \"https://github.com/processone/fast_xml/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1459274717.0,\n      \"description\": \"P1\
+        \ YAML is an Erlang wrapper for libyaml \\\"C\\\" library.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-fast_yaml\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317184\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An Erlang wrapper\
+        \ for libyaml \\\"C\\\" library\",\n      \"upstream_url\": \"https://github.com/processone/fast_yaml/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1455917846.0,\n\
+        \      \"description\": \"A small Erlang app that provides fast event stream\
+        \ processing.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"erlang-goldrush\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/1309939\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Small, fast event processing and monitoring\
+        \ for Erlang/OTP applications\",\n      \"upstream_url\": \"https://github.com/DeadZen/goldrush\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1459968632.0,\n\
+        \      \"description\": \"Erlang bindings for libiconv. This is used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316762\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Fast encoding conversion library for Erlang / Elixir\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/iconv/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1458136455.0,\n    \
+        \  \"description\": \"An experimental implementation of Lua 5.2 written solely\
+        \ in pure Erlang.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"erlang-luerl\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1317345\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Lua in Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/rvirding/luerl\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1455034950.0,\n      \"description\": \"This library\
+        \ is designed to simplify the implementation of the server side of\\nOAuth2.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1294331\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"An Oauth2 implementation for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/kivra/oauth2\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1454706689.0,\n      \"description\": \"Erlang bindings\
+        \ for iconv. This is used by ejabberd.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-p1_iconv\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1294368\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast encoding conversion\
+        \ library for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/iconv/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454706783.0,\n\
+        \      \"description\": \"This is an Erlang MySQL driver, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295011\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Pure Erlang MySQL driver\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/p1_mysql/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1458568963.0,\n      \"description\": \"This\
+        \ library is designed to simplify the implementation of the server side of\\\
+        nOAuth2. It is a fork of erlang-oauth2 by processone, and is needed by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1317336\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"An Oauth2 implementation for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/p1_oauth2\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1454870042.0,\n      \"description\": \"An\
+        \ Erlang library for ejabberd that helps with PAM authentication.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295035\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Library for ejabberd for PAM authentication support\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/epam/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1454706762.0,\n    \
+        \  \"description\": \"Pure Erlang PostgreSQL driver.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_pgsql\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1294730\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Pure Erlang PostgreSQL\
+        \ driver\",\n      \"upstream_url\": \"https://github.com/processone/p1_pgsql\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1451836021.0,\n\
+        \      \"description\": \"p1_utils is an application containing ProcessOne\
+        \ modules and tools that are\\nleveraged in other development projects.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_utils\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1294587\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Erlang utility modules from ProcessOne\",\n      \"\
+        upstream_url\": \"https://github.com/processone/p1_utils/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1458659356.0,\n      \"description\"\
+        : \"This is an HTTP 1.1 compliant XML-RPC library for Erlang. It is designed\
+        \ to make\\nit easy to write XML-RPC Erlang clients and/or servers. The library\
+        \ is compliant\\nwith the XML-RPC specification published by http://www.xmlrpc.org/.\
+        \ It is a fork\\nof erlang-xmlrpc maintained by processone for ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1317341\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Erlang XMLRPC implementation with SSL, cookies, Authentication\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/p1_xmlrpc\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454870064.0,\n\
+        \      \"description\": \"A native zlib driver for Erlang, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295009\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Native zlib driver for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/ezlib/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1452180599.0,\n      \"description\": \"PropEr\
+        \ (PROPerty-based testing tool for ERlang) is a QuickCheck-inspired\\nopen-source\
+        \ property-based testing tool for Erlang.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-proper\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1295667\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A QuickCheck-inspired\
+        \ property-based testing tool for Erlang\",\n      \"upstream_url\": \"https://github.com/manopapad/proper\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460378560.0,\n\
+        \      \"description\": \"Stringprep is a framework for preparing Unicode\
+        \ test strings in order to\\nincrease the likelihood that string input and\
+        \ string comparison work. The\\nprinciple are defined in RFC-3454: Preparation\
+        \ of Internationalized Strings.\\nThis library is leverage Erlang native NIF\
+        \ mechanism to provide extremely fast\\nand efficient processing.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316772\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A framework for preparing Unicode strings to help\
+        \ input and comparison\",\n      \"upstream_url\": \"https://github.com/processone/stringprep/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460475644.0,\n\
+        \      \"description\": \"STUN and TURN library for Erlang / Elixir. Both\
+        \ STUN (Session Traversal\\nUtilities for NAT) and TURN standards are used\
+        \ as techniques to establish media\\nconnection between peers for VoIP (for\
+        \ example using SIP or Jingle) and WebRTC.\",\n      \"koschei_monitor\":\
+        \ true,\n      \"monitor\": true,\n      \"name\": \"erlang-stun\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317183\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"STUN and TURN library\
+        \ for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/stun/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483391539.0,\n\
+        \      \"description\": \"XMPP is an Erlang XMPP parsing and serialization\
+        \ library, built on top of Fast\\nXML.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-xmpp\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1409326\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Erlang/Elixir XMPP\
+        \ parsing and serialization library\",\n      \"upstream_url\": \"https://github.com/processone/xmpp/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484067733.0,\n\
+        \      \"description\": \"Fegistry is the container registry endpoint for\
+        \ Fedora's users. It will answer\\nthe initial requests when users docker\
+        \ pull Fedora containers.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"fegistry\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/1411462\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"The Fedora registry endpoint\",\n  \
+        \    \"upstream_url\": \"https://pagure.io/fegistry\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1453388826.0,\n      \"description\"\
+        : \"This WSGI application exposes a read-only API similar to\\ndocker-registry,\
+        \ which docker can use for \\\"docker pull\\\" operations.\\nRequests for\
+        \ actual image files are responded to with 302 redirects to\\na URL formed\
+        \ with per-repository settings.\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": true,\n      \"name\": \"python-crane\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297629\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A WSGI app providing\
+        \ a docker-registry-like API with redirection\",\n      \"upstream_url\":\
+        \ \"https://github.com/pulp/crane\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1419871778.0,\n      \"description\": \"A library\
+        \ to support the Internationalised Domain Names in Applications (IDNA)\\nprotocol\
+        \ as specified in RFC 5891 <http://tools.ietf.org/html/rfc5891>.  This\\nversion\
+        \ of the protocol is often referred to as \\\"IDNA2008\\\" and can produce\\\
+        ndifferent results from the earlier standard from 2003.\\n\\nThe library is\
+        \ also intended to act as a suitable drop-in replacement for the\\n\\\"encodings.idna\\\
+        \" module that comes with the Python standard library but\\ncurrently only\
+        \ supports the older 2003 specification.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-idna\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1119056\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Internationalized\
+        \ Domain Names in Applications (IDNA)\",\n      \"upstream_url\": \"https://github.com/kjd/idna\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"IPython features (tab completion, syntax highlighting,\
+        \ better tracebacks,\\nbetter introspection) right in pdb.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-ipdb\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"IPython enabled Python debugger\",\n\
+        \      \"upstream_url\": \"https://github.com/gotcha/ipdb/\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"This module implements ISO 8601 date, time and duration parsing.\
+        \ The\\nimplementation follows ISO8601:2004 standard, and implements only\
+        \ date/time\\nrepresentations mentioned in the standard. If something is not\
+        \ mentioned there,\\nthen it is treated as non existent, and not as an allowed\
+        \ option.\\n\\nFor instance, ISO8601:2004 never mentions 2 digit years. So,\
+        \ it is not intended\\nby this module to support 2 digit years. (while it\
+        \ may still be valid as ISO\\ndate, because it is not explicitly forbidden.)\
+        \ Another example is, when no time\\nzone information is given for a time,\
+        \ then it should be interpreted as local\\ntime, and not UTC.\\n\\nAs this\
+        \ module maps ISO 8601 dates/times to standard Python data types, like\\ndate,\
+        \ time, datetime and timedelta, it is not possible to convert all possible\\\
+        nISO 8601 dates/times. For instance, dates before 0001-01-01 are not allowed\
+        \ by\\nthe Python date and datetime classes. Additionally fractional seconds\
+        \ are\\nlimited to microseconds. That means if the parser finds for instance\\\
+        nnanoseconds it will round it to microseconds.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-isodate\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An ISO 8601 date/time/duration parser\
+        \ and formatter\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/isodate\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483389591.0,\n\
+        \      \"description\": \"configuration parser.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-kaptan\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1405742\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Configuration parser\"\
+        ,\n      \"upstream_url\": \"https://pypi.python.org/pypi/kaptan\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"The Python driver for MongoDB.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-pymongo\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Python driver for MongoDB\",\n     \
+        \ \"upstream_url\": \"http://api.mongodb.org/python\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Most existing Python modules for sending HTTP requests are extremely verbose\
+        \ and\\ncumbersome. Python\\u2019s built-in urllib2 module provides most of\
+        \ the HTTP\\ncapabilities you should need, but the API is thoroughly broken.\
+        \ This library is\\ndesigned to make HTTP requests easy for developers.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-requests\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"HTTP library,\
+        \ written in Python, for human beings\",\n      \"upstream_url\": \"https://pypi.io/project/requests\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1448383568.0,\n\
+        \      \"description\": \"A wrapper around pdb allowing remote debugging via\
+        \ netcat or telnet.\\nThis is especially useful in a Tomcat/Jython environment\
+        \ where little\\ndebugging tools are available.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-rpdb\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1284155\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A wrapper around\
+        \ pdb allowing remote debugging\",\n      \"upstream_url\": \"https://github.com/tamentis/rpdb\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Python HTTP module with connection pooling and file\
+        \ POST abilities.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-urllib3\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Python HTTP library with thread-safe connection pooling and file\
+        \ post\",\n      \"upstream_url\": \"https://github.com/shazow/urllib3\"\n\
+        \    }\n  ],\n  \"output\": \"ok\",\n  \"point of contact\": [\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1452379737.0,\n      \"description\"\
+        : \"This application is intended to proxy back-end operations for Key-Value\
+        \ insert,\\nlookup and delete and maintain a cache of those Key-Values in-memory,\
+        \ to save\\nback-end operations. Operations are intended to be atomic between\
+        \ back-end and\\ncache tables. The lifetime of the cache object and the max\
+        \ size of the cache\\ncan be defined as table parameters to limit the size\
+        \ of the in-memory tables.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": true,\n      \"name\": \"erlang-cache_tab\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1295075\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Erlang cache table\
+        \ application\",\n      \"upstream_url\": \"https://github.com/processone/cache_tab/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454421370.0,\n\
+        \      \"description\": \"ProcessOne SIP server component in Erlang.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1303434\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"ProcessOne SIP server component in Erlang\",\n   \
+        \   \"upstream_url\": \"https://github.com/processone/p1_sip/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1454521406.0,\n    \
+        \  \"description\": \"Stringprep is a framework for preparing Unicode test\
+        \ strings in order to\\nincrease the likelihood that string input and string\
+        \ comparison work. The\\nprinciple are defined in RFC-3454: Preparation of\
+        \ Internationalized Strings.\\nThis library is leverage Erlang native NIF\
+        \ mechanism to provide extremely fast\\nand efficient processing.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1296792\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A framework for preparing Unicode strings to help\
+        \ input and comparison\",\n      \"upstream_url\": \"https://github.com/processone/stringprep/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453840458.0,\n\
+        \      \"description\": \"STUN and TURN library for Erlang / Elixir. Both\
+        \ STUN (Session Traversal\\nUtilities for NAT) and TURN standards are used\
+        \ as techniques to establish media\\nconnection between peers for VoIP (for\
+        \ example using SIP or Jingle) and WebRTC.\",\n      \"koschei_monitor\":\
+        \ false,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_stun\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1301316\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"STUN and TURN library\
+        \ for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/stun/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453389245.0,\n\
+        \      \"description\": \"TLS / SSL native driver for Erlang / Elixir. This\
+        \ is used by ejabberd.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"erlang-p1_tls\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1299305\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"TLS / SSL native driver for\
+        \ Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/tls/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454593209.0,\n\
+        \      \"description\": \"Fast Expat based Erlang XML parsing and manipulation\
+        \ library, with a strong\\nfocus on XML stream parsing from network. It supports\
+        \ full XML structure\\nparsing, suitable for small but complete XML chunks,\
+        \ and XML stream parsing\\nsuitable for large XML document, or infinite network\
+        \ XML stream like XMPP.\\nThis module can parse files much faster than built-in\
+        \ module xmerl. Depending\\non file complexity and size xml_stream:parse_element/1\
+        \ can be 8-18 times faster\\nthan calling xmerl_scan:string/2.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_xml\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297150\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast Expat based\
+        \ Erlang XML parsing and manipulation library\",\n      \"upstream_url\":\
+        \ \"https://github.com/processone/xml/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1453730519.0,\n      \"description\": \"P1 YAML\
+        \ is an Erlang wrapper for libyaml \\\"C\\\" library.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_yaml\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297094\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An Erlang wrapper\
+        \ for libyaml \\\"C\\\" library\",\n      \"upstream_url\": \"https://github.com/processone/p1_yaml/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467902264.0,\n\
+        \      \"description\": \"Argument Parsing for Humans.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-args\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352993\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Argument Parsing\
+        \ for Humans\",\n      \"upstream_url\": \"https://github.com/kennethreitz/args\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468427737.0,\n\
+        \      \"description\": \"Clint is a module filled with a set of awesome tools\
+        \ for developing commandline\\napplications. It supports colors, but detects\
+        \ if the session is a TTY, so\\ndoesn't render the colors if you're piping\
+        \ stuff around. Automagically.\",\n      \"koschei_monitor\": true,\n    \
+        \  \"monitor\": true,\n      \"name\": \"python-clint\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1355871\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A set of awesome\
+        \ tools for developing commandline applications\",\n      \"upstream_url\"\
+        : \"https://github.com/kennethreitz/clint\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1452266443.0,\n      \"description\": \"A\
+        \ web based tool for monitoring and administrating Celery clusters. It offers\\\
+        nreal-time monitoring using Celery events, remote control of workers and tasks,\\\
+        nbroker monitoring, and an HTTP API.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-flower\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1285941\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A web based tool\
+        \ for monitoring and administrating Celery clusters\",\n      \"upstream_url\"\
+        : \"https://github.com/mher/flower\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1486055679.0,\n      \"description\": \"fmn is a\
+        \ family of systems to manage end-user notifications triggered by\\nfedmsg,\
+        \ the FEDerated MESsage bus. fmn provides a single place for all\\napplications\
+        \ using fedmsg to notify users of events. Notifications can be\\ndelivered\
+        \ by email, IRC, and server-sent events. Users can configure their\\nnotifications\
+        \ for all the applications they use in one place.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-fmn\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1410901\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A system for generic\
+        \ fedmsg-driven notifications for end users\",\n      \"upstream_url\": \"\
+        https://github.com/fedora-infra/fmn\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1485179561.0,\n      \"description\": \"fmn is a\
+        \ family of systems to manage end-user notifications triggered by\\nfedmsg,\
+        \ the FEDerated MESsage bus. The FMN Server-Sent Events server allows\\nusers\
+        \ to view their fedmsg feed in real-time using server-sent events. It relies\\\
+        non a service to populate the RabbitMQ message queues for it. Typically, this\
+        \ is\\ndone with the FMN core services.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-fmn-sse\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1412798\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A server-sent events\
+        \ server that integrates with FMN\",\n      \"upstream_url\": \"https://github.com/fedora-infra/fmn.sse\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467055928.0,\n\
+        \      \"description\": \"Invocations is a collection of reusable Invoke tasks/task\
+        \ modules, including\\n(but not limited to) Python project management tools\
+        \ such as documentation\\nbuilding and dependency organization. It has no\
+        \ stand-alone components and is\\ndesigned to be imported into your pre-existing\
+        \ Invoke task files.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-invocations\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1349121\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Invocations is a collection\
+        \ of reusable Invoke tasks/task modules\",\n      \"upstream_url\": \"https://github.com/pyinvoke/invocations\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489158551.0,\n\
+        \      \"description\": \"Allows synapse to use LDAP as a password provider.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-matrix-synapse-ldap3\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1430170\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Allows synapse to use LDAP as a password\
+        \ provider\",\n      \"upstream_url\": \"https://github.com/matrix-org/matrix-synapse-ldap3\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467054202.0,\n\
+        \      \"description\": \"This package provides an API for querying the distutils\
+        \ metadata written in the\\nPKG-INFO file inside a source distribution (an\
+        \ sdist) or a binary distribution\\n(e.g., created by running bdist_egg).\
+        \ It can also query the EGG-INFO directory\\nof an installed distribution,\
+        \ and the *.egg-info stored in a \\\"development\\ncheckout\\\" (e.g, created\
+        \ by running setup.py develop).\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": true,\n      \"name\": \"python-pkginfo\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1349026\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Query metadata from\
+        \ sdists / bdists / installed packages\",\n      \"upstream_url\": \"https://pypi.python.org/pypi/pkginfo\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489425664.0,\n\
+        \      \"description\": \"This is a Python re-implementation of the libmacaroons\
+        \ C library.\\nMacaroons, like cookies, are a form of bearer credential. Unlike\\\
+        nopaque tokens, macaroons embed caveats that define specific authorization\\\
+        nrequirements for the target service, the service that issued the root macaroon\\\
+        nand which is capable of verifying the integrity of macaroons it receives.\\\
+        n\\nMacaroons allow for delegation and attenuation of authorization. They\
+        \ are\\nsimple and fast to verify, and decouple authorization policy from\
+        \ the\\nenforcement of that policy.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-pymacaroons-pynacl\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1430107\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Library providing\
+        \ non-opaque cookies for authorization\",\n      \"upstream_url\": \"https://github.com/matrix-org/pymacaroons\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467389346.0,\n\
+        \      \"description\": \"Releases is a Sphinx extension designed to help\
+        \ you keep a source control\\nfriendly, merge friendly changelog file & turn\
+        \ it into useful, human readable\\nHTML output.\\n\\nSpecifically:\\n\\n*\
+        \ The source format (kept in your Sphinx tree as changelog.rst) is a stream-like\\\
+        ntimeline that plays well with source control & only requires one entry per\\\
+        nchange (even for changes that exist in multiple release lines).\\n* The output\
+        \ (when you have the extension installed and run your Sphinx build\\ncommand)\
+        \ is a traditional looking changelog page with a section for every\\nrelease;\
+        \ multi-release issues are copied automatically into each release.\\n* By\
+        \ default, feature and support issues are only displayed under feature\\nreleases,\
+        \ and bugs are only displayed under bugfix releases. This can be\\noverridden\
+        \ on a per-issue basis.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-releases\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1350943\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"A Sphinx extension for changelog\
+        \ manipulation\",\n      \"upstream_url\": \"https://github.com/bitprophet/releases\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1450359898.0,\n\
+        \      \"description\": \"sphinxcontrib-fulltoc is an extension for the Sphinx\
+        \ documentation system that\\nchanges the HTML output to include a more detailed\
+        \ table of contents in the\\nsidebar. By default Sphinx only shows the local\
+        \ headers for the current page.\\nWith the extension installed, all of the\
+        \ page titles are included, and the\\nlocal headers for the current page are\
+        \ also included in the appropriate place\\nwithin the document.\",\n     \
+        \ \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"\
+        python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1291007\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Include a full table of contents in\
+        \ your Sphinx HTML sidebar\",\n      \"upstream_url\": \"https://github.com/dreamhost/sphinxcontrib-fulltoc\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484077565.0,\n\
+        \      \"description\": \"Turn SQLAlchemy DB Model into a graph.\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"\
+        python-sqlalchemy_schemadisplay\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1409929\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Turn SQLAlchemy DB Model into a graph\"\
+        ,\n      \"upstream_url\": \"https://github.com/fschulze/sqlalchemy_schemadisplay\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1469020897.0,\n\
+        \      \"description\": \"Twine is a utility for interacting with PyPI.\\\
+        nCurrently it only supports registering projects and uploading distributions.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-twine\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1352972\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Collection of utilities for interacting with PyPI\"\
+        ,\n      \"upstream_url\": \"https://github.com/pypa/twine\"\n    }\n  ],\n\
+        \  \"watch\": [\n    {\n      \"acls\": [],\n      \"creation_date\": 1468428962.0,\n\
+        \      \"description\": \"A parser for TOML-0.4.0\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-pytoml\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1353606\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Parser for TOML\"\
+        ,\n      \"upstream_url\": \"https://github.com/avakar/pytoml\"\n    }\n \
+        \ ]\n}"}
+    headers:
+      accept-ranges: [bytes]
+      age: ['0']
+      appserver: [proxy03.fedoraproject.org]
+      apptime: [D=245079]
+      connection: [Keep-Alive]
+      content-length: ['33867']
+      content-type: [application/json]
+      date: ['Wed, 29 Mar 2017 16:06:56 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['pkgdb=eyJfcGVybWFuZW50Ijp0cnVlfQ.C71tIA.d-BCyNvycXXWHrD8lAnQQKZ6vMw;
+          Expires=Wed, 29-Mar-2017 17:06:56 GMT; Secure; HttpOnly; Path=/pkgdb/']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['4494912']
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagesForTests.test_point_of_contact
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagesForTests.test_point_of_contact
@@ -1,0 +1,505 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/packager/package/jcline
+  response:
+    body: {string: !!python/unicode "{\n  \"co-maintained\": [\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Bodhi\
+        \ is a web application that facilitates the process of publishing\\nupdates\
+        \ for a software distribution.\\n\\nA modular piece of the Fedora Infrastructure\
+        \ stack\\n* Utilizes the Koji Buildsystem for tracking RPMs\\n* Creates the\
+        \ update repositories using Mash, which composes a repository based\\n  on\
+        \ tagged builds in Koji.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"bodhi\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"A modular framework that facilitates publishing software updates\",\n\
+        \      \"upstream_url\": \"https://github.com/fedora-infra/bodhi\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"ejabberd is a Free and Open Source distributed fault-tolerant\\\
+        nJabber/XMPP server. It is mostly written in Erlang, and runs on many\\nplatforms\
+        \ (tested on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"ejabberd\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"A distributed, fault-tolerant\
+        \ Jabber/XMPP server\",\n      \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1461430105.0,\n\
+        \      \"description\": \"ProcessOne SIP server component in Erlang.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"review_url\":\
+        \ \"https://bugzilla.redhat.com/1329441\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"ProcessOne SIP server component in Erlang\",\n   \
+        \   \"upstream_url\": \"https://github.com/processone/esip/\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1459274896.0,\n      \"\
+        description\": \"A native zlib driver for Erlang / Elixir, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1315134\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Native zlib driver for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/ezlib/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1460378527.0,\n      \"description\": \"TLS\
+        \ / SSL native driver for Erlang / Elixir. This is used by ejabberd.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316767\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"TLS / SSL native driver for Erlang / Elixir\",\n \
+        \     \"upstream_url\": \"https://github.com/processone/fast_tls/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1460475617.0,\n    \
+        \  \"description\": \"Fast Expat based Erlang XML parsing and manipulation\
+        \ library, with a strong\\nfocus on XML stream parsing from network. It supports\
+        \ full XML structure\\nparsing, suitable for small but complete XML chunks,\
+        \ and XML stream parsing\\nsuitable for large XML document, or infinite network\
+        \ XML stream like XMPP.\\nThis module can parse files much faster than built-in\
+        \ module xmerl. Depending\\non file complexity and size xml_stream:parse_element/1\
+        \ can be 8-18 times faster\\nthan calling xmerl_scan:string/2.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"erlang-fast_xml\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317182\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast Expat based\
+        \ Erlang XML parsing and manipulation library\",\n      \"upstream_url\":\
+        \ \"https://github.com/processone/fast_xml/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1459274717.0,\n      \"description\": \"P1\
+        \ YAML is an Erlang wrapper for libyaml \\\"C\\\" library.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-fast_yaml\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317184\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An Erlang wrapper\
+        \ for libyaml \\\"C\\\" library\",\n      \"upstream_url\": \"https://github.com/processone/fast_yaml/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1455917846.0,\n\
+        \      \"description\": \"A small Erlang app that provides fast event stream\
+        \ processing.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"erlang-goldrush\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/1309939\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Small, fast event processing and monitoring\
+        \ for Erlang/OTP applications\",\n      \"upstream_url\": \"https://github.com/DeadZen/goldrush\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1459968632.0,\n\
+        \      \"description\": \"Erlang bindings for libiconv. This is used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316762\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Fast encoding conversion library for Erlang / Elixir\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/iconv/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1458136455.0,\n    \
+        \  \"description\": \"An experimental implementation of Lua 5.2 written solely\
+        \ in pure Erlang.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"erlang-luerl\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1317345\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Lua in Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/rvirding/luerl\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1455034950.0,\n      \"description\": \"This library\
+        \ is designed to simplify the implementation of the server side of\\nOAuth2.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1294331\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"An Oauth2 implementation for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/kivra/oauth2\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1454706689.0,\n      \"description\": \"Erlang bindings\
+        \ for iconv. This is used by ejabberd.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-p1_iconv\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1294368\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast encoding conversion\
+        \ library for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/iconv/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454706783.0,\n\
+        \      \"description\": \"This is an Erlang MySQL driver, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295011\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Pure Erlang MySQL driver\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/p1_mysql/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1458568963.0,\n      \"description\": \"This\
+        \ library is designed to simplify the implementation of the server side of\\\
+        nOAuth2. It is a fork of erlang-oauth2 by processone, and is needed by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1317336\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"An Oauth2 implementation for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/p1_oauth2\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1454870042.0,\n      \"description\": \"An\
+        \ Erlang library for ejabberd that helps with PAM authentication.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295035\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Library for ejabberd for PAM authentication support\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/epam/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1454706762.0,\n    \
+        \  \"description\": \"Pure Erlang PostgreSQL driver.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_pgsql\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1294730\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Pure Erlang PostgreSQL\
+        \ driver\",\n      \"upstream_url\": \"https://github.com/processone/p1_pgsql\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1451836021.0,\n\
+        \      \"description\": \"p1_utils is an application containing ProcessOne\
+        \ modules and tools that are\\nleveraged in other development projects.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_utils\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1294587\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Erlang utility modules from ProcessOne\",\n      \"\
+        upstream_url\": \"https://github.com/processone/p1_utils/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1458659356.0,\n      \"description\"\
+        : \"This is an HTTP 1.1 compliant XML-RPC library for Erlang. It is designed\
+        \ to make\\nit easy to write XML-RPC Erlang clients and/or servers. The library\
+        \ is compliant\\nwith the XML-RPC specification published by http://www.xmlrpc.org/.\
+        \ It is a fork\\nof erlang-xmlrpc maintained by processone for ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1317341\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Erlang XMLRPC implementation with SSL, cookies, Authentication\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/p1_xmlrpc\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454870064.0,\n\
+        \      \"description\": \"A native zlib driver for Erlang, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295009\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Native zlib driver for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/ezlib/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1452180599.0,\n      \"description\": \"PropEr\
+        \ (PROPerty-based testing tool for ERlang) is a QuickCheck-inspired\\nopen-source\
+        \ property-based testing tool for Erlang.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-proper\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1295667\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A QuickCheck-inspired\
+        \ property-based testing tool for Erlang\",\n      \"upstream_url\": \"https://github.com/manopapad/proper\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460378560.0,\n\
+        \      \"description\": \"Stringprep is a framework for preparing Unicode\
+        \ test strings in order to\\nincrease the likelihood that string input and\
+        \ string comparison work. The\\nprinciple are defined in RFC-3454: Preparation\
+        \ of Internationalized Strings.\\nThis library is leverage Erlang native NIF\
+        \ mechanism to provide extremely fast\\nand efficient processing.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316772\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A framework for preparing Unicode strings to help\
+        \ input and comparison\",\n      \"upstream_url\": \"https://github.com/processone/stringprep/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460475644.0,\n\
+        \      \"description\": \"STUN and TURN library for Erlang / Elixir. Both\
+        \ STUN (Session Traversal\\nUtilities for NAT) and TURN standards are used\
+        \ as techniques to establish media\\nconnection between peers for VoIP (for\
+        \ example using SIP or Jingle) and WebRTC.\",\n      \"koschei_monitor\":\
+        \ true,\n      \"monitor\": true,\n      \"name\": \"erlang-stun\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317183\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"STUN and TURN library\
+        \ for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/stun/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483391539.0,\n\
+        \      \"description\": \"XMPP is an Erlang XMPP parsing and serialization\
+        \ library, built on top of Fast\\nXML.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-xmpp\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1409326\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Erlang/Elixir XMPP\
+        \ parsing and serialization library\",\n      \"upstream_url\": \"https://github.com/processone/xmpp/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484067733.0,\n\
+        \      \"description\": \"Fegistry is the container registry endpoint for\
+        \ Fedora's users. It will answer\\nthe initial requests when users docker\
+        \ pull Fedora containers.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"fegistry\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/1411462\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"The Fedora registry endpoint\",\n  \
+        \    \"upstream_url\": \"https://pagure.io/fegistry\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1453388826.0,\n      \"description\"\
+        : \"This WSGI application exposes a read-only API similar to\\ndocker-registry,\
+        \ which docker can use for \\\"docker pull\\\" operations.\\nRequests for\
+        \ actual image files are responded to with 302 redirects to\\na URL formed\
+        \ with per-repository settings.\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": true,\n      \"name\": \"python-crane\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297629\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A WSGI app providing\
+        \ a docker-registry-like API with redirection\",\n      \"upstream_url\":\
+        \ \"https://github.com/pulp/crane\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1419871778.0,\n      \"description\": \"A library\
+        \ to support the Internationalised Domain Names in Applications (IDNA)\\nprotocol\
+        \ as specified in RFC 5891 <http://tools.ietf.org/html/rfc5891>.  This\\nversion\
+        \ of the protocol is often referred to as \\\"IDNA2008\\\" and can produce\\\
+        ndifferent results from the earlier standard from 2003.\\n\\nThe library is\
+        \ also intended to act as a suitable drop-in replacement for the\\n\\\"encodings.idna\\\
+        \" module that comes with the Python standard library but\\ncurrently only\
+        \ supports the older 2003 specification.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-idna\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1119056\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Internationalized\
+        \ Domain Names in Applications (IDNA)\",\n      \"upstream_url\": \"https://github.com/kjd/idna\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"IPython features (tab completion, syntax highlighting,\
+        \ better tracebacks,\\nbetter introspection) right in pdb.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-ipdb\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"IPython enabled Python debugger\",\n\
+        \      \"upstream_url\": \"https://github.com/gotcha/ipdb/\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"This module implements ISO 8601 date, time and duration parsing.\
+        \ The\\nimplementation follows ISO8601:2004 standard, and implements only\
+        \ date/time\\nrepresentations mentioned in the standard. If something is not\
+        \ mentioned there,\\nthen it is treated as non existent, and not as an allowed\
+        \ option.\\n\\nFor instance, ISO8601:2004 never mentions 2 digit years. So,\
+        \ it is not intended\\nby this module to support 2 digit years. (while it\
+        \ may still be valid as ISO\\ndate, because it is not explicitly forbidden.)\
+        \ Another example is, when no time\\nzone information is given for a time,\
+        \ then it should be interpreted as local\\ntime, and not UTC.\\n\\nAs this\
+        \ module maps ISO 8601 dates/times to standard Python data types, like\\ndate,\
+        \ time, datetime and timedelta, it is not possible to convert all possible\\\
+        nISO 8601 dates/times. For instance, dates before 0001-01-01 are not allowed\
+        \ by\\nthe Python date and datetime classes. Additionally fractional seconds\
+        \ are\\nlimited to microseconds. That means if the parser finds for instance\\\
+        nnanoseconds it will round it to microseconds.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-isodate\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An ISO 8601 date/time/duration parser\
+        \ and formatter\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/isodate\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483389591.0,\n\
+        \      \"description\": \"configuration parser.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-kaptan\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1405742\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Configuration parser\"\
+        ,\n      \"upstream_url\": \"https://pypi.python.org/pypi/kaptan\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"The Python driver for MongoDB.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-pymongo\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Python driver for MongoDB\",\n     \
+        \ \"upstream_url\": \"http://api.mongodb.org/python\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Most existing Python modules for sending HTTP requests are extremely verbose\
+        \ and\\ncumbersome. Python\\u2019s built-in urllib2 module provides most of\
+        \ the HTTP\\ncapabilities you should need, but the API is thoroughly broken.\
+        \ This library is\\ndesigned to make HTTP requests easy for developers.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-requests\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"HTTP library,\
+        \ written in Python, for human beings\",\n      \"upstream_url\": \"https://pypi.io/project/requests\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1448383568.0,\n\
+        \      \"description\": \"A wrapper around pdb allowing remote debugging via\
+        \ netcat or telnet.\\nThis is especially useful in a Tomcat/Jython environment\
+        \ where little\\ndebugging tools are available.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-rpdb\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1284155\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A wrapper around\
+        \ pdb allowing remote debugging\",\n      \"upstream_url\": \"https://github.com/tamentis/rpdb\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Python HTTP module with connection pooling and file\
+        \ POST abilities.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-urllib3\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Python HTTP library with thread-safe connection pooling and file\
+        \ post\",\n      \"upstream_url\": \"https://github.com/shazow/urllib3\"\n\
+        \    }\n  ],\n  \"output\": \"ok\",\n  \"point of contact\": [\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1452379737.0,\n      \"description\"\
+        : \"This application is intended to proxy back-end operations for Key-Value\
+        \ insert,\\nlookup and delete and maintain a cache of those Key-Values in-memory,\
+        \ to save\\nback-end operations. Operations are intended to be atomic between\
+        \ back-end and\\ncache tables. The lifetime of the cache object and the max\
+        \ size of the cache\\ncan be defined as table parameters to limit the size\
+        \ of the in-memory tables.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": true,\n      \"name\": \"erlang-cache_tab\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1295075\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Erlang cache table\
+        \ application\",\n      \"upstream_url\": \"https://github.com/processone/cache_tab/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454421370.0,\n\
+        \      \"description\": \"ProcessOne SIP server component in Erlang.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1303434\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"ProcessOne SIP server component in Erlang\",\n   \
+        \   \"upstream_url\": \"https://github.com/processone/p1_sip/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1454521406.0,\n    \
+        \  \"description\": \"Stringprep is a framework for preparing Unicode test\
+        \ strings in order to\\nincrease the likelihood that string input and string\
+        \ comparison work. The\\nprinciple are defined in RFC-3454: Preparation of\
+        \ Internationalized Strings.\\nThis library is leverage Erlang native NIF\
+        \ mechanism to provide extremely fast\\nand efficient processing.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1296792\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A framework for preparing Unicode strings to help\
+        \ input and comparison\",\n      \"upstream_url\": \"https://github.com/processone/stringprep/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453840458.0,\n\
+        \      \"description\": \"STUN and TURN library for Erlang / Elixir. Both\
+        \ STUN (Session Traversal\\nUtilities for NAT) and TURN standards are used\
+        \ as techniques to establish media\\nconnection between peers for VoIP (for\
+        \ example using SIP or Jingle) and WebRTC.\",\n      \"koschei_monitor\":\
+        \ false,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_stun\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1301316\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"STUN and TURN library\
+        \ for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/stun/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453389245.0,\n\
+        \      \"description\": \"TLS / SSL native driver for Erlang / Elixir. This\
+        \ is used by ejabberd.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"erlang-p1_tls\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1299305\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"TLS / SSL native driver for\
+        \ Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/tls/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454593209.0,\n\
+        \      \"description\": \"Fast Expat based Erlang XML parsing and manipulation\
+        \ library, with a strong\\nfocus on XML stream parsing from network. It supports\
+        \ full XML structure\\nparsing, suitable for small but complete XML chunks,\
+        \ and XML stream parsing\\nsuitable for large XML document, or infinite network\
+        \ XML stream like XMPP.\\nThis module can parse files much faster than built-in\
+        \ module xmerl. Depending\\non file complexity and size xml_stream:parse_element/1\
+        \ can be 8-18 times faster\\nthan calling xmerl_scan:string/2.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_xml\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297150\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast Expat based\
+        \ Erlang XML parsing and manipulation library\",\n      \"upstream_url\":\
+        \ \"https://github.com/processone/xml/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1453730519.0,\n      \"description\": \"P1 YAML\
+        \ is an Erlang wrapper for libyaml \\\"C\\\" library.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_yaml\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297094\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An Erlang wrapper\
+        \ for libyaml \\\"C\\\" library\",\n      \"upstream_url\": \"https://github.com/processone/p1_yaml/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467902264.0,\n\
+        \      \"description\": \"Argument Parsing for Humans.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-args\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352993\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Argument Parsing\
+        \ for Humans\",\n      \"upstream_url\": \"https://github.com/kennethreitz/args\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468427737.0,\n\
+        \      \"description\": \"Clint is a module filled with a set of awesome tools\
+        \ for developing commandline\\napplications. It supports colors, but detects\
+        \ if the session is a TTY, so\\ndoesn't render the colors if you're piping\
+        \ stuff around. Automagically.\",\n      \"koschei_monitor\": true,\n    \
+        \  \"monitor\": true,\n      \"name\": \"python-clint\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1355871\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A set of awesome\
+        \ tools for developing commandline applications\",\n      \"upstream_url\"\
+        : \"https://github.com/kennethreitz/clint\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1452266443.0,\n      \"description\": \"A\
+        \ web based tool for monitoring and administrating Celery clusters. It offers\\\
+        nreal-time monitoring using Celery events, remote control of workers and tasks,\\\
+        nbroker monitoring, and an HTTP API.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-flower\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1285941\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A web based tool\
+        \ for monitoring and administrating Celery clusters\",\n      \"upstream_url\"\
+        : \"https://github.com/mher/flower\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1486055679.0,\n      \"description\": \"fmn is a\
+        \ family of systems to manage end-user notifications triggered by\\nfedmsg,\
+        \ the FEDerated MESsage bus. fmn provides a single place for all\\napplications\
+        \ using fedmsg to notify users of events. Notifications can be\\ndelivered\
+        \ by email, IRC, and server-sent events. Users can configure their\\nnotifications\
+        \ for all the applications they use in one place.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-fmn\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1410901\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A system for generic\
+        \ fedmsg-driven notifications for end users\",\n      \"upstream_url\": \"\
+        https://github.com/fedora-infra/fmn\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1485179561.0,\n      \"description\": \"fmn is a\
+        \ family of systems to manage end-user notifications triggered by\\nfedmsg,\
+        \ the FEDerated MESsage bus. The FMN Server-Sent Events server allows\\nusers\
+        \ to view their fedmsg feed in real-time using server-sent events. It relies\\\
+        non a service to populate the RabbitMQ message queues for it. Typically, this\
+        \ is\\ndone with the FMN core services.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-fmn-sse\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1412798\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A server-sent events\
+        \ server that integrates with FMN\",\n      \"upstream_url\": \"https://github.com/fedora-infra/fmn.sse\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467055928.0,\n\
+        \      \"description\": \"Invocations is a collection of reusable Invoke tasks/task\
+        \ modules, including\\n(but not limited to) Python project management tools\
+        \ such as documentation\\nbuilding and dependency organization. It has no\
+        \ stand-alone components and is\\ndesigned to be imported into your pre-existing\
+        \ Invoke task files.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-invocations\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1349121\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Invocations is a collection\
+        \ of reusable Invoke tasks/task modules\",\n      \"upstream_url\": \"https://github.com/pyinvoke/invocations\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489158551.0,\n\
+        \      \"description\": \"Allows synapse to use LDAP as a password provider.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-matrix-synapse-ldap3\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1430170\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Allows synapse to use LDAP as a password\
+        \ provider\",\n      \"upstream_url\": \"https://github.com/matrix-org/matrix-synapse-ldap3\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467054202.0,\n\
+        \      \"description\": \"This package provides an API for querying the distutils\
+        \ metadata written in the\\nPKG-INFO file inside a source distribution (an\
+        \ sdist) or a binary distribution\\n(e.g., created by running bdist_egg).\
+        \ It can also query the EGG-INFO directory\\nof an installed distribution,\
+        \ and the *.egg-info stored in a \\\"development\\ncheckout\\\" (e.g, created\
+        \ by running setup.py develop).\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": true,\n      \"name\": \"python-pkginfo\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1349026\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Query metadata from\
+        \ sdists / bdists / installed packages\",\n      \"upstream_url\": \"https://pypi.python.org/pypi/pkginfo\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489425664.0,\n\
+        \      \"description\": \"This is a Python re-implementation of the libmacaroons\
+        \ C library.\\nMacaroons, like cookies, are a form of bearer credential. Unlike\\\
+        nopaque tokens, macaroons embed caveats that define specific authorization\\\
+        nrequirements for the target service, the service that issued the root macaroon\\\
+        nand which is capable of verifying the integrity of macaroons it receives.\\\
+        n\\nMacaroons allow for delegation and attenuation of authorization. They\
+        \ are\\nsimple and fast to verify, and decouple authorization policy from\
+        \ the\\nenforcement of that policy.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-pymacaroons-pynacl\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1430107\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Library providing\
+        \ non-opaque cookies for authorization\",\n      \"upstream_url\": \"https://github.com/matrix-org/pymacaroons\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467389346.0,\n\
+        \      \"description\": \"Releases is a Sphinx extension designed to help\
+        \ you keep a source control\\nfriendly, merge friendly changelog file & turn\
+        \ it into useful, human readable\\nHTML output.\\n\\nSpecifically:\\n\\n*\
+        \ The source format (kept in your Sphinx tree as changelog.rst) is a stream-like\\\
+        ntimeline that plays well with source control & only requires one entry per\\\
+        nchange (even for changes that exist in multiple release lines).\\n* The output\
+        \ (when you have the extension installed and run your Sphinx build\\ncommand)\
+        \ is a traditional looking changelog page with a section for every\\nrelease;\
+        \ multi-release issues are copied automatically into each release.\\n* By\
+        \ default, feature and support issues are only displayed under feature\\nreleases,\
+        \ and bugs are only displayed under bugfix releases. This can be\\noverridden\
+        \ on a per-issue basis.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-releases\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1350943\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"A Sphinx extension for changelog\
+        \ manipulation\",\n      \"upstream_url\": \"https://github.com/bitprophet/releases\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1450359898.0,\n\
+        \      \"description\": \"sphinxcontrib-fulltoc is an extension for the Sphinx\
+        \ documentation system that\\nchanges the HTML output to include a more detailed\
+        \ table of contents in the\\nsidebar. By default Sphinx only shows the local\
+        \ headers for the current page.\\nWith the extension installed, all of the\
+        \ page titles are included, and the\\nlocal headers for the current page are\
+        \ also included in the appropriate place\\nwithin the document.\",\n     \
+        \ \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"\
+        python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1291007\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Include a full table of contents in\
+        \ your Sphinx HTML sidebar\",\n      \"upstream_url\": \"https://github.com/dreamhost/sphinxcontrib-fulltoc\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484077565.0,\n\
+        \      \"description\": \"Turn SQLAlchemy DB Model into a graph.\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"\
+        python-sqlalchemy_schemadisplay\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1409929\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Turn SQLAlchemy DB Model into a graph\"\
+        ,\n      \"upstream_url\": \"https://github.com/fschulze/sqlalchemy_schemadisplay\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1469020897.0,\n\
+        \      \"description\": \"Twine is a utility for interacting with PyPI.\\\
+        nCurrently it only supports registering projects and uploading distributions.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-twine\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1352972\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Collection of utilities for interacting with PyPI\"\
+        ,\n      \"upstream_url\": \"https://github.com/pypa/twine\"\n    }\n  ],\n\
+        \  \"watch\": [\n    {\n      \"acls\": [],\n      \"creation_date\": 1468428962.0,\n\
+        \      \"description\": \"A parser for TOML-0.4.0\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-pytoml\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1353606\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Parser for TOML\"\
+        ,\n      \"upstream_url\": \"https://github.com/avakar/pytoml\"\n    }\n \
+        \ ]\n}"}
+    headers:
+      accept-ranges: [bytes]
+      age: ['0']
+      appserver: [proxy12.fedoraproject.org]
+      apptime: [D=455085]
+      connection: [Keep-Alive]
+      content-length: ['33867']
+      content-type: [application/json]
+      date: ['Wed, 29 Mar 2017 16:06:57 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['pkgdb=eyJfcGVybWFuZW50Ijp0cnVlfQ.C71tIg.YrKJTas2ua0pGq-uuD9z8pLtXYU;
+          Expires=Wed, 29-Mar-2017 17:06:58 GMT; Secure; HttpOnly; Path=/pkgdb/']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['9484237']
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagesForTests.test_watch
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagesForTests.test_watch
@@ -1,0 +1,505 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.12.5]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/packager/package/jcline
+  response:
+    body: {string: !!python/unicode "{\n  \"co-maintained\": [\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Bodhi\
+        \ is a web application that facilitates the process of publishing\\nupdates\
+        \ for a software distribution.\\n\\nA modular piece of the Fedora Infrastructure\
+        \ stack\\n* Utilizes the Koji Buildsystem for tracking RPMs\\n* Creates the\
+        \ update repositories using Mash, which composes a repository based\\n  on\
+        \ tagged builds in Koji.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"bodhi\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"A modular framework that facilitates publishing software updates\",\n\
+        \      \"upstream_url\": \"https://github.com/fedora-infra/bodhi\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"ejabberd is a Free and Open Source distributed fault-tolerant\\\
+        nJabber/XMPP server. It is mostly written in Erlang, and runs on many\\nplatforms\
+        \ (tested on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"ejabberd\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"A distributed, fault-tolerant\
+        \ Jabber/XMPP server\",\n      \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1461430105.0,\n\
+        \      \"description\": \"ProcessOne SIP server component in Erlang.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"review_url\":\
+        \ \"https://bugzilla.redhat.com/1329441\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"ProcessOne SIP server component in Erlang\",\n   \
+        \   \"upstream_url\": \"https://github.com/processone/esip/\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1459274896.0,\n      \"\
+        description\": \"A native zlib driver for Erlang / Elixir, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1315134\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Native zlib driver for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/ezlib/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1460378527.0,\n      \"description\": \"TLS\
+        \ / SSL native driver for Erlang / Elixir. This is used by ejabberd.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316767\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"TLS / SSL native driver for Erlang / Elixir\",\n \
+        \     \"upstream_url\": \"https://github.com/processone/fast_tls/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1460475617.0,\n    \
+        \  \"description\": \"Fast Expat based Erlang XML parsing and manipulation\
+        \ library, with a strong\\nfocus on XML stream parsing from network. It supports\
+        \ full XML structure\\nparsing, suitable for small but complete XML chunks,\
+        \ and XML stream parsing\\nsuitable for large XML document, or infinite network\
+        \ XML stream like XMPP.\\nThis module can parse files much faster than built-in\
+        \ module xmerl. Depending\\non file complexity and size xml_stream:parse_element/1\
+        \ can be 8-18 times faster\\nthan calling xmerl_scan:string/2.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"erlang-fast_xml\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317182\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast Expat based\
+        \ Erlang XML parsing and manipulation library\",\n      \"upstream_url\":\
+        \ \"https://github.com/processone/fast_xml/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1459274717.0,\n      \"description\": \"P1\
+        \ YAML is an Erlang wrapper for libyaml \\\"C\\\" library.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-fast_yaml\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317184\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An Erlang wrapper\
+        \ for libyaml \\\"C\\\" library\",\n      \"upstream_url\": \"https://github.com/processone/fast_yaml/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1455917846.0,\n\
+        \      \"description\": \"A small Erlang app that provides fast event stream\
+        \ processing.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"erlang-goldrush\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/1309939\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Small, fast event processing and monitoring\
+        \ for Erlang/OTP applications\",\n      \"upstream_url\": \"https://github.com/DeadZen/goldrush\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1459968632.0,\n\
+        \      \"description\": \"Erlang bindings for libiconv. This is used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316762\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Fast encoding conversion library for Erlang / Elixir\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/iconv/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1458136455.0,\n    \
+        \  \"description\": \"An experimental implementation of Lua 5.2 written solely\
+        \ in pure Erlang.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"erlang-luerl\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1317345\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Lua in Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/rvirding/luerl\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1455034950.0,\n      \"description\": \"This library\
+        \ is designed to simplify the implementation of the server side of\\nOAuth2.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1294331\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"An Oauth2 implementation for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/kivra/oauth2\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1454706689.0,\n      \"description\": \"Erlang bindings\
+        \ for iconv. This is used by ejabberd.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-p1_iconv\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1294368\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast encoding conversion\
+        \ library for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/iconv/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454706783.0,\n\
+        \      \"description\": \"This is an Erlang MySQL driver, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295011\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Pure Erlang MySQL driver\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/p1_mysql/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1458568963.0,\n      \"description\": \"This\
+        \ library is designed to simplify the implementation of the server side of\\\
+        nOAuth2. It is a fork of erlang-oauth2 by processone, and is needed by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1317336\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"An Oauth2 implementation for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/p1_oauth2\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1454870042.0,\n      \"description\": \"An\
+        \ Erlang library for ejabberd that helps with PAM authentication.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295035\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Library for ejabberd for PAM authentication support\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/epam/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1454706762.0,\n    \
+        \  \"description\": \"Pure Erlang PostgreSQL driver.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_pgsql\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1294730\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Pure Erlang PostgreSQL\
+        \ driver\",\n      \"upstream_url\": \"https://github.com/processone/p1_pgsql\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1451836021.0,\n\
+        \      \"description\": \"p1_utils is an application containing ProcessOne\
+        \ modules and tools that are\\nleveraged in other development projects.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_utils\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1294587\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Erlang utility modules from ProcessOne\",\n      \"\
+        upstream_url\": \"https://github.com/processone/p1_utils/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1458659356.0,\n      \"description\"\
+        : \"This is an HTTP 1.1 compliant XML-RPC library for Erlang. It is designed\
+        \ to make\\nit easy to write XML-RPC Erlang clients and/or servers. The library\
+        \ is compliant\\nwith the XML-RPC specification published by http://www.xmlrpc.org/.\
+        \ It is a fork\\nof erlang-xmlrpc maintained by processone for ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1317341\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Erlang XMLRPC implementation with SSL, cookies, Authentication\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/p1_xmlrpc\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454870064.0,\n\
+        \      \"description\": \"A native zlib driver for Erlang, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295009\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Native zlib driver for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/ezlib/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1452180599.0,\n      \"description\": \"PropEr\
+        \ (PROPerty-based testing tool for ERlang) is a QuickCheck-inspired\\nopen-source\
+        \ property-based testing tool for Erlang.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-proper\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1295667\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A QuickCheck-inspired\
+        \ property-based testing tool for Erlang\",\n      \"upstream_url\": \"https://github.com/manopapad/proper\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460378560.0,\n\
+        \      \"description\": \"Stringprep is a framework for preparing Unicode\
+        \ test strings in order to\\nincrease the likelihood that string input and\
+        \ string comparison work. The\\nprinciple are defined in RFC-3454: Preparation\
+        \ of Internationalized Strings.\\nThis library is leverage Erlang native NIF\
+        \ mechanism to provide extremely fast\\nand efficient processing.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316772\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A framework for preparing Unicode strings to help\
+        \ input and comparison\",\n      \"upstream_url\": \"https://github.com/processone/stringprep/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460475644.0,\n\
+        \      \"description\": \"STUN and TURN library for Erlang / Elixir. Both\
+        \ STUN (Session Traversal\\nUtilities for NAT) and TURN standards are used\
+        \ as techniques to establish media\\nconnection between peers for VoIP (for\
+        \ example using SIP or Jingle) and WebRTC.\",\n      \"koschei_monitor\":\
+        \ true,\n      \"monitor\": true,\n      \"name\": \"erlang-stun\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317183\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"STUN and TURN library\
+        \ for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/stun/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483391539.0,\n\
+        \      \"description\": \"XMPP is an Erlang XMPP parsing and serialization\
+        \ library, built on top of Fast\\nXML.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-xmpp\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1409326\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Erlang/Elixir XMPP\
+        \ parsing and serialization library\",\n      \"upstream_url\": \"https://github.com/processone/xmpp/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484067733.0,\n\
+        \      \"description\": \"Fegistry is the container registry endpoint for\
+        \ Fedora's users. It will answer\\nthe initial requests when users docker\
+        \ pull Fedora containers.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"fegistry\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/1411462\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"The Fedora registry endpoint\",\n  \
+        \    \"upstream_url\": \"https://pagure.io/fegistry\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1453388826.0,\n      \"description\"\
+        : \"This WSGI application exposes a read-only API similar to\\ndocker-registry,\
+        \ which docker can use for \\\"docker pull\\\" operations.\\nRequests for\
+        \ actual image files are responded to with 302 redirects to\\na URL formed\
+        \ with per-repository settings.\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": true,\n      \"name\": \"python-crane\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297629\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A WSGI app providing\
+        \ a docker-registry-like API with redirection\",\n      \"upstream_url\":\
+        \ \"https://github.com/pulp/crane\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1419871778.0,\n      \"description\": \"A library\
+        \ to support the Internationalised Domain Names in Applications (IDNA)\\nprotocol\
+        \ as specified in RFC 5891 <http://tools.ietf.org/html/rfc5891>.  This\\nversion\
+        \ of the protocol is often referred to as \\\"IDNA2008\\\" and can produce\\\
+        ndifferent results from the earlier standard from 2003.\\n\\nThe library is\
+        \ also intended to act as a suitable drop-in replacement for the\\n\\\"encodings.idna\\\
+        \" module that comes with the Python standard library but\\ncurrently only\
+        \ supports the older 2003 specification.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-idna\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1119056\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Internationalized\
+        \ Domain Names in Applications (IDNA)\",\n      \"upstream_url\": \"https://github.com/kjd/idna\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"IPython features (tab completion, syntax highlighting,\
+        \ better tracebacks,\\nbetter introspection) right in pdb.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-ipdb\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"IPython enabled Python debugger\",\n\
+        \      \"upstream_url\": \"https://github.com/gotcha/ipdb/\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"This module implements ISO 8601 date, time and duration parsing.\
+        \ The\\nimplementation follows ISO8601:2004 standard, and implements only\
+        \ date/time\\nrepresentations mentioned in the standard. If something is not\
+        \ mentioned there,\\nthen it is treated as non existent, and not as an allowed\
+        \ option.\\n\\nFor instance, ISO8601:2004 never mentions 2 digit years. So,\
+        \ it is not intended\\nby this module to support 2 digit years. (while it\
+        \ may still be valid as ISO\\ndate, because it is not explicitly forbidden.)\
+        \ Another example is, when no time\\nzone information is given for a time,\
+        \ then it should be interpreted as local\\ntime, and not UTC.\\n\\nAs this\
+        \ module maps ISO 8601 dates/times to standard Python data types, like\\ndate,\
+        \ time, datetime and timedelta, it is not possible to convert all possible\\\
+        nISO 8601 dates/times. For instance, dates before 0001-01-01 are not allowed\
+        \ by\\nthe Python date and datetime classes. Additionally fractional seconds\
+        \ are\\nlimited to microseconds. That means if the parser finds for instance\\\
+        nnanoseconds it will round it to microseconds.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-isodate\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An ISO 8601 date/time/duration parser\
+        \ and formatter\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/isodate\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483389591.0,\n\
+        \      \"description\": \"configuration parser.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-kaptan\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1405742\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Configuration parser\"\
+        ,\n      \"upstream_url\": \"https://pypi.python.org/pypi/kaptan\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"The Python driver for MongoDB.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-pymongo\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Python driver for MongoDB\",\n     \
+        \ \"upstream_url\": \"http://api.mongodb.org/python\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Most existing Python modules for sending HTTP requests are extremely verbose\
+        \ and\\ncumbersome. Python\\u2019s built-in urllib2 module provides most of\
+        \ the HTTP\\ncapabilities you should need, but the API is thoroughly broken.\
+        \ This library is\\ndesigned to make HTTP requests easy for developers.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-requests\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"HTTP library,\
+        \ written in Python, for human beings\",\n      \"upstream_url\": \"https://pypi.io/project/requests\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1448383568.0,\n\
+        \      \"description\": \"A wrapper around pdb allowing remote debugging via\
+        \ netcat or telnet.\\nThis is especially useful in a Tomcat/Jython environment\
+        \ where little\\ndebugging tools are available.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-rpdb\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1284155\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A wrapper around\
+        \ pdb allowing remote debugging\",\n      \"upstream_url\": \"https://github.com/tamentis/rpdb\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Python HTTP module with connection pooling and file\
+        \ POST abilities.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-urllib3\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Python HTTP library with thread-safe connection pooling and file\
+        \ post\",\n      \"upstream_url\": \"https://github.com/shazow/urllib3\"\n\
+        \    }\n  ],\n  \"output\": \"ok\",\n  \"point of contact\": [\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1452379737.0,\n      \"description\"\
+        : \"This application is intended to proxy back-end operations for Key-Value\
+        \ insert,\\nlookup and delete and maintain a cache of those Key-Values in-memory,\
+        \ to save\\nback-end operations. Operations are intended to be atomic between\
+        \ back-end and\\ncache tables. The lifetime of the cache object and the max\
+        \ size of the cache\\ncan be defined as table parameters to limit the size\
+        \ of the in-memory tables.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": true,\n      \"name\": \"erlang-cache_tab\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1295075\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Erlang cache table\
+        \ application\",\n      \"upstream_url\": \"https://github.com/processone/cache_tab/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454421370.0,\n\
+        \      \"description\": \"ProcessOne SIP server component in Erlang.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1303434\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"ProcessOne SIP server component in Erlang\",\n   \
+        \   \"upstream_url\": \"https://github.com/processone/p1_sip/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1454521406.0,\n    \
+        \  \"description\": \"Stringprep is a framework for preparing Unicode test\
+        \ strings in order to\\nincrease the likelihood that string input and string\
+        \ comparison work. The\\nprinciple are defined in RFC-3454: Preparation of\
+        \ Internationalized Strings.\\nThis library is leverage Erlang native NIF\
+        \ mechanism to provide extremely fast\\nand efficient processing.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1296792\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A framework for preparing Unicode strings to help\
+        \ input and comparison\",\n      \"upstream_url\": \"https://github.com/processone/stringprep/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453840458.0,\n\
+        \      \"description\": \"STUN and TURN library for Erlang / Elixir. Both\
+        \ STUN (Session Traversal\\nUtilities for NAT) and TURN standards are used\
+        \ as techniques to establish media\\nconnection between peers for VoIP (for\
+        \ example using SIP or Jingle) and WebRTC.\",\n      \"koschei_monitor\":\
+        \ false,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_stun\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1301316\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"STUN and TURN library\
+        \ for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/stun/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453389245.0,\n\
+        \      \"description\": \"TLS / SSL native driver for Erlang / Elixir. This\
+        \ is used by ejabberd.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"erlang-p1_tls\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1299305\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"TLS / SSL native driver for\
+        \ Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/tls/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454593209.0,\n\
+        \      \"description\": \"Fast Expat based Erlang XML parsing and manipulation\
+        \ library, with a strong\\nfocus on XML stream parsing from network. It supports\
+        \ full XML structure\\nparsing, suitable for small but complete XML chunks,\
+        \ and XML stream parsing\\nsuitable for large XML document, or infinite network\
+        \ XML stream like XMPP.\\nThis module can parse files much faster than built-in\
+        \ module xmerl. Depending\\non file complexity and size xml_stream:parse_element/1\
+        \ can be 8-18 times faster\\nthan calling xmerl_scan:string/2.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_xml\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297150\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast Expat based\
+        \ Erlang XML parsing and manipulation library\",\n      \"upstream_url\":\
+        \ \"https://github.com/processone/xml/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1453730519.0,\n      \"description\": \"P1 YAML\
+        \ is an Erlang wrapper for libyaml \\\"C\\\" library.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_yaml\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297094\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An Erlang wrapper\
+        \ for libyaml \\\"C\\\" library\",\n      \"upstream_url\": \"https://github.com/processone/p1_yaml/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467902264.0,\n\
+        \      \"description\": \"Argument Parsing for Humans.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-args\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352993\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Argument Parsing\
+        \ for Humans\",\n      \"upstream_url\": \"https://github.com/kennethreitz/args\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468427737.0,\n\
+        \      \"description\": \"Clint is a module filled with a set of awesome tools\
+        \ for developing commandline\\napplications. It supports colors, but detects\
+        \ if the session is a TTY, so\\ndoesn't render the colors if you're piping\
+        \ stuff around. Automagically.\",\n      \"koschei_monitor\": true,\n    \
+        \  \"monitor\": true,\n      \"name\": \"python-clint\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1355871\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A set of awesome\
+        \ tools for developing commandline applications\",\n      \"upstream_url\"\
+        : \"https://github.com/kennethreitz/clint\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1452266443.0,\n      \"description\": \"A\
+        \ web based tool for monitoring and administrating Celery clusters. It offers\\\
+        nreal-time monitoring using Celery events, remote control of workers and tasks,\\\
+        nbroker monitoring, and an HTTP API.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-flower\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1285941\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A web based tool\
+        \ for monitoring and administrating Celery clusters\",\n      \"upstream_url\"\
+        : \"https://github.com/mher/flower\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1486055679.0,\n      \"description\": \"fmn is a\
+        \ family of systems to manage end-user notifications triggered by\\nfedmsg,\
+        \ the FEDerated MESsage bus. fmn provides a single place for all\\napplications\
+        \ using fedmsg to notify users of events. Notifications can be\\ndelivered\
+        \ by email, IRC, and server-sent events. Users can configure their\\nnotifications\
+        \ for all the applications they use in one place.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-fmn\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1410901\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A system for generic\
+        \ fedmsg-driven notifications for end users\",\n      \"upstream_url\": \"\
+        https://github.com/fedora-infra/fmn\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1485179561.0,\n      \"description\": \"fmn is a\
+        \ family of systems to manage end-user notifications triggered by\\nfedmsg,\
+        \ the FEDerated MESsage bus. The FMN Server-Sent Events server allows\\nusers\
+        \ to view their fedmsg feed in real-time using server-sent events. It relies\\\
+        non a service to populate the RabbitMQ message queues for it. Typically, this\
+        \ is\\ndone with the FMN core services.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-fmn-sse\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1412798\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A server-sent events\
+        \ server that integrates with FMN\",\n      \"upstream_url\": \"https://github.com/fedora-infra/fmn.sse\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467055928.0,\n\
+        \      \"description\": \"Invocations is a collection of reusable Invoke tasks/task\
+        \ modules, including\\n(but not limited to) Python project management tools\
+        \ such as documentation\\nbuilding and dependency organization. It has no\
+        \ stand-alone components and is\\ndesigned to be imported into your pre-existing\
+        \ Invoke task files.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-invocations\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1349121\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Invocations is a collection\
+        \ of reusable Invoke tasks/task modules\",\n      \"upstream_url\": \"https://github.com/pyinvoke/invocations\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489158551.0,\n\
+        \      \"description\": \"Allows synapse to use LDAP as a password provider.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-matrix-synapse-ldap3\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1430170\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Allows synapse to use LDAP as a password\
+        \ provider\",\n      \"upstream_url\": \"https://github.com/matrix-org/matrix-synapse-ldap3\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467054202.0,\n\
+        \      \"description\": \"This package provides an API for querying the distutils\
+        \ metadata written in the\\nPKG-INFO file inside a source distribution (an\
+        \ sdist) or a binary distribution\\n(e.g., created by running bdist_egg).\
+        \ It can also query the EGG-INFO directory\\nof an installed distribution,\
+        \ and the *.egg-info stored in a \\\"development\\ncheckout\\\" (e.g, created\
+        \ by running setup.py develop).\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": true,\n      \"name\": \"python-pkginfo\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1349026\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Query metadata from\
+        \ sdists / bdists / installed packages\",\n      \"upstream_url\": \"https://pypi.python.org/pypi/pkginfo\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489425664.0,\n\
+        \      \"description\": \"This is a Python re-implementation of the libmacaroons\
+        \ C library.\\nMacaroons, like cookies, are a form of bearer credential. Unlike\\\
+        nopaque tokens, macaroons embed caveats that define specific authorization\\\
+        nrequirements for the target service, the service that issued the root macaroon\\\
+        nand which is capable of verifying the integrity of macaroons it receives.\\\
+        n\\nMacaroons allow for delegation and attenuation of authorization. They\
+        \ are\\nsimple and fast to verify, and decouple authorization policy from\
+        \ the\\nenforcement of that policy.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-pymacaroons-pynacl\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1430107\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Library providing\
+        \ non-opaque cookies for authorization\",\n      \"upstream_url\": \"https://github.com/matrix-org/pymacaroons\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467389346.0,\n\
+        \      \"description\": \"Releases is a Sphinx extension designed to help\
+        \ you keep a source control\\nfriendly, merge friendly changelog file & turn\
+        \ it into useful, human readable\\nHTML output.\\n\\nSpecifically:\\n\\n*\
+        \ The source format (kept in your Sphinx tree as changelog.rst) is a stream-like\\\
+        ntimeline that plays well with source control & only requires one entry per\\\
+        nchange (even for changes that exist in multiple release lines).\\n* The output\
+        \ (when you have the extension installed and run your Sphinx build\\ncommand)\
+        \ is a traditional looking changelog page with a section for every\\nrelease;\
+        \ multi-release issues are copied automatically into each release.\\n* By\
+        \ default, feature and support issues are only displayed under feature\\nreleases,\
+        \ and bugs are only displayed under bugfix releases. This can be\\noverridden\
+        \ on a per-issue basis.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-releases\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1350943\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"A Sphinx extension for changelog\
+        \ manipulation\",\n      \"upstream_url\": \"https://github.com/bitprophet/releases\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1450359898.0,\n\
+        \      \"description\": \"sphinxcontrib-fulltoc is an extension for the Sphinx\
+        \ documentation system that\\nchanges the HTML output to include a more detailed\
+        \ table of contents in the\\nsidebar. By default Sphinx only shows the local\
+        \ headers for the current page.\\nWith the extension installed, all of the\
+        \ page titles are included, and the\\nlocal headers for the current page are\
+        \ also included in the appropriate place\\nwithin the document.\",\n     \
+        \ \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"\
+        python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1291007\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Include a full table of contents in\
+        \ your Sphinx HTML sidebar\",\n      \"upstream_url\": \"https://github.com/dreamhost/sphinxcontrib-fulltoc\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484077565.0,\n\
+        \      \"description\": \"Turn SQLAlchemy DB Model into a graph.\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"\
+        python-sqlalchemy_schemadisplay\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1409929\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Turn SQLAlchemy DB Model into a graph\"\
+        ,\n      \"upstream_url\": \"https://github.com/fschulze/sqlalchemy_schemadisplay\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1469020897.0,\n\
+        \      \"description\": \"Twine is a utility for interacting with PyPI.\\\
+        nCurrently it only supports registering projects and uploading distributions.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-twine\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1352972\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Collection of utilities for interacting with PyPI\"\
+        ,\n      \"upstream_url\": \"https://github.com/pypa/twine\"\n    }\n  ],\n\
+        \  \"watch\": [\n    {\n      \"acls\": [],\n      \"creation_date\": 1468428962.0,\n\
+        \      \"description\": \"A parser for TOML-0.4.0\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-pytoml\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1353606\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Parser for TOML\"\
+        ,\n      \"upstream_url\": \"https://github.com/avakar/pytoml\"\n    }\n \
+        \ ]\n}"}
+    headers:
+      accept-ranges: [bytes]
+      age: ['0']
+      appserver: [proxy09.fedoraproject.org]
+      apptime: [D=1775546]
+      connection: [Keep-Alive]
+      content-length: ['33867']
+      content-type: [application/json]
+      date: ['Wed, 29 Mar 2017 18:10:29 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['pkgdb=eyJfcGVybWFuZW50Ijp0cnVlfQ.C72KFg.w07dcFks-rm1tla9CXUZiEC4jhA;
+          Expires=Wed, 29-Mar-2017 19:10:30 GMT; Secure; HttpOnly; Path=/pkgdb/']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['19470670']
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagesForTests.test_watched
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagesForTests.test_watched
@@ -1,0 +1,505 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/packager/package/jcline
+  response:
+    body: {string: !!python/unicode "{\n  \"co-maintained\": [\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1400070978.0,\n      \"description\": \"Bodhi\
+        \ is a web application that facilitates the process of publishing\\nupdates\
+        \ for a software distribution.\\n\\nA modular piece of the Fedora Infrastructure\
+        \ stack\\n* Utilizes the Koji Buildsystem for tracking RPMs\\n* Creates the\
+        \ update repositories using Mash, which composes a repository based\\n  on\
+        \ tagged builds in Koji.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"bodhi\",\n      \"namespace\": \"rpms\",\n    \
+        \  \"review_url\": null,\n      \"status\": \"Approved\",\n      \"summary\"\
+        : \"A modular framework that facilitates publishing software updates\",\n\
+        \      \"upstream_url\": \"https://github.com/fedora-infra/bodhi\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"ejabberd is a Free and Open Source distributed fault-tolerant\\\
+        nJabber/XMPP server. It is mostly written in Erlang, and runs on many\\nplatforms\
+        \ (tested on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"ejabberd\",\n      \"namespace\": \"rpms\",\n      \"review_url\": null,\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"A distributed, fault-tolerant\
+        \ Jabber/XMPP server\",\n      \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1461430105.0,\n\
+        \      \"description\": \"ProcessOne SIP server component in Erlang.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"review_url\":\
+        \ \"https://bugzilla.redhat.com/1329441\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"ProcessOne SIP server component in Erlang\",\n   \
+        \   \"upstream_url\": \"https://github.com/processone/esip/\"\n    },\n  \
+        \  {\n      \"acls\": [],\n      \"creation_date\": 1459274896.0,\n      \"\
+        description\": \"A native zlib driver for Erlang / Elixir, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1315134\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Native zlib driver for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/ezlib/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1460378527.0,\n      \"description\": \"TLS\
+        \ / SSL native driver for Erlang / Elixir. This is used by ejabberd.\",\n\
+        \      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316767\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"TLS / SSL native driver for Erlang / Elixir\",\n \
+        \     \"upstream_url\": \"https://github.com/processone/fast_tls/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1460475617.0,\n    \
+        \  \"description\": \"Fast Expat based Erlang XML parsing and manipulation\
+        \ library, with a strong\\nfocus on XML stream parsing from network. It supports\
+        \ full XML structure\\nparsing, suitable for small but complete XML chunks,\
+        \ and XML stream parsing\\nsuitable for large XML document, or infinite network\
+        \ XML stream like XMPP.\\nThis module can parse files much faster than built-in\
+        \ module xmerl. Depending\\non file complexity and size xml_stream:parse_element/1\
+        \ can be 8-18 times faster\\nthan calling xmerl_scan:string/2.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"erlang-fast_xml\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317182\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast Expat based\
+        \ Erlang XML parsing and manipulation library\",\n      \"upstream_url\":\
+        \ \"https://github.com/processone/fast_xml/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1459274717.0,\n      \"description\": \"P1\
+        \ YAML is an Erlang wrapper for libyaml \\\"C\\\" library.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-fast_yaml\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317184\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An Erlang wrapper\
+        \ for libyaml \\\"C\\\" library\",\n      \"upstream_url\": \"https://github.com/processone/fast_yaml/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1455917846.0,\n\
+        \      \"description\": \"A small Erlang app that provides fast event stream\
+        \ processing.\",\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n\
+        \      \"name\": \"erlang-goldrush\",\n      \"namespace\": \"rpms\",\n  \
+        \    \"review_url\": \"https://bugzilla.redhat.com/1309939\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Small, fast event processing and monitoring\
+        \ for Erlang/OTP applications\",\n      \"upstream_url\": \"https://github.com/DeadZen/goldrush\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1459968632.0,\n\
+        \      \"description\": \"Erlang bindings for libiconv. This is used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316762\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Fast encoding conversion library for Erlang / Elixir\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/iconv/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1458136455.0,\n    \
+        \  \"description\": \"An experimental implementation of Lua 5.2 written solely\
+        \ in pure Erlang.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"erlang-luerl\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1317345\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"Lua in Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/rvirding/luerl\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1455034950.0,\n      \"description\": \"This library\
+        \ is designed to simplify the implementation of the server side of\\nOAuth2.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1294331\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"An Oauth2 implementation for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/kivra/oauth2\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1454706689.0,\n      \"description\": \"Erlang bindings\
+        \ for iconv. This is used by ejabberd.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-p1_iconv\",\n      \"\
+        namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1294368\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast encoding conversion\
+        \ library for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/iconv/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454706783.0,\n\
+        \      \"description\": \"This is an Erlang MySQL driver, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295011\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Pure Erlang MySQL driver\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/p1_mysql/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1458568963.0,\n      \"description\": \"This\
+        \ library is designed to simplify the implementation of the server side of\\\
+        nOAuth2. It is a fork of erlang-oauth2 by processone, and is needed by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1317336\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"An Oauth2 implementation for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/p1_oauth2\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1454870042.0,\n      \"description\": \"An\
+        \ Erlang library for ejabberd that helps with PAM authentication.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295035\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Library for ejabberd for PAM authentication support\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/epam/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1454706762.0,\n    \
+        \  \"description\": \"Pure Erlang PostgreSQL driver.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_pgsql\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1294730\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Pure Erlang PostgreSQL\
+        \ driver\",\n      \"upstream_url\": \"https://github.com/processone/p1_pgsql\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1451836021.0,\n\
+        \      \"description\": \"p1_utils is an application containing ProcessOne\
+        \ modules and tools that are\\nleveraged in other development projects.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_utils\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1294587\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Erlang utility modules from ProcessOne\",\n      \"\
+        upstream_url\": \"https://github.com/processone/p1_utils/\"\n    },\n    {\n\
+        \      \"acls\": [],\n      \"creation_date\": 1458659356.0,\n      \"description\"\
+        : \"This is an HTTP 1.1 compliant XML-RPC library for Erlang. It is designed\
+        \ to make\\nit easy to write XML-RPC Erlang clients and/or servers. The library\
+        \ is compliant\\nwith the XML-RPC specification published by http://www.xmlrpc.org/.\
+        \ It is a fork\\nof erlang-xmlrpc maintained by processone for ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1317341\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Erlang XMLRPC implementation with SSL, cookies, Authentication\"\
+        ,\n      \"upstream_url\": \"https://github.com/processone/p1_xmlrpc\"\n \
+        \   },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454870064.0,\n\
+        \      \"description\": \"A native zlib driver for Erlang, used by ejabberd.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1295009\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Native zlib driver for Erlang\",\n      \"upstream_url\"\
+        : \"https://github.com/processone/ezlib/\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1452180599.0,\n      \"description\": \"PropEr\
+        \ (PROPerty-based testing tool for ERlang) is a QuickCheck-inspired\\nopen-source\
+        \ property-based testing tool for Erlang.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-proper\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1295667\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A QuickCheck-inspired\
+        \ property-based testing tool for Erlang\",\n      \"upstream_url\": \"https://github.com/manopapad/proper\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460378560.0,\n\
+        \      \"description\": \"Stringprep is a framework for preparing Unicode\
+        \ test strings in order to\\nincrease the likelihood that string input and\
+        \ string comparison work. The\\nprinciple are defined in RFC-3454: Preparation\
+        \ of Internationalized Strings.\\nThis library is leverage Erlang native NIF\
+        \ mechanism to provide extremely fast\\nand efficient processing.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1316772\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A framework for preparing Unicode strings to help\
+        \ input and comparison\",\n      \"upstream_url\": \"https://github.com/processone/stringprep/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1460475644.0,\n\
+        \      \"description\": \"STUN and TURN library for Erlang / Elixir. Both\
+        \ STUN (Session Traversal\\nUtilities for NAT) and TURN standards are used\
+        \ as techniques to establish media\\nconnection between peers for VoIP (for\
+        \ example using SIP or Jingle) and WebRTC.\",\n      \"koschei_monitor\":\
+        \ true,\n      \"monitor\": true,\n      \"name\": \"erlang-stun\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1317183\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"STUN and TURN library\
+        \ for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/stun/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483391539.0,\n\
+        \      \"description\": \"XMPP is an Erlang XMPP parsing and serialization\
+        \ library, built on top of Fast\\nXML.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"erlang-xmpp\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1409326\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Erlang/Elixir XMPP\
+        \ parsing and serialization library\",\n      \"upstream_url\": \"https://github.com/processone/xmpp/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484067733.0,\n\
+        \      \"description\": \"Fegistry is the container registry endpoint for\
+        \ Fedora's users. It will answer\\nthe initial requests when users docker\
+        \ pull Fedora containers.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"fegistry\",\n      \"namespace\": \"rpms\",\n \
+        \     \"review_url\": \"https://bugzilla.redhat.com/1411462\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"The Fedora registry endpoint\",\n  \
+        \    \"upstream_url\": \"https://pagure.io/fegistry\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1453388826.0,\n      \"description\"\
+        : \"This WSGI application exposes a read-only API similar to\\ndocker-registry,\
+        \ which docker can use for \\\"docker pull\\\" operations.\\nRequests for\
+        \ actual image files are responded to with 302 redirects to\\na URL formed\
+        \ with per-repository settings.\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": true,\n      \"name\": \"python-crane\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297629\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A WSGI app providing\
+        \ a docker-registry-like API with redirection\",\n      \"upstream_url\":\
+        \ \"https://github.com/pulp/crane\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1419871778.0,\n      \"description\": \"A library\
+        \ to support the Internationalised Domain Names in Applications (IDNA)\\nprotocol\
+        \ as specified in RFC 5891 <http://tools.ietf.org/html/rfc5891>.  This\\nversion\
+        \ of the protocol is often referred to as \\\"IDNA2008\\\" and can produce\\\
+        ndifferent results from the earlier standard from 2003.\\n\\nThe library is\
+        \ also intended to act as a suitable drop-in replacement for the\\n\\\"encodings.idna\\\
+        \" module that comes with the Python standard library but\\ncurrently only\
+        \ supports the older 2003 specification.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-idna\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1119056\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Internationalized\
+        \ Domain Names in Applications (IDNA)\",\n      \"upstream_url\": \"https://github.com/kjd/idna\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"IPython features (tab completion, syntax highlighting,\
+        \ better tracebacks,\\nbetter introspection) right in pdb.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-ipdb\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"IPython enabled Python debugger\",\n\
+        \      \"upstream_url\": \"https://github.com/gotcha/ipdb/\"\n    },\n   \
+        \ {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"\
+        description\": \"This module implements ISO 8601 date, time and duration parsing.\
+        \ The\\nimplementation follows ISO8601:2004 standard, and implements only\
+        \ date/time\\nrepresentations mentioned in the standard. If something is not\
+        \ mentioned there,\\nthen it is treated as non existent, and not as an allowed\
+        \ option.\\n\\nFor instance, ISO8601:2004 never mentions 2 digit years. So,\
+        \ it is not intended\\nby this module to support 2 digit years. (while it\
+        \ may still be valid as ISO\\ndate, because it is not explicitly forbidden.)\
+        \ Another example is, when no time\\nzone information is given for a time,\
+        \ then it should be interpreted as local\\ntime, and not UTC.\\n\\nAs this\
+        \ module maps ISO 8601 dates/times to standard Python data types, like\\ndate,\
+        \ time, datetime and timedelta, it is not possible to convert all possible\\\
+        nISO 8601 dates/times. For instance, dates before 0001-01-01 are not allowed\
+        \ by\\nthe Python date and datetime classes. Additionally fractional seconds\
+        \ are\\nlimited to microseconds. That means if the parser finds for instance\\\
+        nnanoseconds it will round it to microseconds.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-isodate\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"An ISO 8601 date/time/duration parser\
+        \ and formatter\",\n      \"upstream_url\": \"http://pypi.python.org/pypi/isodate\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1483389591.0,\n\
+        \      \"description\": \"configuration parser.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-kaptan\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1405742\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Configuration parser\"\
+        ,\n      \"upstream_url\": \"https://pypi.python.org/pypi/kaptan\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n    \
+        \  \"description\": \"The Python driver for MongoDB.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-pymongo\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": null,\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Python driver for MongoDB\",\n     \
+        \ \"upstream_url\": \"http://api.mongodb.org/python\"\n    },\n    {\n   \
+        \   \"acls\": [],\n      \"creation_date\": 1400070978.0,\n      \"description\"\
+        : \"Most existing Python modules for sending HTTP requests are extremely verbose\
+        \ and\\ncumbersome. Python\\u2019s built-in urllib2 module provides most of\
+        \ the HTTP\\ncapabilities you should need, but the API is thoroughly broken.\
+        \ This library is\\ndesigned to make HTTP requests easy for developers.\"\
+        ,\n      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-requests\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : null,\n      \"status\": \"Approved\",\n      \"summary\": \"HTTP library,\
+        \ written in Python, for human beings\",\n      \"upstream_url\": \"https://pypi.io/project/requests\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1448383568.0,\n\
+        \      \"description\": \"A wrapper around pdb allowing remote debugging via\
+        \ netcat or telnet.\\nThis is especially useful in a Tomcat/Jython environment\
+        \ where little\\ndebugging tools are available.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-rpdb\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1284155\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A wrapper around\
+        \ pdb allowing remote debugging\",\n      \"upstream_url\": \"https://github.com/tamentis/rpdb\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1400070978.0,\n\
+        \      \"description\": \"Python HTTP module with connection pooling and file\
+        \ POST abilities.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-urllib3\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": null,\n      \"status\": \"Approved\",\n      \"\
+        summary\": \"Python HTTP library with thread-safe connection pooling and file\
+        \ post\",\n      \"upstream_url\": \"https://github.com/shazow/urllib3\"\n\
+        \    }\n  ],\n  \"output\": \"ok\",\n  \"point of contact\": [\n    {\n  \
+        \    \"acls\": [],\n      \"creation_date\": 1452379737.0,\n      \"description\"\
+        : \"This application is intended to proxy back-end operations for Key-Value\
+        \ insert,\\nlookup and delete and maintain a cache of those Key-Values in-memory,\
+        \ to save\\nback-end operations. Operations are intended to be atomic between\
+        \ back-end and\\ncache tables. The lifetime of the cache object and the max\
+        \ size of the cache\\ncan be defined as table parameters to limit the size\
+        \ of the in-memory tables.\",\n      \"koschei_monitor\": true,\n      \"\
+        monitor\": true,\n      \"name\": \"erlang-cache_tab\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1295075\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Erlang cache table\
+        \ application\",\n      \"upstream_url\": \"https://github.com/processone/cache_tab/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454421370.0,\n\
+        \      \"description\": \"ProcessOne SIP server component in Erlang.\",\n\
+        \      \"koschei_monitor\": false,\n      \"monitor\": true,\n      \"name\"\
+        : \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1303434\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"ProcessOne SIP server component in Erlang\",\n   \
+        \   \"upstream_url\": \"https://github.com/processone/p1_sip/\"\n    },\n\
+        \    {\n      \"acls\": [],\n      \"creation_date\": 1454521406.0,\n    \
+        \  \"description\": \"Stringprep is a framework for preparing Unicode test\
+        \ strings in order to\\nincrease the likelihood that string input and string\
+        \ comparison work. The\\nprinciple are defined in RFC-3454: Preparation of\
+        \ Internationalized Strings.\\nThis library is leverage Erlang native NIF\
+        \ mechanism to provide extremely fast\\nand efficient processing.\",\n   \
+        \   \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\":\
+        \ \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1296792\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"A framework for preparing Unicode strings to help\
+        \ input and comparison\",\n      \"upstream_url\": \"https://github.com/processone/stringprep/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453840458.0,\n\
+        \      \"description\": \"STUN and TURN library for Erlang / Elixir. Both\
+        \ STUN (Session Traversal\\nUtilities for NAT) and TURN standards are used\
+        \ as techniques to establish media\\nconnection between peers for VoIP (for\
+        \ example using SIP or Jingle) and WebRTC.\",\n      \"koschei_monitor\":\
+        \ false,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_stun\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1301316\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"STUN and TURN library\
+        \ for Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/stun/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1453389245.0,\n\
+        \      \"description\": \"TLS / SSL native driver for Erlang / Elixir. This\
+        \ is used by ejabberd.\",\n      \"koschei_monitor\": false,\n      \"monitor\"\
+        : true,\n      \"name\": \"erlang-p1_tls\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1299305\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"TLS / SSL native driver for\
+        \ Erlang / Elixir\",\n      \"upstream_url\": \"https://github.com/processone/tls/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1454593209.0,\n\
+        \      \"description\": \"Fast Expat based Erlang XML parsing and manipulation\
+        \ library, with a strong\\nfocus on XML stream parsing from network. It supports\
+        \ full XML structure\\nparsing, suitable for small but complete XML chunks,\
+        \ and XML stream parsing\\nsuitable for large XML document, or infinite network\
+        \ XML stream like XMPP.\\nThis module can parse files much faster than built-in\
+        \ module xmerl. Depending\\non file complexity and size xml_stream:parse_element/1\
+        \ can be 8-18 times faster\\nthan calling xmerl_scan:string/2.\",\n      \"\
+        koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_xml\"\
+        ,\n      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297150\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Fast Expat based\
+        \ Erlang XML parsing and manipulation library\",\n      \"upstream_url\":\
+        \ \"https://github.com/processone/xml/\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1453730519.0,\n      \"description\": \"P1 YAML\
+        \ is an Erlang wrapper for libyaml \\\"C\\\" library.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"erlang-p1_yaml\",\n \
+        \     \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1297094\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"An Erlang wrapper\
+        \ for libyaml \\\"C\\\" library\",\n      \"upstream_url\": \"https://github.com/processone/p1_yaml/\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467902264.0,\n\
+        \      \"description\": \"Argument Parsing for Humans.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-args\",\n    \
+        \  \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1352993\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Argument Parsing\
+        \ for Humans\",\n      \"upstream_url\": \"https://github.com/kennethreitz/args\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1468427737.0,\n\
+        \      \"description\": \"Clint is a module filled with a set of awesome tools\
+        \ for developing commandline\\napplications. It supports colors, but detects\
+        \ if the session is a TTY, so\\ndoesn't render the colors if you're piping\
+        \ stuff around. Automagically.\",\n      \"koschei_monitor\": true,\n    \
+        \  \"monitor\": true,\n      \"name\": \"python-clint\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1355871\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A set of awesome\
+        \ tools for developing commandline applications\",\n      \"upstream_url\"\
+        : \"https://github.com/kennethreitz/clint\"\n    },\n    {\n      \"acls\"\
+        : [],\n      \"creation_date\": 1452266443.0,\n      \"description\": \"A\
+        \ web based tool for monitoring and administrating Celery clusters. It offers\\\
+        nreal-time monitoring using Celery events, remote control of workers and tasks,\\\
+        nbroker monitoring, and an HTTP API.\",\n      \"koschei_monitor\": false,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-flower\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1285941\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A web based tool\
+        \ for monitoring and administrating Celery clusters\",\n      \"upstream_url\"\
+        : \"https://github.com/mher/flower\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1486055679.0,\n      \"description\": \"fmn is a\
+        \ family of systems to manage end-user notifications triggered by\\nfedmsg,\
+        \ the FEDerated MESsage bus. fmn provides a single place for all\\napplications\
+        \ using fedmsg to notify users of events. Notifications can be\\ndelivered\
+        \ by email, IRC, and server-sent events. Users can configure their\\nnotifications\
+        \ for all the applications they use in one place.\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-fmn\",\n     \
+        \ \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1410901\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A system for generic\
+        \ fedmsg-driven notifications for end users\",\n      \"upstream_url\": \"\
+        https://github.com/fedora-infra/fmn\"\n    },\n    {\n      \"acls\": [],\n\
+        \      \"creation_date\": 1485179561.0,\n      \"description\": \"fmn is a\
+        \ family of systems to manage end-user notifications triggered by\\nfedmsg,\
+        \ the FEDerated MESsage bus. The FMN Server-Sent Events server allows\\nusers\
+        \ to view their fedmsg feed in real-time using server-sent events. It relies\\\
+        non a service to populate the RabbitMQ message queues for it. Typically, this\
+        \ is\\ndone with the FMN core services.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-fmn-sse\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1412798\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"A server-sent events\
+        \ server that integrates with FMN\",\n      \"upstream_url\": \"https://github.com/fedora-infra/fmn.sse\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467055928.0,\n\
+        \      \"description\": \"Invocations is a collection of reusable Invoke tasks/task\
+        \ modules, including\\n(but not limited to) Python project management tools\
+        \ such as documentation\\nbuilding and dependency organization. It has no\
+        \ stand-alone components and is\\ndesigned to be imported into your pre-existing\
+        \ Invoke task files.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-invocations\",\n      \"namespace\": \"\
+        rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1349121\",\n\
+        \      \"status\": \"Approved\",\n      \"summary\": \"Invocations is a collection\
+        \ of reusable Invoke tasks/task modules\",\n      \"upstream_url\": \"https://github.com/pyinvoke/invocations\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489158551.0,\n\
+        \      \"description\": \"Allows synapse to use LDAP as a password provider.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-matrix-synapse-ldap3\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1430170\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Allows synapse to use LDAP as a password\
+        \ provider\",\n      \"upstream_url\": \"https://github.com/matrix-org/matrix-synapse-ldap3\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467054202.0,\n\
+        \      \"description\": \"This package provides an API for querying the distutils\
+        \ metadata written in the\\nPKG-INFO file inside a source distribution (an\
+        \ sdist) or a binary distribution\\n(e.g., created by running bdist_egg).\
+        \ It can also query the EGG-INFO directory\\nof an installed distribution,\
+        \ and the *.egg-info stored in a \\\"development\\ncheckout\\\" (e.g, created\
+        \ by running setup.py develop).\",\n      \"koschei_monitor\": true,\n   \
+        \   \"monitor\": true,\n      \"name\": \"python-pkginfo\",\n      \"namespace\"\
+        : \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1349026\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Query metadata from\
+        \ sdists / bdists / installed packages\",\n      \"upstream_url\": \"https://pypi.python.org/pypi/pkginfo\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1489425664.0,\n\
+        \      \"description\": \"This is a Python re-implementation of the libmacaroons\
+        \ C library.\\nMacaroons, like cookies, are a form of bearer credential. Unlike\\\
+        nopaque tokens, macaroons embed caveats that define specific authorization\\\
+        nrequirements for the target service, the service that issued the root macaroon\\\
+        nand which is capable of verifying the integrity of macaroons it receives.\\\
+        n\\nMacaroons allow for delegation and attenuation of authorization. They\
+        \ are\\nsimple and fast to verify, and decouple authorization policy from\
+        \ the\\nenforcement of that policy.\",\n      \"koschei_monitor\": true,\n\
+        \      \"monitor\": true,\n      \"name\": \"python-pymacaroons-pynacl\",\n\
+        \      \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1430107\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Library providing\
+        \ non-opaque cookies for authorization\",\n      \"upstream_url\": \"https://github.com/matrix-org/pymacaroons\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1467389346.0,\n\
+        \      \"description\": \"Releases is a Sphinx extension designed to help\
+        \ you keep a source control\\nfriendly, merge friendly changelog file & turn\
+        \ it into useful, human readable\\nHTML output.\\n\\nSpecifically:\\n\\n*\
+        \ The source format (kept in your Sphinx tree as changelog.rst) is a stream-like\\\
+        ntimeline that plays well with source control & only requires one entry per\\\
+        nchange (even for changes that exist in multiple release lines).\\n* The output\
+        \ (when you have the extension installed and run your Sphinx build\\ncommand)\
+        \ is a traditional looking changelog page with a section for every\\nrelease;\
+        \ multi-release issues are copied automatically into each release.\\n* By\
+        \ default, feature and support issues are only displayed under feature\\nreleases,\
+        \ and bugs are only displayed under bugfix releases. This can be\\noverridden\
+        \ on a per-issue basis.\",\n      \"koschei_monitor\": true,\n      \"monitor\"\
+        : true,\n      \"name\": \"python-releases\",\n      \"namespace\": \"rpms\"\
+        ,\n      \"review_url\": \"https://bugzilla.redhat.com/1350943\",\n      \"\
+        status\": \"Approved\",\n      \"summary\": \"A Sphinx extension for changelog\
+        \ manipulation\",\n      \"upstream_url\": \"https://github.com/bitprophet/releases\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1450359898.0,\n\
+        \      \"description\": \"sphinxcontrib-fulltoc is an extension for the Sphinx\
+        \ documentation system that\\nchanges the HTML output to include a more detailed\
+        \ table of contents in the\\nsidebar. By default Sphinx only shows the local\
+        \ headers for the current page.\\nWith the extension installed, all of the\
+        \ page titles are included, and the\\nlocal headers for the current page are\
+        \ also included in the appropriate place\\nwithin the document.\",\n     \
+        \ \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"\
+        python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\",\n      \"\
+        review_url\": \"https://bugzilla.redhat.com/1291007\",\n      \"status\":\
+        \ \"Approved\",\n      \"summary\": \"Include a full table of contents in\
+        \ your Sphinx HTML sidebar\",\n      \"upstream_url\": \"https://github.com/dreamhost/sphinxcontrib-fulltoc\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1484077565.0,\n\
+        \      \"description\": \"Turn SQLAlchemy DB Model into a graph.\",\n    \
+        \  \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\": \"\
+        python-sqlalchemy_schemadisplay\",\n      \"namespace\": \"rpms\",\n     \
+        \ \"review_url\": \"https://bugzilla.redhat.com/1409929\",\n      \"status\"\
+        : \"Approved\",\n      \"summary\": \"Turn SQLAlchemy DB Model into a graph\"\
+        ,\n      \"upstream_url\": \"https://github.com/fschulze/sqlalchemy_schemadisplay\"\
+        \n    },\n    {\n      \"acls\": [],\n      \"creation_date\": 1469020897.0,\n\
+        \      \"description\": \"Twine is a utility for interacting with PyPI.\\\
+        nCurrently it only supports registering projects and uploading distributions.\"\
+        ,\n      \"koschei_monitor\": true,\n      \"monitor\": true,\n      \"name\"\
+        : \"python-twine\",\n      \"namespace\": \"rpms\",\n      \"review_url\"\
+        : \"https://bugzilla.redhat.com/1352972\",\n      \"status\": \"Approved\"\
+        ,\n      \"summary\": \"Collection of utilities for interacting with PyPI\"\
+        ,\n      \"upstream_url\": \"https://github.com/pypa/twine\"\n    }\n  ],\n\
+        \  \"watch\": [\n    {\n      \"acls\": [],\n      \"creation_date\": 1468428962.0,\n\
+        \      \"description\": \"A parser for TOML-0.4.0\",\n      \"koschei_monitor\"\
+        : true,\n      \"monitor\": true,\n      \"name\": \"python-pytoml\",\n  \
+        \    \"namespace\": \"rpms\",\n      \"review_url\": \"https://bugzilla.redhat.com/1353606\"\
+        ,\n      \"status\": \"Approved\",\n      \"summary\": \"Parser for TOML\"\
+        ,\n      \"upstream_url\": \"https://github.com/avakar/pytoml\"\n    }\n \
+        \ ]\n}"}
+    headers:
+      accept-ranges: [bytes]
+      age: ['0']
+      appserver: [proxy10.phx2.fedoraproject.org]
+      apptime: [D=166303]
+      connection: [Keep-Alive]
+      content-length: ['33867']
+      content-type: [application/json]
+      date: ['Wed, 29 Mar 2017 16:07:00 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['pkgdb=eyJfcGVybWFuZW50Ijp0cnVlfQ.C71tJA.P5jo_lJQJpIJupzYGj4R1ePI_yU;
+          Expires=Wed, 29-Mar-2017 17:07:00 GMT; Secure; HttpOnly; Path=/pkgdb/']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['10985617']
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/rules/test_generic.py
+++ b/fmn/tests/rules/test_generic.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of FMN.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335,  USA
+"""Tests for the :mod:`fmn.rules.generic` module."""
+from __future__ import unicode_literals
+
+from fedmsg.meta import make_processors
+import unittest
+
+from fmn.rules import generic
+from fmn.tests import Base
+
+
+class UserPackageFilterTests(Base):
+
+    def setUp(self):
+        super(UserPackageFilterTests, self).setUp()
+        self.config['fmn.rules.cache'] = {'backend': 'dogpile.cache.memory'}
+        self.config['topic_prefix_re'] = r'org.fedoraproject.prod.*'
+        make_processors(**self.config)
+        self.rpm_msg = {
+            "source_name": "datanommer",
+            "i": 1,
+            "timestamp": 1490794708.0,
+            "msg_id": "2017-9dc3a3f6-4130-401b-865a-5c1240be84cd",
+            "topic": "org.fedoraproject.prod.pkgdb.package.branch.new",
+            "source_version": "0.6.5",
+            "msg": {
+                "package_listing": {
+                    "status": "Approved",
+                    "point_of_contact": "besser82",
+                    "package": {
+                        "status": "Approved",
+                        "upstream_url": "https://github.com/moses-palmer/pystray",
+                        "koschei_monitor": True,
+                        "monitor": True,
+                        "summary": "Provides system tray integration",
+                        "namespace": "rpms",
+                        "name": "python-pystray",
+                        "acls": [],
+                        "creation_date": 1490794685.0,
+                        "review_url": "https://bugzilla.redhat.com/1436347",
+                        "description": "This library allows you to create a system tray icon."
+                    },
+                    "collection": {
+                        "status": "Active",
+                        "dist_tag": ".fc25",
+                        "koji_name": "f25",
+                        "name": "Fedora",
+                        "allow_retire": False,
+                        "date_updated": "2016-11-22 14:31:43",
+                        "version": "25",
+                        "date_created": "2016-07-26 13:50:32",
+                        "branchname": "f25"
+                    },
+                    "critpath": False,
+                    "status_change": 1490794704.0
+                },
+                "agent": "limb",
+                "package": {
+                    "status": "Approved",
+                    "upstream_url": "https://github.com/moses-palmer/pystray",
+                    "koschei_monitor": True,
+                    "monitor": True,
+                    "summary": "Provides system tray integration",
+                    "namespace": "rpms",
+                    "name": "python-pystray",
+                    "acls": [],
+                    "creation_date": 1490794685.0,
+                    "review_url": "https://bugzilla.redhat.com/1436347",
+                    "description": "This library allows you to create a system tray icon."
+                }
+            }
+        }
+
+        self.module_msg = {
+            "source_name": "datanommer",
+            "certificate": "snip",
+            "i": 10,
+            "timestamp": 1490707946.0,
+            "msg_id": "2017-5893b671-d7fd-4334-b600-f5d89e200270",
+            "topic": "org.fedoraproject.prod.pkgdb.package.branch.new",
+            "source_version": "0.6.5",
+            "signature": "snip",
+            "msg": {
+                "package_listing": {
+                    "status": "Approved",
+                    "point_of_contact": "ralph",
+                    "package": {
+                        "status": "Approved",
+                        "upstream_url": "",
+                        "koschei_monitor": True,
+                        "monitor": False,
+                        "summary": "PHP scripting language for creating dynamic web sites",
+                        "namespace": "modules",
+                        "name": "php",
+                        "acls": [],
+                        "creation_date": 1490707940.0,
+                        "review_url": "https://bugzilla.redhat.com/1419506",
+                        "description": "snip",
+                    },
+                    "collection": {
+                        "status": "Under Development",
+                        "dist_tag": ".fc26",
+                        "koji_name": "f26",
+                        "name": "Fedora",
+                        "allow_retire": True,
+                        "date_updated": "2017-02-28 20:24:43",
+                        "version": "26",
+                        "date_created": "2017-02-28 20:24:57",
+                        "branchname": "f26"
+                    },
+                    "critpath": False,
+                    "status_change": 1490707945.0
+                },
+                "agent": "ralph",
+                "package": {
+                    "status": "Approved",
+                    "upstream_url": "",
+                    "koschei_monitor": True,
+                    "monitor": False,
+                    "summary": "PHP scripting language for creating dynamic web sites",
+                    "namespace": "modules",
+                    "name": "php",
+                    "acls": [],
+                    "creation_date": 1490707940.0,
+                    "review_url": "https://bugzilla.redhat.com/1419506",
+                    "description": "snip",
+                }
+            }
+        }
+
+    def test_no_fasnick(self):
+        """Assert if no fasnick is specified, False is returned."""
+        self.assertFalse(generic.user_package_filter(self.config, self.rpm_msg))
+
+    def test_empty_message(self):
+        """Assert that an empty message results in False."""
+        self.assertFalse(generic.user_package_filter(self.config, {}))
+
+    def test_no_matching_packages(self):
+        """Assert that a message with no matching packages results in False."""
+        self.assertFalse(generic.user_package_filter(self.config, self.rpm_msg, fasnick='jcline'))
+
+    def test_matching_packages(self):
+        """Assert that a message with matching packages results in True."""
+        self.assertTrue(generic.user_package_filter(self.config, self.rpm_msg, fasnick='besser82'))
+
+    def test_different_namespaces(self):
+        """Assert packages with the same name in a different namespace results in False."""
+        # remi owns the php RPM, but no the module.
+        self.assertFalse(generic.user_package_filter(self.config, self.module_msg, fasnick='remi'))
+
+    def test_namespaces(self):
+        """Assert that a message with a namespaced package works correctly."""
+        # ralph owns the php module
+        self.assertTrue(generic.user_package_filter(self.config, self.module_msg, fasnick='ralph'))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/fmn/tests/rules/test_generic.py
+++ b/fmn/tests/rules/test_generic.py
@@ -19,8 +19,9 @@
 """Tests for the :mod:`fmn.rules.generic` module."""
 from __future__ import unicode_literals
 
-from fedmsg.meta import make_processors
 import unittest
+
+from fedmsg.meta import make_processors
 
 from fmn.rules import generic
 from fmn.tests import Base
@@ -163,7 +164,7 @@ class UserPackageFilterTests(Base):
 
     def test_different_namespaces(self):
         """Assert packages with the same name in a different namespace results in False."""
-        # remi owns the php RPM, but no the module.
+        # remi owns the php RPM, but not the module.
         self.assertFalse(generic.user_package_filter(self.config, self.module_msg, fasnick='remi'))
 
     def test_namespaces(self):

--- a/fmn/tests/rules/test_utils.py
+++ b/fmn/tests/rules/test_utils.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of FMN.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Suite 500, Boston, MA 02110-1335,  USA
+"""Tests for the :mod:`fmn.rules.utils` module."""
+from __future__ import unicode_literals
+
+import unittest
+
+from fmn.rules import utils
+from fmn.tests import Base
+
+
+class GetPkgdb2PackagesForTests(Base):
+
+    def setUp(self):
+        super(GetPkgdb2PackagesForTests, self).setUp()
+        self.config['fmn.rules.utils.pkgdb_url'] = 'https://admin.fedoraproject.org/pkgdb/api'
+        self.expected_point_of_contact = {
+            'rpms': set([
+                'erlang-cache_tab',
+                'erlang-p1_sip',
+                'erlang-p1_stringprep',
+                'erlang-p1_stun',
+                'erlang-p1_tls',
+                'erlang-p1_xml',
+                'erlang-p1_yaml',
+                'python-args',
+                'python-clint',
+                'python-flower',
+                'python-fmn',
+                'python-fmn-sse',
+                'python-invocations',
+                'python-matrix-synapse-ldap3',
+                'python-pkginfo',
+                'python-pymacaroons-pynacl',
+                'python-releases',
+                'python-sphinxcontrib-fulltoc',
+                'python-sqlalchemy_schemadisplay',
+                'python-twine',
+            ])
+        }
+        self.expected_comaintained = {
+            'rpms': set([
+                'bodhi',
+                'ejabberd',
+                'erlang-esip',
+                'erlang-ezlib',
+                'erlang-fast_tls',
+                'erlang-fast_xml',
+                'erlang-fast_yaml',
+                'erlang-goldrush',
+                'erlang-iconv',
+                'erlang-luerl',
+                'erlang-oauth2',
+                'erlang-p1_iconv',
+                'erlang-p1_mysql',
+                'erlang-p1_oauth2',
+                'erlang-p1_pam',
+                'erlang-p1_pgsql',
+                'erlang-p1_utils',
+                'erlang-p1_xmlrpc',
+                'erlang-p1_zlib',
+                'erlang-proper',
+                'erlang-stringprep',
+                'erlang-stun',
+                'erlang-xmpp',
+                'fegistry',
+                'python-crane',
+                'python-idna',
+                'python-ipdb',
+                'python-isodate',
+                'python-kaptan',
+                'python-pymongo',
+                'python-requests',
+                'python-rpdb',
+                'python-urllib3',
+            ])
+        }
+        self.expected_watch = {'rpms': set(['python-pytoml'])}
+        self.expected_all = {
+            'rpms': self.expected_watch['rpms'].union(self.expected_comaintained['rpms'].union(
+                self.expected_point_of_contact['rpms'])),
+        }
+
+    def test_bad_response(self):
+        """Assert a bad response results in an empty result."""
+        packages = utils._get_pkgdb2_packages_for(self.config, 'thisisnotausername123', [])
+        self.assertEqual(dict(), packages)
+
+    def test_watch(self):
+        """Assert watch results from pkgdb2 works."""
+        packages = utils._get_pkgdb2_packages_for(self.config, 'jcline', ['watch'])
+        self.assertEqual(self.expected_watch, packages)
+
+    def test_comaintained(self):
+        """Assert co-maintained results from pkgdb2 works."""
+        packages = utils._get_pkgdb2_packages_for(self.config, 'jcline', ['co-maintained'])
+        self.assertEqual(self.expected_comaintained, packages)
+
+    def test_point_of_contact(self):
+        """Assert point of contact results from pkgdb2 works."""
+        packages = utils._get_pkgdb2_packages_for(self.config, 'jcline', ['point of contact'])
+        self.assertEqual(self.expected_point_of_contact, packages)
+
+    def test_all(self):
+        packages = utils._get_pkgdb2_packages_for(
+            self.config, 'jcline', ['point of contact', 'watch', 'co-maintained'])
+        self.assertEqual(self.expected_all, packages)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ bleach
 docutils
 dogpile.cache
 fedmsg[consumers, commands]
-fedmsg_meta_fedora_infrastructure
+fedmsg_meta_fedora_infrastructure>=0.18.0
 markupsafe
 moksha.hub
 pika


### PR DESCRIPTION
This depends on a change in the Fedora Processor changing to accept a
new kwarg, ``namespace``, that accounts for the namespace a package is
in when performing ``msg2packages``.

fixes #176

Note: The tests currently don't pass (since there needs to be a fix in https://github.com/fedora-infra/fedmsg_meta_fedora_infrastructure) and this shouldn't be merged yet. 