### PR TITLE
Cache the rule-loading code

### DIFF
--- a/fmn/lib/__init__.py
+++ b/fmn/lib/__init__.py
@@ -6,6 +6,8 @@ import logging
 import re
 import smtplib
 
+from dogpile.cache import make_region
+from dogpile.cache.util import kwarg_function_key_generator
 import bs4
 import docutils.examples
 import fedmsg
@@ -154,6 +156,12 @@ def update_preferences(openid, existing_preferences):
     return existing_preferences
 
 
+#: A dictionary-backed cache that maps Python paths to a set of rules.
+_rule_cache = make_region(function_key_generator=kwarg_function_key_generator)
+_rule_cache.configure('dogpile.cache.memory')
+
+
+@_rule_cache.cache_on_arguments()
 def load_rules(root='fmn.rules'):
     """ Load the big list of allowed callable rules. """
 


### PR DESCRIPTION
``fmn.lib.load_rules`` is called all over the place without arguments,
and each time it takes about 2.5 seconds to load (on a fast disk) before
it's calling ``__import__`` on tons of files.

This is a short-term fix that simply caches the results in a dictionary.
This makes creating 100 users drop from 221 seconds to 3.3 seconds.

fixes #191

Signed-off-by: Jeremy Cline <jeremy@jcline.org>