### PR TITLE
Adjust the test runners to handle the trial tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+include =
+    fmn/*
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:
+omit =
+    fmn/tests/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ build
 _trial_temp/*
 sse.log
 fedmsg.d/fas_credentials.py
+htmlcov/
+.cache/
+.coverage
+.tox/
+coverage.xml
 
 # Images are generated as part of the docs build process
 docs/images/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 sudo: required
 language: python
-python:
- - "2.7"
- - "3.3"
- - "3.4"
- - "3.5"
 
 before_install:
   - sudo apt-get -qq update
@@ -12,13 +7,29 @@ before_install:
 
 install:
  - pip install --upgrade setuptools pip
- - pip install -r dev-requirements.txt
- - pip install -r requirements.txt
- - pip install -e .
-script: python -m unittest discover
+ - pip install tox
 
+script:
+  - tox
+
+after_success:
+  - source .tox/${TOXENV}/bin/activate && pip install codecov && codecov --env TRAVIS_OS_NAME,TOXENV
+
+env:
+  global:
+    - PYTHONWARNINGS=always::DeprecationWarning
+  matrix:
+    - TOXENV=lint
+    - TOXENV=py27
 matrix:
+  include:
+    - python: "3.4"
+      env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
   allow_failures:
-    - python: "3.3"
     - python: "3.4"
     - python: "3.5"
+    - python: "3.6"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,8 @@
 flake8
 html5lib
 mock
-nose
+pytest
+pytest-cov
 vcrpy
 # Docs requirements
 sphinx

--- a/fmn/__init__.py
+++ b/fmn/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/fmn/tests/lib/test_lib.py
+++ b/fmn/tests/lib/test_lib.py
@@ -157,6 +157,30 @@ class TestRecipients(BaseTestCase):
     def test_basic_recipients_list(self):
         self.create_user_and_context_data()
         self.create_preference_data_empty()
+        expected_recipients = sorted([
+            {
+                'triggered_by_links': True,
+                'markup_messages': False,
+                'shorten_links': False,
+                'irc nick': 'threebean',
+                'user': 'ralph.id.fedoraproject.org',
+                'filter_name': 'test filter',
+                'filter_id': 1,
+                'filter_oneshot': False,
+                'verbose': True,
+            },
+            {
+                'triggered_by_links': True,
+                'markup_messages': False,
+                'shorten_links': False,
+                'irc nick': 'abadger1999',
+                'user': 'toshio.id.fedoraproject.org',
+                'filter_name': 'test filter 2',
+                'filter_id': 2,
+                'filter_oneshot': False,
+                'verbose': True,
+            },
+        ])
 
         code_path = "fmn.tests.example_rules:wat_rule"
         self.create_preference_data_basic(code_path)
@@ -167,17 +191,7 @@ class TestRecipients(BaseTestCase):
         preferences = load_preferences()
         recipients = get_recipients(
             preferences, msg, self.valid_paths, self.config)
-        self.assertDictEqual(recipients['irc'][0], {
-            'triggered_by_links': True,
-            'markup_messages': False,
-            'shorten_links': False,
-            'irc nick': 'threebean',
-            'user': 'ralph.id.fedoraproject.org',
-            'filter_name': 'test filter',
-            'filter_id': 1,
-            'filter_oneshot': False,
-            'verbose': True,
-        })
+        self.assertEqual(expected_recipients, sorted(recipients['irc']))
 
     def test_miss_recipients_list(self):
         self.create_user_and_context_data()
@@ -236,18 +250,31 @@ class TestRecipients(BaseTestCase):
         preferences = load_preferences()
         recipients = get_recipients(
             preferences, msg, self.valid_paths, self.config)
-        expected = {
-            'triggered_by_links': True,
-            'markup_messages': False,
-            'shorten_links': False,
-            'irc nick': 'threebean',
-            'user': 'ralph.id.fedoraproject.org',
-            'filter_name': 'test filter',
-            'filter_id': 1,
-            'filter_oneshot': False,
-            'verbose': True,
-        }
-        self.assertDictEqual(recipients['irc'][0], expected)
+        expected_recipients = sorted([
+            {
+                'triggered_by_links': True,
+                'markup_messages': False,
+                'shorten_links': False,
+                'irc nick': 'threebean',
+                'user': 'ralph.id.fedoraproject.org',
+                'filter_name': 'test filter',
+                'filter_id': 1,
+                'filter_oneshot': False,
+                'verbose': True,
+            },
+            {
+                'triggered_by_links': True,
+                'markup_messages': False,
+                'shorten_links': False,
+                'irc nick': 'abadger1999',
+                'user': 'toshio.id.fedoraproject.org',
+                'filter_name': 'test filter 2',
+                'filter_id': 2,
+                'filter_oneshot': False,
+                'verbose': True,
+            },
+        ])
+        self.assertEqual(expected_recipients, sorted(recipients['irc']))
 
     def test_multiple_different_filters_hit(self):
         self.create_user_and_context_data()
@@ -269,17 +296,31 @@ class TestRecipients(BaseTestCase):
         preferences = load_preferences()
         recipients = get_recipients(
             preferences, msg, self.valid_paths, self.config)
-        self.assertDictEqual(recipients['irc'][0], {
-            'triggered_by_links': True,
-            'markup_messages': False,
-            'shorten_links': False,
-            'irc nick': 'threebean',
-            'user': 'ralph.id.fedoraproject.org',
-            'filter_name': 'test filter',
-            'filter_id': 1,
-            'filter_oneshot': False,
-            'verbose': True,
-        })
+        expected_recipients = sorted([
+            {
+                'triggered_by_links': True,
+                'markup_messages': False,
+                'shorten_links': False,
+                'irc nick': 'threebean',
+                'user': 'ralph.id.fedoraproject.org',
+                'filter_name': 'test filter',
+                'filter_id': 1,
+                'filter_oneshot': False,
+                'verbose': True,
+            },
+            {
+                'triggered_by_links': True,
+                'markup_messages': False,
+                'shorten_links': False,
+                'irc nick': 'abadger1999',
+                'user': 'toshio.id.fedoraproject.org',
+                'filter_name': 'test filter 2',
+                'filter_id': 2,
+                'filter_oneshot': False,
+                'verbose': True,
+            },
+        ])
+        self.assertEqual(expected_recipients, sorted(recipients['irc']))
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
     tests_require=get_requirements('dev-requirements.txt'),
     test_suite='fmn.tests',
     packages=find_packages(exclude=('fmn.tests', 'fmn.tests.*')),
-    namespace_packages=['fmn'],
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,34 @@
 [tox]
-envlist =py27,py34,py35,lint,docs
+envlist = lint,py27,py34,py35,py36,docs
 skip_missing_interpreters = True
 
 [testenv]
+passenv = TRAVIS TRAVIS_*
 deps =
     -rrequirements.txt
     -rdev-requirements.txt
+whitelist_externals =
+    rm
 commands =
-    nosetests -v
+    rm -rf htmlcov coverage.xml
+    py.test --cov-config .coveragerc --cov=fmn --cov-report term \
+        --cov-report xml --cov-report html
 
 [testenv:docs]
+basepython=python2
 changedir = docs
-deps =
-    sphinx
-    sphinxcontrib-httpdomain
-    -rrequirements.txt
 whitelist_externals =
     mkdir
-    sphinx-build
+    rm
 commands=
+    rm -rf _build/
     mkdir -p _static
+    mkdir -p images
+    python2 create_db_schema
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  _build/html
 
 [testenv:lint]
+basepython=python2
 deps =
     flake8 > 3.0
 commands =
@@ -31,4 +37,4 @@ commands =
 [flake8]
 show-source = True
 max-line-length = 100
-exclude = .git,.tox,dist,*egg,docs,alembic,,setup.py
+exclude = .git,.tox,dist,*egg,docs,alembic,ansible,setup.py,fmn/lib/,fmn/rules,fmn/web/,fedmsg.d/fmn.py


### PR DESCRIPTION
Several tests for the FMN SSE server use the Twisted trial test
framework, which the native test runner does not handle. pytest handles
them just fine, though.

Since we're not distributing fmn as separate eggs anymore, we don't need
the namespace package and as it stood it made py.test fail in tox.

This also switched TravisCI to run the tests via Tox rather than
switching it to using py.test so the tests are run uniformly locally and
in CI.