### PR TITLE
Pagure ownership queries.

### DIFF
--- a/fedmsg.d/fmn.py
+++ b/fedmsg.d/fmn.py
@@ -24,6 +24,8 @@ config = {
     "datanommer.sqlalchemy.url": "postgresql+psycopg2://datanommer:bunbunbun@localhost:5432/datanommer",
 
     # Some configuration for the rule processors
+    "fmn.rules.utils.use_pagure_for_ownership": False,
+    "fmn.rules.utils.pagure_api_url": "https://src.stg.fedoraproject.org/pagure/api/",
     "fmn.rules.utils.use_pkgdb2": False,
     "fmn.rules.utils.pkgdb2_api_url": "http://209.132.184.188/api/",
     "fmn.rules.cache": {

--- a/fmn/rules/utils.py
+++ b/fmn/rules/utils.py
@@ -4,11 +4,7 @@ from collections import defaultdict
 import logging
 import time
 
-try:
-    from urllib.parse import urlencode  # python3
-except ImportError:
-    from urllib import urlencode  # python2
-
+from six.moves.urllib.parse import urlencode
 import requests
 import requests.exceptions
 
@@ -72,30 +68,38 @@ def get_fas(config):
     return _FAS
 
 
-def _paginate_pagure_data(url, params, key):
+def _paginate_pagure_data(url, params):
+    """
+    Paginate over a Pagure URL.
+
+    Args:
+        url (str): The URL to paginate over, without any parameters.
+        params (dict): A dictionary of URL parameters to use when querying Pagure.
+
+    Yields:
+        dict: The deserialized JSON response for a given page.
+    """
+
     # Set up the first page query
     params['page'] = 1
-    # Also, set the short param to make the queries lighter
-    params['short'] = 'true'
     next_page_url = url + "?" + urlencode(params)
 
-    while next_page_url is not None:
+    while next_page_url:
         try:
             response = requests.get(next_page_url, timeout=25)
-        except requests.exceptions.ConnectTimeout as e:
-            log.warn('URL %s timed out %r', response.url, e)
-            raise StopIteration
+            if response.status_code == 200:
+                data = response.json()
+                # When we run out of pages, this will be None
+                next_page_url = data['pagination']['next']
+                yield data
+            else:
+                log.error('Querying Pagure at %s returned code %s',
+                          response.url, response.status_code)
+                next_page_url = None
 
-        if not response.status_code == 200:
-            log.warn('URL %s returned code %s', response.url, response.status_code)
-            raise StopIteration
-
-        data = response.json()
-        for entry in data[key]:
-            yield entry
-
-        # When we run out of pages, this will be None
-        next_page_url = data['pagination']['next']
+        except requests.exceptions.Timeout as e:
+            log.warn('URL %s timed out %r', next_page_url, e)
+            next_page_url = None
 
 
 def get_packagers_of_package(config, package):
@@ -141,11 +145,10 @@ def _get_pagure_packagers_for(config, package):
     Returns:
         set:  A `set` of packager usernames.
     """
-    log.debug("Requesting pagure packagers of package %r" % package)
     base = config.get('fmn.rules.utils.pagure_api_url',
                       'https://src.fedoraproject.org/pagure/api')
 
-    # XXX. give a default namespace if one is not provided
+    # Give a default namespace if one is not provided. See
     # https://github.com/fedora-infra/fmn/issues/208
     if '/' not in package:
         package = 'rpms/' + package
@@ -154,8 +157,8 @@ def _get_pagure_packagers_for(config, package):
     log.info("Querying Pagure at %s for packager information", url)
     try:
         response = requests.get(url, timeout=25)
-    except requests.exceptions.ConnectTimeout as e:
-        log.warn('URL %s timed out %r', response.url, e)
+    except requests.exceptions.Timeout as e:
+        log.warn('URL %s timed out %r', url, e)
         return set()
 
     if response.status_code != 200:
@@ -192,8 +195,8 @@ def _get_pkgdb2_packagers_for(config, package):
     log.info("Querying PkgDB at %s for packager information", url)
     try:
         req = requests.get(url, timeout=15)
-    except requests.exceptions.ConnectTimeout as e:
-        log.warn('URL %s timed out %r', req.url, e)
+    except requests.exceptions.Timeout as e:
+        log.warn('URL %s timed out %r', url, e)
         return set()
 
     if not req.status_code == 200:
@@ -311,8 +314,8 @@ def _get_pkgdb2_packages_for(config, username, flags):
 
     try:
         req = requests.get(url, timeout=15)
-    except requests.exceptions.ConnectTimeout as e:
-        log.warn('URL %s timed out %r', req.url, e)
+    except requests.exceptions.Timeout as e:
+        log.warn('URL %s timed out %r', url, e)
         return set()
 
     if not req.status_code == 200:
@@ -339,42 +342,42 @@ def _get_pagure_packages_for(config, username, flags):
         username (str): The FAS username to fetch the packages for.
         flags (list): The type of relationship the user should have to the
             package (e.g. "watch", "point of contact", etc.).
+
     Returns:
-        dict:  A `dict` mapping namespaces to sets of package names.
+        dict:  A dictionary mapping namespaces to sets of package names.
+
+    Raises:
+        ValueError: If invalid flags are provided, or no flags are provided.
     """
     log.debug("Requesting pagure packages for user %r" % username)
 
+    # In the future we want to also support the 'watch' state.
     # See https://github.com/fedora-infra/fmn/issues/209
     # which depends on https://pagure.io/pagure/issue/2421
-    valid_flags = ['point of contact', 'co-maintained']#, 'watch']
+    valid_flags = ['point of contact', 'co-maintained']
 
     bogus = set(flags) - set(valid_flags)
     if bogus:
-        log.error("%r are not valid owner flags for %r." % (bogus, username))
-        # ... but, proceed.
-
-    valid = set(flags) & set(valid_flags)
-    if not valid:
-        log.error("No valid owner flags by which to query.")
-        return dict()
+        raise ValueError(
+            "{flags} are not valid owner flags for {user}.".format(flags=bogus, user=username))
+    if len(flags) == 0:
+        raise ValueError("No valid owner flags by which to query.")
 
     base = config.get('fmn.rules.utils.pagure_api_url',
                       'https://src.fedoraproject.org/pagure/api')
     url = base + '/0/projects'
 
     packages = defaultdict(set)
-    for flag in valid:
+    for flag in flags:
         if flag == 'point of contact':
-            params = dict(owner=username)
-        elif flag == 'co-maintained':
-            params = dict(username=username)
-        else:
-            # Belt and suspenders.  We should never get here.
-            raise NotImplementedError("%r is not a valid flag" % flag)
+            params = dict(owner=username, short=True)
+        else:  # 'co-maintained'
+            params = dict(username=username, short=True)
 
-        repos = _paginate_pagure_data(url, params, key='projects')
-        for repo in repos:
-            packages[repo['namespace']].add(repo['name'])
+        pages = _paginate_pagure_data(url, params)
+        for page in pages:
+            for repo in page['projects']:
+                packages[repo['namespace']].add(repo['name'])
 
     return dict(packages)
 

--- a/fmn/rules/utils.py
+++ b/fmn/rules/utils.py
@@ -4,6 +4,11 @@ from collections import defaultdict
 import logging
 import time
 
+try:
+    from urllib.parse import urlencode  # python3
+except ImportError:
+    from urllib import urlencode  # python2
+
 import requests
 import requests.exceptions
 
@@ -67,6 +72,32 @@ def get_fas(config):
     return _FAS
 
 
+def _paginate_pagure_data(url, params, key):
+    # Set up the first page query
+    params['page'] = 1
+    # Also, set the short param to make the queries lighter
+    params['short'] = 'true'
+    next_page_url = url + "?" + urlencode(params)
+
+    while next_page_url is not None:
+        try:
+            response = requests.get(next_page_url, timeout=25)
+        except requests.exceptions.ConnectTimeout as e:
+            log.warn('URL %s timed out %r', response.url, e)
+            raise StopIteration
+
+        if not response.status_code == 200:
+            log.warn('URL %s returned code %s', response.url, response.status_code)
+            raise StopIteration
+
+        data = response.json()
+        for entry in data[key]:
+            yield entry
+
+        # When we run out of pages, this will be None
+        next_page_url = data['pagination']['next']
+
+
 def get_packagers_of_package(config, package):
     """ Retrieve the list of users who have commit on a package.
 
@@ -79,18 +110,91 @@ def get_packagers_of_package(config, package):
         _cache.configure(**config['fmn.rules.cache'].copy())
 
     key = cache_key_generator(get_packagers_of_package, package)
-    creator = lambda: _get_pkgdb2_packagers_for(config, package)
+    creator = lambda: _get_packagers_for(config, package)
     return _cache.get_or_create(key, creator)
 
 
+def _get_packagers_for(config, package):
+    """ Get the packagers (users) associated with a given package.
+
+    The list is gathered from either pkgdb2 (old) or pagure (new) depending on
+    the configuration value of ``fmn.rules.utils.use_pagure_for_ownership``.
+
+    Args:
+        config (dict): The application configuration.
+        package (str): The package name.
+    Returns:
+        set:  A `set` of packager usernames.
+    """
+    if config['fmn.rules.utils.use_pagure_for_ownership']:
+        return _get_pagure_packagers_for(config, package)
+    else:
+        return _get_pkgdb2_packagers_for(config, package)
+
+
+def _get_pagure_packagers_for(config, package):
+    """ Get the packagers (users) associated with a given package in pagure.
+
+    Args:
+        config (dict): The application configuration.
+        package (str): The package name.
+    Returns:
+        set:  A `set` of packager usernames.
+    """
+    log.debug("Requesting pagure packagers of package %r" % package)
+    base = config.get('fmn.rules.utils.pagure_api_url',
+                      'https://src.fedoraproject.org/pagure/api')
+
+    # XXX. give a default namespace if one is not provided
+    # https://github.com/fedora-infra/fmn/issues/208
+    if '/' not in package:
+        package = 'rpms/' + package
+
+    url = '{0}/0/{1}'.format(base, package)
+    log.info("Querying Pagure at %s for packager information", url)
+    try:
+        response = requests.get(url, timeout=25)
+    except requests.exceptions.ConnectTimeout as e:
+        log.warn('URL %s timed out %r', response.url, e)
+        return set()
+
+    if response.status_code != 200:
+        log.warn('URL %s returned code %s', response.url, response.status_code)
+        return set()
+
+    data = response.json()
+
+    packagers = set(sum(data['access_users'].values(), []))
+    groups = set(sum(data['access_groups'].values(), []))
+
+    if groups:
+        fas = get_fas(config)
+    for group in groups:
+        packagers.update(get_user_of_group(config, fas, group))
+
+    return packagers
+
+
 def _get_pkgdb2_packagers_for(config, package):
+    """ Get the packagers (users) associated with a given package in pkgdb.
+
+    Args:
+        config (dict): The application configuration.
+        package (str): The package name.
+    Returns:
+        set:  A `set` of packager usernames.
+    """
     log.debug("Requesting pkgdb2 packagers of package %r" % package)
 
-    default = 'https://admin.fedoraproject.org/pkgdb/api'
-    base = config.get('fmn.rules.utils.pkgdb_url', default)
+    base = config.get('fmn.rules.utils.pkgdb_url',
+                      'https://admin.fedoraproject.org/pkgdb/api')
     url = '{0}/package/{1}'.format(base, package)
-    log.info("hitting url: %r" % url)
-    req = requests.get(url)
+    log.info("Querying PkgDB at %s for packager information", url)
+    try:
+        req = requests.get(url, timeout=15)
+    except requests.exceptions.ConnectTimeout as e:
+        log.warn('URL %s timed out %r', req.url, e)
+        return set()
 
     if not req.status_code == 200:
         log.debug('URL %s returned code %s', req.url, req.status_code)
@@ -142,7 +246,7 @@ def get_packages_of_user(config, username, flags):
 
     for owner in owners:
         key = cache_key_generator(get_packages_of_user, owner)
-        creator = lambda: _get_pkgdb2_packages_for(config, owner, flags)
+        creator = lambda: _get_packages_for(config, owner, flags)
         subset = _cache.get_or_create(key, creator)
         for namespace in subset:
             packages[namespace].update(subset[namespace])
@@ -162,6 +266,27 @@ def invalidate_cache_for(config, fn, arg):
     return _cache.delete(key)
 
 
+def _get_packages_for(config, username, flags):
+    """ Get the packages with which a user is associated.
+
+    The list is gathered from either pkgdb2 (old) or pagure (new) depending on
+    the configuration value of ``fmn.rules.utils.use_pagure_for_ownership``.
+
+    Args:
+        config (dict): The application configuration.
+        username (str): The FAS username to fetch the packages for.
+        flags (list): The type of relationship the user should have to the
+            package (e.g. "watch", "point of contact", or "co-maintained").
+    Returns:
+        dict:  A `dict` mapping namespaces to sets of package names.
+    """
+
+    if config['fmn.rules.utils.use_pagure_for_ownership']:
+        return _get_pagure_packages_for(config, username, flags)
+    else:
+        return _get_pkgdb2_packages_for(config, username, flags)
+
+
 def _get_pkgdb2_packages_for(config, username, flags):
     """
     Get the packages a user is associated with from pkgdb2.
@@ -172,16 +297,23 @@ def _get_pkgdb2_packages_for(config, username, flags):
         flags (list): The type of relationship the user should have to the
             package (e.g. "watch", "point of contact", etc.). See the pkgdb2
             API for details.
+    Returns:
+        dict:  A `dict` mapping namespaces to sets of package names.
     """
     log.debug("Requesting pkgdb2 packages for user %r" % username)
     start = time.time()
 
-    default = 'https://admin.fedoraproject.org/pkgdb/api'
-    base = config.get('fmn.rules.utils.pkgdb_url', default)
+    base = config.get('fmn.rules.utils.pkgdb_url',
+                      'https://admin.fedoraproject.org/pkgdb/api')
 
     url = '{0}/packager/package/{1}'.format(base, username)
-    log.info("hitting url: %r" % url)
-    req = requests.get(url)
+    log.info("Querying pkgdb at %s for packager information", url)
+
+    try:
+        req = requests.get(url, timeout=15)
+    except requests.exceptions.ConnectTimeout as e:
+        log.warn('URL %s timed out %r', req.url, e)
+        return set()
 
     if not req.status_code == 200:
         log.debug('URL %s returned code %s', req.url, req.status_code)
@@ -195,6 +327,55 @@ def _get_pkgdb2_packages_for(config, username, flags):
     for package in packages_of_interest:
         packages[package.get('namespace', 'rpms')].add(package['name'])
     log.debug("done talking with pkgdb2 for now.  %0.2fs", time.time() - start)
+    return dict(packages)
+
+
+def _get_pagure_packages_for(config, username, flags):
+    """
+    Get the packages a user is associated with from pagure.
+
+    Args:
+        config (dict): The application configuration.
+        username (str): The FAS username to fetch the packages for.
+        flags (list): The type of relationship the user should have to the
+            package (e.g. "watch", "point of contact", etc.).
+    Returns:
+        dict:  A `dict` mapping namespaces to sets of package names.
+    """
+    log.debug("Requesting pagure packages for user %r" % username)
+
+    # See https://github.com/fedora-infra/fmn/issues/209
+    # which depends on https://pagure.io/pagure/issue/2421
+    valid_flags = ['point of contact', 'co-maintained']#, 'watch']
+
+    bogus = set(flags) - set(valid_flags)
+    if bogus:
+        log.error("%r are not valid owner flags for %r." % (bogus, username))
+        # ... but, proceed.
+
+    valid = set(flags) & set(valid_flags)
+    if not valid:
+        log.error("No valid owner flags by which to query.")
+        return dict()
+
+    base = config.get('fmn.rules.utils.pagure_api_url',
+                      'https://src.fedoraproject.org/pagure/api')
+    url = base + '/0/projects'
+
+    packages = defaultdict(set)
+    for flag in valid:
+        if flag == 'point of contact':
+            params = dict(owner=username)
+        elif flag == 'co-maintained':
+            params = dict(username=username)
+        else:
+            # Belt and suspenders.  We should never get here.
+            raise NotImplementedError("%r is not a valid flag" % flag)
+
+        repos = _paginate_pagure_data(url, params, key='projects')
+        for repo in repos:
+            packages[repo['namespace']].add(repo['name'])
+
     return dict(packages)
 
 

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagersForTests.test_error_response
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagersForTests.test_error_response
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.2]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/notanamespace/orapackage
+  response:
+    body: {string: !!python/unicode "{\n  \"error\": \"Project not found\",\n  \"\
+        error_code\": \"ENOPROJECT\"\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=167972]
+      connection: [Keep-Alive]
+      content-length: ['64']
+      content-type: [application/json]
+      date: ['Mon, 31 Jul 2017 13:23:29 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DGDA0Q._gBNEn6lO5vCQRtrWQYKvIgTrHY;
+          Expires=Thu, 31-Aug-2017 13:23:29 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 404, message: NOT FOUND}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagersForTests.test_groups
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagersForTests.test_groups
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.2]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/rpms/python-urllib3
+  response:
+    body: {string: !!python/unicode "{\n  \"access_groups\": {\n    \"admin\": [],\n\
+        \    \"commit\": [\n      \"infra-sig\"\n    ],\n    \"ticket\": []\n  },\n\
+        \  \"access_users\": {\n    \"admin\": [],\n    \"commit\": [\n      \"ralph\"\
+        ,\n      \"abompard\",\n      \"jcline\"\n    ],\n    \"owner\": [\n     \
+        \ \"sagarun\"\n    ],\n    \"ticket\": []\n  },\n  \"close_status\": [],\n\
+        \  \"custom_keys\": [],\n  \"date_created\": \"1501277141\",\n  \"date_modified\"\
+        : \"1501277142\",\n  \"description\": \"The python-urllib3 rpms\",\n  \"fullname\"\
+        : \"rpms/python-urllib3\",\n  \"id\": 18233,\n  \"milestones\": {},\n  \"\
+        name\": \"python-urllib3\",\n  \"namespace\": \"rpms\",\n  \"parent\": null,\n\
+        \  \"priorities\": {},\n  \"tags\": [],\n  \"user\": {\n    \"fullname\":\
+        \ \"sagarun\",\n    \"name\": \"sagarun\"\n  }\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=3191414]
+      connection: [Keep-Alive]
+      content-length: ['664']
+      content-type: [application/json]
+      date: ['Mon, 31 Jul 2017 13:48:51 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DGDGxg.Y0o6FLtBjF2dSJ3ovCcsHxaJa1s;
+          Expires=Thu, 31-Aug-2017 13:48:54 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'login=Login&password=supersecret&user_name=jcline'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['98']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-agent: [Fedora Account System Client/0.9.0]
+    method: POST
+    uri: https://admin.fedoraproject.org/accounts/group/dump/infra-sig
+  response:
+    body: {string: "{\"people\": [[\"abompard\", \"aurelien@bompard.org\", \"Aurelien\
+        \ Bompard\", \"user\", 0], [\"bochecha\", \"bochecha@daitauha.fr\", \"Mathieu\
+        \ Bridon\", \"user\", 0], [\"bowlofeggs\", \"randy@electronsweatshop.com\"\
+        , \"Randy Barlow\", \"user\", 0], [\"codeblock\", \"codeblock@elrod.me\",\
+        \ \"Ricky Elrod\", \"sponsor\", 0], [\"jcline\", \"jeremy@jcline.org\", \"\
+        Jeremy Cline\", \"user\", 0], [\"kevin\", \"kevin@scrye.com\", \"Kevin Fenzi\"\
+        , \"sponsor\", 4], [\"lmacken\", \"lewk@openmailbox.org\", \"Luke Macken\"\
+        , \"sponsor\", 0], [\"pingou\", \"pingou@pingoured.fr\", \"Pierre-YvesChibon\"\
+        , \"administrator\", 7], [\"puiterwijk\", \"puiterwijk@redhat.com\", \"Patrick\
+        \ \\\"\u30DE\u30EB\u30BF\u30A4\u30F3\u30A2\u30F3\u30C9\u30EC\u30A2\u30B9\\\
+        \" Uiterwijk\", \"sponsor\", 0], [\"sayanchowdhury\", \"sayan.chowdhury2012@gmail.com\"\
+        , \"Sayan Chowdhury\", \"user\", 0], [\"toshio\", \"a.badger@gmail.com\",\
+        \ \"Toshio \u304F\u3089\u3068\u307F\", \"sponsor\", 0]], \"tg_flash\": null}"}
+    headers:
+      appserver: [proxy14.fedoraproject.org]
+      apptime: [D=355685]
+      connection: [Keep-Alive]
+      content-length: ['835']
+      content-type: [application/json]
+      date: ['Mon, 31 Jul 2017 13:48:54 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.2.15 (Red Hat)]
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagersForTests.test_no_groups
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagersForTests.test_no_groups
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.2]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/rpms/ejabberd
+  response:
+    body: {string: !!python/unicode "{\n  \"access_groups\": {\n    \"admin\": [],\n\
+        \    \"commit\": [],\n    \"ticket\": []\n  },\n  \"access_users\": {\n  \
+        \  \"admin\": [],\n    \"commit\": [\n      \"jcline\",\n      \"xavierb\"\
+        ,\n      \"martinlanghoff\",\n      \"bowlofeggs\"\n    ],\n    \"owner\"\
+        : [\n      \"peter\"\n    ],\n    \"ticket\": []\n  },\n  \"close_status\"\
+        : [],\n  \"custom_keys\": [],\n  \"date_created\": \"1501274592\",\n  \"date_modified\"\
+        : \"1501274592\",\n  \"description\": \"The ejabberd rpms\",\n  \"fullname\"\
+        : \"rpms/ejabberd\",\n  \"id\": 3070,\n  \"milestones\": {},\n  \"name\":\
+        \ \"ejabberd\",\n  \"namespace\": \"rpms\",\n  \"parent\": null,\n  \"priorities\"\
+        : {},\n  \"tags\": [],\n  \"user\": {\n    \"fullname\": \"peter\",\n    \"\
+        name\": \"peter\"\n  }\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=232120]
+      connection: [Keep-Alive]
+      content-length: ['644']
+      content-type: [application/json]
+      date: ['Mon, 31 Jul 2017 13:23:31 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DGDA0w.RPRdyUgS7qcDGrZrMrOYJBKt2r8;
+          Expires=Thu, 31-Aug-2017 13:23:31 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagersForTests.test_no_namespace
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagersForTests.test_no_namespace
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.2]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/rpms/ejabberd
+  response:
+    body: {string: !!python/unicode "{\n  \"access_groups\": {\n    \"admin\": [],\n\
+        \    \"commit\": [],\n    \"ticket\": []\n  },\n  \"access_users\": {\n  \
+        \  \"admin\": [],\n    \"commit\": [\n      \"bowlofeggs\",\n      \"martinlanghoff\"\
+        ,\n      \"jcline\",\n      \"xavierb\"\n    ],\n    \"owner\": [\n      \"\
+        peter\"\n    ],\n    \"ticket\": []\n  },\n  \"close_status\": [],\n  \"custom_keys\"\
+        : [],\n  \"date_created\": \"1501274592\",\n  \"date_modified\": \"1501274592\"\
+        ,\n  \"description\": \"The ejabberd rpms\",\n  \"fullname\": \"rpms/ejabberd\"\
+        ,\n  \"id\": 3070,\n  \"milestones\": {},\n  \"name\": \"ejabberd\",\n  \"\
+        namespace\": \"rpms\",\n  \"parent\": null,\n  \"priorities\": {},\n  \"tags\"\
+        : [],\n  \"user\": {\n    \"fullname\": \"peter\",\n    \"name\": \"peter\"\
+        \n  }\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=188834]
+      connection: [Keep-Alive]
+      content-length: ['644']
+      content-type: [application/json]
+      date: ['Mon, 31 Jul 2017 13:23:31 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DGDA0w.RPRdyUgS7qcDGrZrMrOYJBKt2r8;
+          Expires=Thu, 31-Aug-2017 13:23:31 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_all
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_all
@@ -5,492 +5,71 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
+      User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&namespace=rpms
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&short=True&page=1
   response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        \"rpms\",\n    \"owner\": null,\n    \"pattern\": null,\n    \"short\": false,\n
-        \   \"tags\": [],\n    \"username\": \"jcline\"\n  },\n  \"projects\": [\n
-        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"martinlanghoff\",\n          \"bowlofeggs\",\n
-        \         \"jcline\"\n        ],\n        \"owner\": [\n          \"peter\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784730\",\n      \"description\":
-        \"The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"id\":
-        3062,\n      \"milestones\": {},\n      \"name\": \"ejabberd\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"peter\",\n        \"name\":
-        \"peter\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784743\",\n      \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
-        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784744\",\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
-        \"rpms/erlang-esip\",\n      \"id\": 3230,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784744\",\n      \"description\": \"The erlang-ezlib rpms\",\n      \"fullname\":
-        \"rpms/erlang-ezlib\",\n      \"id\": 3233,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784745\",\n      \"description\": \"The erlang-fast_tls rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_tls\",\n      \"id\": 3234,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784745\",\n      \"description\": \"The erlang-fast_xml rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_xml\",\n      \"id\": 3235,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_xml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784745\",\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_yaml\",\n      \"id\": 3236,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784745\",\n      \"description\": \"The erlang-goldrush rpms\",\n      \"fullname\":
-        \"rpms/erlang-goldrush\",\n      \"id\": 3241,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-goldrush\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784746\",\n      \"description\": \"The erlang-iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-iconv\",\n      \"id\": 3246,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784747\",\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\":
-        \"rpms/erlang-luerl\",\n      \"id\": 3255,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-luerl\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-oauth2 rpms\",\n      \"fullname\":
-        \"rpms/erlang-oauth2\",\n      \"id\": 3265,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_iconv\",\n      \"id\": 3266,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_mysql rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_mysql\",\n      \"id\": 3267,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_oauth2 rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_oauth2\",\n      \"id\": 3268,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pam\",\n      \"id\": 3269,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_pgsql rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pgsql\",\n      \"id\": 3270,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_sip\",\n      \"id\": 3271,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
-        \     \"description\": \"The erlang-p1_stringprep rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stringprep\",\n      \"id\": 3272,\n      \"milestones\":
-        {},\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n
-        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
-        \     \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stun\",\n      \"id\": 3273,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n
-        \     \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
-        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_utils rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\",\n
-        \     \"id\": 3275,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_utils\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
-        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"peter\",\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_xmlrpc\",\n      \"id\": 3277,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_yaml\",\n      \"id\": 3278,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-p1_zlib rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_zlib\",\n      \"id\": 3279,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-proper rpms\",\n      \"fullname\":
-        \"rpms/erlang-proper\",\n      \"id\": 3283,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-proper\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784751\",\n      \"description\": \"The erlang-stringprep rpms\",\n
-        \     \"fullname\": \"rpms/erlang-stringprep\",\n      \"id\": 3307,\n      \"milestones\":
-        {},\n      \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n
-        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
-        \     \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
-        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784752\",\n      \"description\": \"The erlang-stun rpms\",\n      \"fullname\":
-        \"rpms/erlang-stun\",\n      \"id\": 3308,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-stun\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"jcline\",\n
-        \         \"bowlofeggs\",\n          \"jortel\",\n          \"pcreech17\"\n
-        \       ],\n        \"owner\": [\n          \"ipanova\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785931\",\n      \"description\": \"The pulp rpms\",\n      \"fullname\":
-        \"rpms/pulp\",\n      \"id\": 16269,\n      \"milestones\": {},\n      \"name\":
-        \"pulp\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n
-        \       \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"ipanova\",\n          \"asmacdo\",\n          \"jcline\",\n
-        \         \"jortel\",\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"pcreech17\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785929\",\n      \"description\": \"The pulp-docker rpms\",\n      \"fullname\":
-        \"rpms/pulp-docker\",\n      \"id\": 16264,\n      \"milestones\": {},\n      \"name\":
-        \"pulp-docker\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"ipanova\",\n          \"asmacdo\",\n
-        \         \"jcline\",\n          \"jortel\",\n          \"bowlofeggs\"\n        ],\n
-        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785929\",\n      \"description\": \"The pulp-ostree rpms\",\n      \"fullname\":
-        \"rpms/pulp-ostree\",\n      \"id\": 16265,\n      \"milestones\": {},\n      \"name\":
-        \"pulp-ostree\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"ipanova\",\n          \"asmacdo\",\n
-        \         \"jcline\",\n          \"jortel\",\n          \"bowlofeggs\"\n        ],\n
-        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785929\",\n      \"description\": \"The pulp-puppet rpms\",\n      \"fullname\":
-        \"rpms/pulp-puppet\",\n      \"id\": 16266,\n      \"milestones\": {},\n      \"name\":
-        \"pulp-puppet\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"jcline\",\n
-        \         \"bowlofeggs\",\n          \"jortel\",\n          \"pcreech17\"\n
-        \       ],\n        \"owner\": [\n          \"ipanova\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785930\",\n      \"description\": \"The pulp-python rpms\",\n      \"fullname\":
-        \"rpms/pulp-python\",\n      \"id\": 16267,\n      \"milestones\": {},\n      \"name\":
-        \"pulp-python\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"ipanova\",\n        \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"asmacdo\",\n          \"jcline\",\n          \"bowlofeggs\",\n
-        \         \"jortel\",\n          \"pcreech17\"\n        ],\n        \"owner\":
-        [\n          \"ipanova\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499785930\",\n
-        \     \"description\": \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n
-        \     \"id\": 16268,\n      \"milestones\": {},\n      \"name\": \"pulp-rpm\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n
-        \       \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785955\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
-        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
-        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
-        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
-        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"ipanova\",\n          \"asmacdo\",\n
-        \         \"jcline\",\n          \"jortel\",\n          \"bowlofeggs\"\n        ],\n
-        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785970\",\n      \"description\": \"The python-crane rpms\",\n      \"fullname\":
-        \"rpms/python-crane\",\n      \"id\": 16726,\n      \"milestones\": {},\n
-        \     \"name\": \"python-crane\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
-        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
-        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"dscott\",\n          \"jcline\",\n          \"jmatthews\",\n
-        \         \"dcallagh\"\n        ],\n        \"owner\": [\n          \"jlaska\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786003\",\n      \"description\":
-        \"The python-isodate rpms\",\n      \"fullname\": \"rpms/python-isodate\",\n
-        \     \"id\": 17130,\n      \"milestones\": {},\n      \"name\": \"python-isodate\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jlaska\",\n
-        \       \"name\": \"jlaska\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
-        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
-        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"apevec\",\n          \"jcline\",\n          \"cstratak\",\n
-        \         \"amcnabb\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786039\",\n      \"description\":
-        \"The python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\",\n
-        \     \"id\": 17575,\n      \"milestones\": {},\n      \"name\": \"python-pymongo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
-        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786046\",\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
-        \"rpms/python-rpdb\",\n      \"id\": 17711,\n      \"milestones\": {},\n      \"name\":
-        \"python-rpdb\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"williamjmorenor\",\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
-        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
-        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
-        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
-        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
+        namespace\": null,\n    \"owner\": \"jcline\",\n    \"page\": 1,\n    \"pattern\"\
+        : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
+        \    \"username\": null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=True&page=1\"\
+        ,\n    \"next\": null,\n    \"page\": 1,\n    \"pages\": 1,\n    \"per_page\"\
+        : 20,\n    \"prev\": null\n  },\n  \"projects\": [\n    {\n      \"description\"\
+        : \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\"\
+        ,\n      \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\"\n\
+        \    },\n    {\n      \"description\": \"The erlang-p1_sip rpms\",\n     \
+        \ \"fullname\": \"rpms/erlang-p1_sip\",\n      \"name\": \"erlang-p1_sip\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\"\
+        ,\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\"\
+        \n    },\n    {\n      \"description\": \"The erlang-p1_stun rpms\",\n   \
+        \   \"fullname\": \"rpms/erlang-p1_stun\",\n      \"name\": \"erlang-p1_stun\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n \
+        \     \"name\": \"erlang-p1_tls\",\n      \"namespace\": \"rpms\"\n    },\n\
+        \    {\n      \"description\": \"The erlang-p1_xml rpms\",\n      \"fullname\"\
+        : \"rpms/erlang-p1_xml\",\n      \"name\": \"erlang-p1_xml\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_yaml rpms\"\
+        ,\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n      \"name\": \"erlang-p1_yaml\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n     \
+        \ \"name\": \"python-args\",\n      \"namespace\": \"rpms\"\n    },\n    {\n\
+        \      \"description\": \"The python-clint rpms\",\n      \"fullname\": \"\
+        rpms/python-clint\",\n      \"name\": \"python-clint\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The python-cryptography\
+        \ rpms\",\n      \"fullname\": \"rpms/python-cryptography\",\n      \"name\"\
+        : \"python-cryptography\",\n      \"namespace\": \"rpms\"\n    },\n    {\n\
+        \      \"description\": \"The python-cryptography-vectors rpms\",\n      \"\
+        fullname\": \"rpms/python-cryptography-vectors\",\n      \"name\": \"python-cryptography-vectors\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n \
+        \     \"name\": \"python-flower\",\n      \"namespace\": \"rpms\"\n    },\n\
+        \    {\n      \"description\": \"The python-invocations rpms\",\n      \"\
+        fullname\": \"rpms/python-invocations\",\n      \"name\": \"python-invocations\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n\
+        \      \"name\": \"python-pkginfo\",\n      \"namespace\": \"rpms\"\n    },\n\
+        \    {\n      \"description\": \"The python-releases rpms\",\n      \"fullname\"\
+        : \"rpms/python-releases\",\n      \"name\": \"python-releases\",\n      \"\
+        namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The python-sphinxcontrib-fulltoc\
+        \ rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n  \
+        \    \"name\": \"python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"\
+        rpms\"\n    },\n    {\n      \"description\": \"The python-twine rpms\",\n\
+        \      \"fullname\": \"rpms/python-twine\",\n      \"name\": \"python-twine\"\
+        ,\n      \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 17\n}"}
     headers:
       appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=5075979]
+      apptime: [D=169987]
       connection: [Keep-Alive]
-      content-length: ['33870']
+      content-length: ['3399']
       content-type: [application/json]
-      date: ['Wed, 12 Jul 2017 18:32:10 GMT']
+      date: ['Mon, 31 Jul 2017 13:23:17 GMT']
       keep-alive: ['timeout=15, max=500']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
           mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEf8rw.HN3HXGtUDMEOMswjCJgSP9zmkfo;
-          Expires=Sat, 12-Aug-2017 18:32:15 GMT; Secure; HttpOnly; Path=/pagure']
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DGDAxQ.dGUwBPeXx-pWC5413eSYhwDHDjE;
+          Expires=Thu, 31-Aug-2017 13:23:17 GMT; Secure; HttpOnly; Path=/pagure']
       strict-transport-security: [max-age=15768000; includeSubDomains; preload]
     status: {code: 200, message: OK}
 - request:
@@ -499,173 +78,79 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
+      User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&namespace=rpms
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=True&page=1&username=jcline
   response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        \"rpms\",\n    \"owner\": \"jcline\",\n    \"pattern\": null,\n    \"short\":
-        false,\n    \"tags\": [],\n    \"username\": null\n  },\n  \"projects\": [\n
-        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784743\",\n
-        \     \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
-        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
-        \     \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n
-        \     \"id\": 3271,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_sip\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
-        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
-        \     \"id\": 3272,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stringprep\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
-        \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
-        \     \"id\": 3273,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stun\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
-        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
-        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n
-        \     \"id\": 3278,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_yaml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785955\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
-        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
-        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
-        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
-        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
-        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
-        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
-        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
-        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
-        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"williamjmorenor\",\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
-        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
-        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
-        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
-        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 15\n}"}
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
+        namespace\": null,\n    \"owner\": null,\n    \"page\": 1,\n    \"pattern\"\
+        : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
+        \    \"username\": \"jcline\"\n  },\n  \"pagination\": {\n    \"first\": \"\
+        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
+        ,\n    \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=2\"\
+        ,\n    \"page\": 1,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\"\
+        : null\n  },\n  \"projects\": [\n    {\n      \"description\": \"The bodhi\
+        \ rpms\",\n      \"fullname\": \"rpms/bodhi\",\n      \"name\": \"bodhi\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"name\"\
+        : \"ejabberd\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\"\
+        : \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\"\
+        ,\n      \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\"\n\
+        \    },\n    {\n      \"description\": \"The erlang-esip rpms\",\n      \"\
+        fullname\": \"rpms/erlang-esip\",\n      \"name\": \"erlang-esip\",\n    \
+        \  \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-ezlib\
+        \ rpms\",\n      \"fullname\": \"rpms/erlang-ezlib\",\n      \"name\": \"\
+        erlang-ezlib\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\"\
+        : \"The erlang-fast_tls rpms\",\n      \"fullname\": \"rpms/erlang-fast_tls\"\
+        ,\n      \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\"\n \
+        \   },\n    {\n      \"description\": \"The erlang-fast_xml rpms\",\n    \
+        \  \"fullname\": \"rpms/erlang-fast_xml\",\n      \"name\": \"erlang-fast_xml\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-fast_yaml rpms\",\n      \"fullname\": \"rpms/erlang-fast_yaml\"\
+        ,\n      \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\"\n\
+        \    },\n    {\n      \"description\": \"The erlang-goldrush rpms\",\n   \
+        \   \"fullname\": \"rpms/erlang-goldrush\",\n      \"name\": \"erlang-goldrush\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-iconv rpms\",\n      \"fullname\": \"rpms/erlang-iconv\",\n   \
+        \   \"name\": \"erlang-iconv\",\n      \"namespace\": \"rpms\"\n    },\n \
+        \   {\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\"\
+        : \"rpms/erlang-luerl\",\n      \"name\": \"erlang-luerl\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-oauth2 rpms\"\
+        ,\n      \"fullname\": \"rpms/erlang-oauth2\",\n      \"name\": \"erlang-oauth2\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-p1_iconv rpms\",\n      \"fullname\": \"rpms/erlang-p1_iconv\"\
+        ,\n      \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\"\n \
+        \   },\n    {\n      \"description\": \"The erlang-p1_mysql rpms\",\n    \
+        \  \"fullname\": \"rpms/erlang-p1_mysql\",\n      \"name\": \"erlang-p1_mysql\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-p1_oauth2 rpms\",\n      \"fullname\": \"rpms/erlang-p1_oauth2\"\
+        ,\n      \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\"\n\
+        \    },\n    {\n      \"description\": \"The erlang-p1_pam rpms\",\n     \
+        \ \"fullname\": \"rpms/erlang-p1_pam\",\n      \"name\": \"erlang-p1_pam\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-p1_pgsql rpms\",\n      \"fullname\": \"rpms/erlang-p1_pgsql\"\
+        ,\n      \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\"\n \
+        \   },\n    {\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"\
+        fullname\": \"rpms/erlang-p1_sip\",\n      \"name\": \"erlang-p1_sip\",\n\
+        \      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The\
+        \ erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\"\
+        ,\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\"\
+        \n    },\n    {\n      \"description\": \"The erlang-p1_stun rpms\",\n   \
+        \   \"fullname\": \"rpms/erlang-p1_stun\",\n      \"name\": \"erlang-p1_stun\"\
+        ,\n      \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 49\n}"}
     headers:
       appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=3211221]
+      apptime: [D=1001739]
       connection: [Keep-Alive]
-      content-length: ['10797']
+      content-length: ['3855']
       content-type: [application/json]
-      date: ['Wed, 12 Jul 2017 18:32:15 GMT']
+      date: ['Mon, 31 Jul 2017 13:23:18 GMT']
       keep-alive: ['timeout=15, max=500']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
           mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEf8sw.4rqLneoYWzzl9eVwVFr151qq3fQ;
-          Expires=Sat, 12-Aug-2017 18:32:19 GMT; Secure; HttpOnly; Path=/pagure']
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DGDAxw.OIq8Pm4Ngy2iGV1wHDRS0pNTreg;
+          Expires=Thu, 31-Aug-2017 13:23:19 GMT; Secure; HttpOnly; Path=/pagure']
       strict-transport-security: [max-age=15768000; includeSubDomains; preload]
     status: {code: 200, message: OK}
 - request:
@@ -674,496 +159,80 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
+      User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=2
   response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"pattern\": null,\n    \"short\": false,\n
-        \   \"tags\": [],\n    \"username\": \"jcline\"\n  },\n  \"projects\": [\n
-        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"bowlofeggs\",\n
-        \         \"martinlanghoff\"\n        ],\n        \"owner\": [\n          \"peter\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784730\",\n      \"description\":
-        \"The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"id\":
-        3062,\n      \"milestones\": {},\n      \"name\": \"ejabberd\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"peter\",\n        \"name\":
-        \"peter\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784743\",\n      \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
-        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784744\",\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
-        \"rpms/erlang-esip\",\n      \"id\": 3230,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784744\",\n      \"description\": \"The erlang-ezlib rpms\",\n      \"fullname\":
-        \"rpms/erlang-ezlib\",\n      \"id\": 3233,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784745\",\n      \"description\": \"The erlang-fast_tls rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_tls\",\n      \"id\": 3234,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784745\",\n      \"description\":
-        \"The erlang-fast_xml rpms\",\n      \"fullname\": \"rpms/erlang-fast_xml\",\n
-        \     \"id\": 3235,\n      \"milestones\": {},\n      \"name\": \"erlang-fast_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784745\",\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_yaml\",\n      \"id\": 3236,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784745\",\n      \"description\":
-        \"The erlang-goldrush rpms\",\n      \"fullname\": \"rpms/erlang-goldrush\",\n
-        \     \"id\": 3241,\n      \"milestones\": {},\n      \"name\": \"erlang-goldrush\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784746\",\n      \"description\": \"The erlang-iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-iconv\",\n      \"id\": 3246,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784747\",\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\":
-        \"rpms/erlang-luerl\",\n      \"id\": 3255,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-luerl\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-oauth2 rpms\",\n      \"fullname\":
-        \"rpms/erlang-oauth2\",\n      \"id\": 3265,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_iconv\",\n      \"id\": 3266,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_mysql rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_mysql\",\n      \"id\": 3267,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_oauth2 rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_oauth2\",\n      \"id\": 3268,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pam\",\n      \"id\": 3269,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_pgsql rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pgsql\",\n      \"id\": 3270,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_sip\",\n      \"id\": 3271,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
-        \     \"description\": \"The erlang-p1_stringprep rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stringprep\",\n      \"id\": 3272,\n      \"milestones\":
-        {},\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n
-        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
-        \     \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stun\",\n      \"id\": 3273,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n
-        \     \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
-        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_utils rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\",\n
-        \     \"id\": 3275,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_utils\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
-        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_xmlrpc\",\n      \"id\": 3277,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_yaml\",\n      \"id\": 3278,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-p1_zlib rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_zlib\",\n      \"id\": 3279,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-proper rpms\",\n      \"fullname\": \"rpms/erlang-proper\",\n
-        \     \"id\": 3283,\n      \"milestones\": {},\n      \"name\": \"erlang-proper\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784751\",\n      \"description\": \"The erlang-stringprep rpms\",\n
-        \     \"fullname\": \"rpms/erlang-stringprep\",\n      \"id\": 3307,\n      \"milestones\":
-        {},\n      \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n
-        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
-        \     \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
-        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784752\",\n      \"description\":
-        \"The erlang-stun rpms\",\n      \"fullname\": \"rpms/erlang-stun\",\n      \"id\":
-        3308,\n      \"milestones\": {},\n      \"name\": \"erlang-stun\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
-        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"bowlofeggs\",\n          \"jortel\",\n          \"pcreech17\",\n
-        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785931\",\n      \"description\":
-        \"The pulp rpms\",\n      \"fullname\": \"rpms/pulp\",\n      \"id\": 16269,\n
-        \     \"milestones\": {},\n      \"name\": \"pulp\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
-        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"asmacdo\",\n
-        \         \"jcline\",\n          \"bowlofeggs\",\n          \"ipanova\",\n
-        \         \"jortel\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785929\",\n      \"description\":
-        \"The pulp-docker rpms\",\n      \"fullname\": \"rpms/pulp-docker\",\n      \"id\":
-        16264,\n      \"milestones\": {},\n      \"name\": \"pulp-docker\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
-        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"asmacdo\",\n
-        \         \"jcline\",\n          \"bowlofeggs\",\n          \"ipanova\",\n
-        \         \"jortel\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785929\",\n      \"description\":
-        \"The pulp-ostree rpms\",\n      \"fullname\": \"rpms/pulp-ostree\",\n      \"id\":
-        16265,\n      \"milestones\": {},\n      \"name\": \"pulp-ostree\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
-        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"asmacdo\",\n
-        \         \"jcline\",\n          \"bowlofeggs\",\n          \"ipanova\",\n
-        \         \"jortel\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785929\",\n      \"description\":
-        \"The pulp-puppet rpms\",\n      \"fullname\": \"rpms/pulp-puppet\",\n      \"id\":
-        16266,\n      \"milestones\": {},\n      \"name\": \"pulp-puppet\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
-        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"bowlofeggs\",\n          \"jortel\",\n          \"pcreech17\",\n
-        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785930\",\n      \"description\":
-        \"The pulp-python rpms\",\n      \"fullname\": \"rpms/pulp-python\",\n      \"id\":
-        16267,\n      \"milestones\": {},\n      \"name\": \"pulp-python\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
-        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"bowlofeggs\",\n          \"jortel\",\n          \"pcreech17\",\n
-        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785930\",\n      \"description\":
-        \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n      \"id\":
-        16268,\n      \"milestones\": {},\n      \"name\": \"pulp-rpm\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
-        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"owner\": [\n
-        \         \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499785955\",\n
-        \     \"description\": \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n
-        \     \"id\": 16563,\n      \"milestones\": {},\n      \"name\": \"python-args\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
-        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
-        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"jcline\",\n
-        \         \"bowlofeggs\",\n          \"ipanova\",\n          \"jortel\"\n
-        \       ],\n        \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785970\",\n      \"description\": \"The python-crane rpms\",\n      \"fullname\":
-        \"rpms/python-crane\",\n      \"id\": 16726,\n      \"milestones\": {},\n
-        \     \"name\": \"python-crane\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
-        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
-        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"dcallagh\",\n          \"dscott\",\n          \"jmatthews\",\n
-        \         \"jcline\"\n        ],\n        \"owner\": [\n          \"jlaska\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786003\",\n      \"description\":
-        \"The python-isodate rpms\",\n      \"fullname\": \"rpms/python-isodate\",\n
-        \     \"id\": 17130,\n      \"milestones\": {},\n      \"name\": \"python-isodate\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jlaska\",\n
-        \       \"name\": \"jlaska\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
-        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
-        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"apevec\",\n          \"cstratak\",\n          \"amcnabb\",\n
-        \         \"jcline\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786039\",\n      \"description\":
-        \"The python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\",\n
-        \     \"id\": 17575,\n      \"milestones\": {},\n      \"name\": \"python-pymongo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
-        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786046\",\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
-        \"rpms/python-rpdb\",\n      \"id\": 17711,\n      \"milestones\": {},\n      \"name\":
-        \"python-rpdb\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"williamjmorenor\",\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
-        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
-        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
-        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
-        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
+        namespace\": null,\n    \"owner\": null,\n    \"page\": 2,\n    \"pattern\"\
+        : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
+        \    \"username\": \"jcline\"\n  },\n  \"pagination\": {\n    \"first\": \"\
+        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
+        ,\n    \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
+        ,\n    \"page\": 2,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\"\
+        : \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
+        \n  },\n  \"projects\": [\n    {\n      \"description\": \"The erlang-p1_tls\
+        \ rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n      \"name\": \"\
+        erlang-p1_tls\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\"\
+        : \"The erlang-p1_utils rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\"\
+        ,\n      \"name\": \"erlang-p1_utils\",\n      \"namespace\": \"rpms\"\n \
+        \   },\n    {\n      \"description\": \"The erlang-p1_xml rpms\",\n      \"\
+        fullname\": \"rpms/erlang-p1_xml\",\n      \"name\": \"erlang-p1_xml\",\n\
+        \      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The\
+        \ erlang-p1_xmlrpc rpms\",\n      \"fullname\": \"rpms/erlang-p1_xmlrpc\"\
+        ,\n      \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\"\n\
+        \    },\n    {\n      \"description\": \"The erlang-p1_yaml rpms\",\n    \
+        \  \"fullname\": \"rpms/erlang-p1_yaml\",\n      \"name\": \"erlang-p1_yaml\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-p1_zlib rpms\",\n      \"fullname\": \"rpms/erlang-p1_zlib\",\n\
+        \      \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\"\n    },\n\
+        \    {\n      \"description\": \"The erlang-proper rpms\",\n      \"fullname\"\
+        : \"rpms/erlang-proper\",\n      \"name\": \"erlang-proper\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-stringprep\
+        \ rpms\",\n      \"fullname\": \"rpms/erlang-stringprep\",\n      \"name\"\
+        : \"erlang-stringprep\",\n      \"namespace\": \"rpms\"\n    },\n    {\n \
+        \     \"description\": \"The erlang-stun rpms\",\n      \"fullname\": \"rpms/erlang-stun\"\
+        ,\n      \"name\": \"erlang-stun\",\n      \"namespace\": \"rpms\"\n    },\n\
+        \    {\n      \"description\": \"The python-args rpms\",\n      \"fullname\"\
+        : \"rpms/python-args\",\n      \"name\": \"python-args\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The python-chardet rpms\"\
+        ,\n      \"fullname\": \"rpms/python-chardet\",\n      \"name\": \"python-chardet\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The python-clint rpms\",\n      \"fullname\": \"rpms/python-clint\",\n   \
+        \   \"name\": \"python-clint\",\n      \"namespace\": \"rpms\"\n    },\n \
+        \   {\n      \"description\": \"The python-crane rpms\",\n      \"fullname\"\
+        : \"rpms/python-crane\",\n      \"name\": \"python-crane\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The python-cryptography\
+        \ rpms\",\n      \"fullname\": \"rpms/python-cryptography\",\n      \"name\"\
+        : \"python-cryptography\",\n      \"namespace\": \"rpms\"\n    },\n    {\n\
+        \      \"description\": \"The python-cryptography-vectors rpms\",\n      \"\
+        fullname\": \"rpms/python-cryptography-vectors\",\n      \"name\": \"python-cryptography-vectors\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n \
+        \     \"name\": \"python-flower\",\n      \"namespace\": \"rpms\"\n    },\n\
+        \    {\n      \"description\": \"The python-idna rpms\",\n      \"fullname\"\
+        : \"rpms/python-idna\",\n      \"name\": \"python-idna\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The python-invocations\
+        \ rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n      \"name\"\
+        : \"python-invocations\",\n      \"namespace\": \"rpms\"\n    },\n    {\n\
+        \      \"description\": \"The python-ipdb rpms\",\n      \"fullname\": \"\
+        rpms/python-ipdb\",\n      \"name\": \"python-ipdb\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The python-isodate rpms\"\
+        ,\n      \"fullname\": \"rpms/python-isodate\",\n      \"name\": \"python-isodate\"\
+        ,\n      \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 49\n}"}
     headers:
       appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=5131740]
+      apptime: [D=982157]
       connection: [Keep-Alive]
-      content-length: ['33868']
+      content-length: ['4005']
       content-type: [application/json]
-      date: ['Wed, 12 Jul 2017 18:50:48 GMT']
+      date: ['Mon, 31 Jul 2017 13:23:19 GMT']
       keep-alive: ['timeout=15, max=500']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
           mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEgBDQ.9gRx7NbfTvCV3UH3Hx6H6N9nyFU;
-          Expires=Sat, 12-Aug-2017 18:50:53 GMT; Secure; HttpOnly; Path=/pagure']
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DGDAyA.adFk3Z4FzbYz74zrQ_rieCKvPMk;
+          Expires=Thu, 31-Aug-2017 13:23:20 GMT; Secure; HttpOnly; Path=/pagure']
       strict-transport-security: [max-age=15768000; includeSubDomains; preload]
     status: {code: 200, message: OK}
 - request:
@@ -1172,1183 +241,53 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
+      User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3
   response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": \"jcline\",\n    \"pattern\": null,\n    \"short\":
-        false,\n    \"tags\": [],\n    \"username\": null\n  },\n  \"projects\": [\n
-        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784743\",\n
-        \     \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
-        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
-        \     \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n
-        \     \"id\": 3271,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_sip\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
-        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
-        \     \"id\": 3272,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stringprep\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
-        \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
-        \     \"id\": 3273,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stun\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
-        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
-        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n
-        \     \"id\": 3278,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_yaml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785955\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
-        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
-        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
-        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
-        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
-        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
-        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
-        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
-        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
-        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
-        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
-        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
-        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
-        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 15\n}"}
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
+        namespace\": null,\n    \"owner\": null,\n    \"page\": 3,\n    \"pattern\"\
+        : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
+        \    \"username\": \"jcline\"\n  },\n  \"pagination\": {\n    \"first\": \"\
+        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
+        ,\n    \"next\": null,\n    \"page\": 3,\n    \"pages\": 3,\n    \"per_page\"\
+        : 20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=2\"\
+        \n  },\n  \"projects\": [\n    {\n      \"description\": \"The python-pkginfo\
+        \ rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n      \"name\": \"\
+        python-pkginfo\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"\
+        description\": \"The python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\"\
+        ,\n      \"name\": \"python-pymongo\",\n      \"namespace\": \"rpms\"\n  \
+        \  },\n    {\n      \"description\": \"The python-pytoml rpms\",\n      \"\
+        fullname\": \"rpms/python-pytoml\",\n      \"name\": \"python-pytoml\",\n\
+        \      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The\
+        \ python-releases rpms\",\n      \"fullname\": \"rpms/python-releases\",\n\
+        \      \"name\": \"python-releases\",\n      \"namespace\": \"rpms\"\n   \
+        \ },\n    {\n      \"description\": \"The python-requests rpms\",\n      \"\
+        fullname\": \"rpms/python-requests\",\n      \"name\": \"python-requests\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The python-rpdb rpms\",\n      \"fullname\": \"rpms/python-rpdb\",\n     \
+        \ \"name\": \"python-rpdb\",\n      \"namespace\": \"rpms\"\n    },\n    {\n\
+        \      \"description\": \"The python-sphinxcontrib-fulltoc rpms\",\n     \
+        \ \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"name\": \"\
+        python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\"\n    },\n \
+        \   {\n      \"description\": \"The python-twine rpms\",\n      \"fullname\"\
+        : \"rpms/python-twine\",\n      \"name\": \"python-twine\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The python-urllib3 rpms\"\
+        ,\n      \"fullname\": \"rpms/python-urllib3\",\n      \"name\": \"python-urllib3\"\
+        ,\n      \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 49\n}"}
     headers:
       appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=855936]
+      apptime: [D=1003406]
       connection: [Keep-Alive]
-      content-length: ['10795']
+      content-length: ['2152']
       content-type: [application/json]
-      date: ['Wed, 12 Jul 2017 18:50:54 GMT']
+      date: ['Mon, 31 Jul 2017 13:23:21 GMT']
       keep-alive: ['timeout=15, max=500']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
           mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEgBDg.WLeuXtUpDfqTUAPsxkJ16NMxyuQ;
-          Expires=Sat, 12-Aug-2017 18:50:54 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?page=1&owner=jcline
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": \"jcline\",\n    \"page\": 1,\n    \"pattern\": null,\n
-        \   \"per_page\": 20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\":
-        null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&page=1\",\n
-        \   \"next\": null,\n    \"page\": 1,\n    \"pages\": 1,\n    \"per_page\":
-        20,\n    \"prev\": null\n  },\n  \"projects\": [\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069208\",\n      \"description\":
-        \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
-        \     \"id\": 3207,\n      \"milestones\": {},\n      \"name\": \"erlang-cache_tab\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n      \"description\":
-        \"The erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n
-        \     \"id\": 3271,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_sip\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n      \"description\":
-        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
-        \     \"id\": 3272,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stringprep\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n      \"description\":
-        \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
-        \     \"id\": 3273,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stun\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
-        \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
-        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
-        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
-        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
-        \"The erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n
-        \     \"id\": 3278,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_yaml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070924\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
-        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
-        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070941\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
-        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
-        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070977\",\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070991\",\n      \"description\":
-        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
-        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500071033\",\n      \"description\":
-        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
-        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500071049\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
-        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500071066\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
-        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500071080\",\n      \"description\":
-        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
-        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
-        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 15\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=1277857]
-      connection: [Keep-Alive]
-      content-length: ['11146']
-      content-type: [application/json]
-      date: ['Thu, 20 Jul 2017 19:00:09 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPOg.BViCt_D7YnUm_cG_l_HuvFbr5CA;
-          Expires=Sun, 20-Aug-2017 19:00:10 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&page=1
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"page\": 1,\n    \"pattern\": null,\n    \"per_page\":
-        20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
-        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
-        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=2\",\n
-        \   \"page\": 1,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
-        null\n  },\n  \"projects\": [\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\",\n
-        \         \"jcline\",\n          \"martinlanghoff\"\n        ],\n        \"owner\":
-        [\n          \"peter\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500069194\",\n
-        \     \"description\": \"The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n
-        \     \"id\": 3062,\n      \"milestones\": {},\n      \"name\": \"ejabberd\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"peter\",\n
-        \       \"name\": \"peter\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069208\",\n      \"description\":
-        \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
-        \     \"id\": 3207,\n      \"milestones\": {},\n      \"name\": \"erlang-cache_tab\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069209\",\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
-        \"rpms/erlang-esip\",\n      \"id\": 3230,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069209\",\n      \"description\": \"The erlang-ezlib rpms\",\n      \"fullname\":
-        \"rpms/erlang-ezlib\",\n      \"id\": 3233,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069209\",\n      \"description\": \"The erlang-fast_tls rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_tls\",\n      \"id\": 3234,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069210\",\n      \"description\":
-        \"The erlang-fast_xml rpms\",\n      \"fullname\": \"rpms/erlang-fast_xml\",\n
-        \     \"id\": 3235,\n      \"milestones\": {},\n      \"name\": \"erlang-fast_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069210\",\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_yaml\",\n      \"id\": 3236,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069210\",\n      \"description\":
-        \"The erlang-goldrush rpms\",\n      \"fullname\": \"rpms/erlang-goldrush\",\n
-        \     \"id\": 3241,\n      \"milestones\": {},\n      \"name\": \"erlang-goldrush\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069211\",\n      \"description\": \"The erlang-iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-iconv\",\n      \"id\": 3246,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069212\",\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\":
-        \"rpms/erlang-luerl\",\n      \"id\": 3255,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-luerl\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069212\",\n      \"description\": \"The erlang-oauth2 rpms\",\n      \"fullname\":
-        \"rpms/erlang-oauth2\",\n      \"id\": 3265,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_iconv\",\n      \"id\": 3266,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_mysql rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_mysql\",\n      \"id\": 3267,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_oauth2 rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_oauth2\",\n      \"id\": 3268,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pam\",\n      \"id\": 3269,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_pgsql rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pgsql\",\n      \"id\": 3270,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_sip\",\n      \"id\": 3271,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n
-        \     \"description\": \"The erlang-p1_stringprep rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stringprep\",\n      \"id\": 3272,\n      \"milestones\":
-        {},\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n
-        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
-        \     \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stun\",\n      \"id\": 3273,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n
-        \     \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
-        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\":
-        46\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=1947390]
-      connection: [Keep-Alive]
-      content-length: ['15136']
-      content-type: [application/json]
-      date: ['Thu, 20 Jul 2017 19:00:10 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPPA.lslyRp86RVwK10YqJWA7khce5b4;
-          Expires=Sun, 20-Aug-2017 19:00:12 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=2
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"page\": 2,\n    \"pattern\": null,\n    \"per_page\":
-        20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
-        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
-        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
-        \   \"page\": 2,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
-        \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\"\n
-        \ },\n  \"projects\": [\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069214\",\n      \"description\": \"The erlang-p1_utils rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_utils\",\n      \"id\": 3275,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_utils\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069214\",\n      \"description\": \"The erlang-p1_xml rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_xml\",\n      \"id\": 3276,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_xml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069214\",\n      \"description\": \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_xmlrpc\",\n      \"id\": 3277,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069214\",\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_yaml\",\n      \"id\": 3278,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069214\",\n      \"description\": \"The erlang-p1_zlib rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_zlib\",\n      \"id\": 3279,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069214\",\n      \"description\": \"The erlang-proper rpms\",\n      \"fullname\":
-        \"rpms/erlang-proper\",\n      \"id\": 3283,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-proper\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069218\",\n      \"description\": \"The erlang-stringprep rpms\",\n
-        \     \"fullname\": \"rpms/erlang-stringprep\",\n      \"id\": 3307,\n      \"milestones\":
-        {},\n      \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n
-        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
-        \     \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
-        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069218\",\n      \"description\": \"The erlang-stun rpms\",\n      \"fullname\":
-        \"rpms/erlang-stun\",\n      \"id\": 3308,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-stun\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"bowlofeggs\",\n
-        \         \"jortel\",\n          \"jcline\",\n          \"pcreech17\"\n        ],\n
-        \       \"owner\": [\n          \"ipanova\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070895\",\n      \"description\": \"The pulp rpms\",\n      \"fullname\":
-        \"rpms/pulp\",\n      \"id\": 16269,\n      \"milestones\": {},\n      \"name\":
-        \"pulp\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n
-        \       \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"asmacdo\",\n          \"ipanova\",\n          \"jortel\",\n
-        \         \"jcline\",\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"pcreech17\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070892\",\n      \"description\": \"The pulp-docker rpms\",\n      \"fullname\":
-        \"rpms/pulp-docker\",\n      \"id\": 16264,\n      \"milestones\": {},\n      \"name\":
-        \"pulp-docker\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"ipanova\",\n
-        \         \"jortel\",\n          \"jcline\",\n          \"bowlofeggs\"\n        ],\n
-        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070893\",\n      \"description\": \"The pulp-ostree rpms\",\n      \"fullname\":
-        \"rpms/pulp-ostree\",\n      \"id\": 16265,\n      \"milestones\": {},\n      \"name\":
-        \"pulp-ostree\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"ipanova\",\n
-        \         \"jortel\",\n          \"jcline\",\n          \"bowlofeggs\"\n        ],\n
-        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070893\",\n      \"description\": \"The pulp-puppet rpms\",\n      \"fullname\":
-        \"rpms/pulp-puppet\",\n      \"id\": 16266,\n      \"milestones\": {},\n      \"name\":
-        \"pulp-puppet\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"bowlofeggs\",\n
-        \         \"jortel\",\n          \"jcline\",\n          \"pcreech17\"\n        ],\n
-        \       \"owner\": [\n          \"ipanova\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070894\",\n      \"description\": \"The pulp-python rpms\",\n      \"fullname\":
-        \"rpms/pulp-python\",\n      \"id\": 16267,\n      \"milestones\": {},\n      \"name\":
-        \"pulp-python\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"ipanova\",\n        \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"asmacdo\",\n          \"bowlofeggs\",\n          \"jortel\",\n
-        \         \"jcline\",\n          \"pcreech17\"\n        ],\n        \"owner\":
-        [\n          \"ipanova\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500070894\",\n
-        \     \"description\": \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n
-        \     \"id\": 16268,\n      \"milestones\": {},\n      \"name\": \"pulp-rpm\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n
-        \       \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070924\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
-        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
-        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070941\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
-        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
-        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"ipanova\",\n
-        \         \"jortel\",\n          \"jcline\",\n          \"bowlofeggs\"\n        ],\n
-        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070947\",\n      \"description\": \"The python-crane rpms\",\n      \"fullname\":
-        \"rpms/python-crane\",\n      \"id\": 16726,\n      \"milestones\": {},\n
-        \     \"name\": \"python-crane\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070977\",\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070991\",\n      \"description\":
-        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
-        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"dcallagh\",\n          \"jmatthews\",\n          \"jcline\",\n
-        \         \"dscott\"\n        ],\n        \"owner\": [\n          \"jlaska\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070992\",\n      \"description\":
-        \"The python-isodate rpms\",\n      \"fullname\": \"rpms/python-isodate\",\n
-        \     \"id\": 17130,\n      \"milestones\": {},\n      \"name\": \"python-isodate\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jlaska\",\n
-        \       \"name\": \"jlaska\"\n      }\n    }\n  ],\n  \"total_projects\":
-        46\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=1876365]
-      connection: [Keep-Alive]
-      content-length: ['15550']
-      content-type: [application/json]
-      date: ['Thu, 20 Jul 2017 19:00:13 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPPw.q-_GE6s8XEf21yBtLBoEmdNeGYo;
-          Expires=Sun, 20-Aug-2017 19:00:15 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"page\": 3,\n    \"pattern\": null,\n    \"per_page\":
-        20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
-        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
-        \   \"next\": null,\n    \"page\": 3,\n    \"pages\": 3,\n    \"per_page\":
-        20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=2\"\n
-        \ },\n  \"projects\": [\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500071033\",\n      \"description\": \"The python-pkginfo rpms\",\n      \"fullname\":
-        \"rpms/python-pkginfo\",\n      \"id\": 17492,\n      \"milestones\": {},\n
-        \     \"name\": \"python-pkginfo\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"cstratak\",\n
-        \         \"apevec\",\n          \"amcnabb\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500071041\",\n      \"description\": \"The python-pymongo rpms\",\n      \"fullname\":
-        \"rpms/python-pymongo\",\n      \"id\": 17575,\n      \"milestones\": {},\n
-        \     \"name\": \"python-pymongo\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"owner\": [\n
-        \         \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500071049\",\n
-        \     \"description\": \"The python-releases rpms\",\n      \"fullname\":
-        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500071056\",\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
-        \"rpms/python-rpdb\",\n      \"id\": 17711,\n      \"milestones\": {},\n      \"name\":
-        \"python-rpdb\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500071066\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
-        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500071080\",\n      \"description\":
-        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
-        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
-        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 46\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=1349584]
-      connection: [Keep-Alive]
-      content-length: ['5015']
-      content-type: [application/json]
-      date: ['Thu, 20 Jul 2017 19:00:16 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPQQ.TTbxsWjtehnSojTNgzkyauID0sQ;
-          Expires=Sun, 20-Aug-2017 19:00:17 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=true&username=jcline&page=1
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"page\": 1,\n    \"pattern\": null,\n    \"per_page\":
-        20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
-        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
-        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=2\",\n
-        \   \"page\": 1,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
-        null\n  },\n  \"projects\": [\n    {\n      \"description\": \"The ejabberd
-        rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"name\": \"ejabberd\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
-        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
-        \"rpms/erlang-esip\",\n      \"name\": \"erlang-esip\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-ezlib rpms\",\n
-        \     \"fullname\": \"rpms/erlang-ezlib\",\n      \"name\": \"erlang-ezlib\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-fast_tls rpms\",\n      \"fullname\": \"rpms/erlang-fast_tls\",\n      \"name\":
-        \"erlang-fast_tls\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The erlang-fast_xml rpms\",\n      \"fullname\": \"rpms/erlang-fast_xml\",\n
-        \     \"name\": \"erlang-fast_xml\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_yaml\",\n      \"name\": \"erlang-fast_yaml\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-goldrush rpms\",\n
-        \     \"fullname\": \"rpms/erlang-goldrush\",\n      \"name\": \"erlang-goldrush\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-iconv rpms\",\n      \"fullname\": \"rpms/erlang-iconv\",\n      \"name\":
-        \"erlang-iconv\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The erlang-luerl rpms\",\n      \"fullname\": \"rpms/erlang-luerl\",\n      \"name\":
-        \"erlang-luerl\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The erlang-oauth2 rpms\",\n      \"fullname\": \"rpms/erlang-oauth2\",\n
-        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_iconv\",\n      \"name\": \"erlang-p1_iconv\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_mysql rpms\",\n
-        \     \"fullname\": \"rpms/erlang-p1_mysql\",\n      \"name\": \"erlang-p1_mysql\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-p1_oauth2 rpms\",\n      \"fullname\": \"rpms/erlang-p1_oauth2\",\n
-        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pam\",\n      \"name\": \"erlang-p1_pam\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_pgsql rpms\",\n
-        \     \"fullname\": \"rpms/erlang-p1_pgsql\",\n      \"name\": \"erlang-p1_pgsql\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n      \"name\":
-        \"erlang-p1_sip\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
-        \     \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\"\n
-        \   },\n    {\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stun\",\n      \"name\": \"erlang-p1_stun\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_tls rpms\",\n
-        \     \"fullname\": \"rpms/erlang-p1_tls\",\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 46\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=2775561]
-      connection: [Keep-Alive]
-      content-length: ['3879']
-      content-type: [application/json]
-      date: ['Fri, 21 Jul 2017 16:46:46 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBeA.60ygyslc95-xclCmjA5nTO64-w8;
-          Expires=Mon, 21-Aug-2017 16:46:48 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=2
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"page\": 2,\n    \"pattern\": null,\n    \"per_page\":
-        20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
-        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
-        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
-        \   \"page\": 2,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
-        \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\"\n
-        \ },\n  \"projects\": [\n    {\n      \"description\": \"The erlang-p1_utils
-        rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\",\n      \"name\": \"erlang-p1_utils\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n      \"name\":
-        \"erlang-p1_xml\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\": \"rpms/erlang-p1_xmlrpc\",\n
-        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_yaml\",\n      \"name\": \"erlang-p1_yaml\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_zlib rpms\",\n
-        \     \"fullname\": \"rpms/erlang-p1_zlib\",\n      \"name\": \"erlang-p1_zlib\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-proper rpms\",\n      \"fullname\": \"rpms/erlang-proper\",\n      \"name\":
-        \"erlang-proper\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The erlang-stringprep rpms\",\n      \"fullname\": \"rpms/erlang-stringprep\",\n
-        \     \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-stun rpms\",\n      \"fullname\":
-        \"rpms/erlang-stun\",\n      \"name\": \"erlang-stun\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The pulp rpms\",\n      \"fullname\":
-        \"rpms/pulp\",\n      \"name\": \"pulp\",\n      \"namespace\": \"rpms\"\n
-        \   },\n    {\n      \"description\": \"The pulp-docker rpms\",\n      \"fullname\":
-        \"rpms/pulp-docker\",\n      \"name\": \"pulp-docker\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The pulp-ostree rpms\",\n
-        \     \"fullname\": \"rpms/pulp-ostree\",\n      \"name\": \"pulp-ostree\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        pulp-puppet rpms\",\n      \"fullname\": \"rpms/pulp-puppet\",\n      \"name\":
-        \"pulp-puppet\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The pulp-python rpms\",\n      \"fullname\": \"rpms/pulp-python\",\n      \"name\":
-        \"pulp-python\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n      \"name\":
-        \"pulp-rpm\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n      \"name\":
-        \"python-args\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-clint rpms\",\n      \"fullname\": \"rpms/python-clint\",\n      \"name\":
-        \"python-clint\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-crane rpms\",\n      \"fullname\": \"rpms/python-crane\",\n      \"name\":
-        \"python-crane\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"name\": \"python-flower\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The python-invocations rpms\",\n      \"fullname\":
-        \"rpms/python-invocations\",\n      \"name\": \"python-invocations\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The python-isodate rpms\",\n
-        \     \"fullname\": \"rpms/python-isodate\",\n      \"name\": \"python-isodate\",\n
-        \     \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 46\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=2567971]
-      connection: [Keep-Alive]
-      content-length: ['3888']
-      content-type: [application/json]
-      date: ['Fri, 21 Jul 2017 16:46:49 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBew.FAwnmZGNRXGORs72JyZeFEXrvCM;
-          Expires=Mon, 21-Aug-2017 16:46:51 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"page\": 3,\n    \"pattern\": null,\n    \"per_page\":
-        20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
-        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
-        \   \"next\": null,\n    \"page\": 3,\n    \"pages\": 3,\n    \"per_page\":
-        20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=2\"\n
-        \ },\n  \"projects\": [\n    {\n      \"description\": \"The python-pkginfo
-        rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\",\n      \"name\":
-        \"python-pymongo\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-releases rpms\",\n      \"fullname\": \"rpms/python-releases\",\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
-        \"rpms/python-rpdb\",\n      \"name\": \"python-rpdb\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"name\":
-        \"python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The python-twine rpms\",\n      \"fullname\":
-        \"rpms/python-twine\",\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\"\n    }\n  ],\n  \"total_projects\": 46\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=909745]
-      connection: [Keep-Alive]
-      content-length: ['1672']
-      content-type: [application/json]
-      date: ['Fri, 21 Jul 2017 16:46:52 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBfQ.GREIBSForxrNntCAXfGY8uhv2BQ;
-          Expires=Mon, 21-Aug-2017 16:46:53 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=true&owner=jcline&page=1
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": \"jcline\",\n    \"page\": 1,\n    \"pattern\": null,\n
-        \   \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\":
-        null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=true&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=true&page=1\",\n
-        \   \"next\": null,\n    \"page\": 1,\n    \"pages\": 1,\n    \"per_page\":
-        20,\n    \"prev\": null\n  },\n  \"projects\": [\n    {\n      \"description\":
-        \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
-        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_sip\",\n      \"name\": \"erlang-p1_sip\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_stringprep
-        rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n      \"name\":
-        \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\"\n    },\n    {\n
-        \     \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
-        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_tls\",\n      \"name\": \"erlang-p1_tls\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_xml rpms\",\n
-        \     \"fullname\": \"rpms/erlang-p1_xml\",\n      \"name\": \"erlang-p1_xml\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n      \"name\":
-        \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n      \"name\":
-        \"python-args\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-clint rpms\",\n      \"fullname\": \"rpms/python-clint\",\n      \"name\":
-        \"python-clint\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"name\": \"python-flower\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The python-invocations rpms\",\n      \"fullname\":
-        \"rpms/python-invocations\",\n      \"name\": \"python-invocations\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The python-pkginfo rpms\",\n
-        \     \"fullname\": \"rpms/python-pkginfo\",\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        python-releases rpms\",\n      \"fullname\": \"rpms/python-releases\",\n      \"name\":
-        \"python-releases\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-sphinxcontrib-fulltoc rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n
-        \     \"name\": \"python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\"\n
-        \   },\n    {\n      \"description\": \"The python-twine rpms\",\n      \"fullname\":
-        \"rpms/python-twine\",\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\"\n    }\n  ],\n  \"total_projects\": 15\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=2757199]
-      connection: [Keep-Alive]
-      content-length: ['3025']
-      content-type: [application/json]
-      date: ['Fri, 21 Jul 2017 16:46:53 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBgA.N0x0EHE9TYpCdWuSZvgjty0mxLU;
-          Expires=Mon, 21-Aug-2017 16:46:56 GMT; Secure; HttpOnly; Path=/pagure']
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DGDAyg.zaAKWEsZ_oO7tFU1Ha6uzzgNero;
+          Expires=Thu, 31-Aug-2017 13:23:22 GMT; Secure; HttpOnly; Path=/pagure']
       strict-transport-security: [max-age=15768000; includeSubDomains; preload]
     status: {code: 200, message: OK}
 version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_all
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_all
@@ -1,0 +1,2354 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&namespace=rpms
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        \"rpms\",\n    \"owner\": null,\n    \"pattern\": null,\n    \"short\": false,\n
+        \   \"tags\": [],\n    \"username\": \"jcline\"\n  },\n  \"projects\": [\n
+        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"martinlanghoff\",\n          \"bowlofeggs\",\n
+        \         \"jcline\"\n        ],\n        \"owner\": [\n          \"peter\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784730\",\n      \"description\":
+        \"The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"id\":
+        3062,\n      \"milestones\": {},\n      \"name\": \"ejabberd\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"peter\",\n        \"name\":
+        \"peter\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784743\",\n      \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
+        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784744\",\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
+        \"rpms/erlang-esip\",\n      \"id\": 3230,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784744\",\n      \"description\": \"The erlang-ezlib rpms\",\n      \"fullname\":
+        \"rpms/erlang-ezlib\",\n      \"id\": 3233,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784745\",\n      \"description\": \"The erlang-fast_tls rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_tls\",\n      \"id\": 3234,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784745\",\n      \"description\": \"The erlang-fast_xml rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_xml\",\n      \"id\": 3235,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_xml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784745\",\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_yaml\",\n      \"id\": 3236,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784745\",\n      \"description\": \"The erlang-goldrush rpms\",\n      \"fullname\":
+        \"rpms/erlang-goldrush\",\n      \"id\": 3241,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-goldrush\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784746\",\n      \"description\": \"The erlang-iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-iconv\",\n      \"id\": 3246,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784747\",\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\":
+        \"rpms/erlang-luerl\",\n      \"id\": 3255,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-luerl\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-oauth2 rpms\",\n      \"fullname\":
+        \"rpms/erlang-oauth2\",\n      \"id\": 3265,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_iconv\",\n      \"id\": 3266,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_mysql rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_mysql\",\n      \"id\": 3267,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_oauth2 rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_oauth2\",\n      \"id\": 3268,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pam\",\n      \"id\": 3269,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_pgsql rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pgsql\",\n      \"id\": 3270,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_sip\",\n      \"id\": 3271,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
+        \     \"description\": \"The erlang-p1_stringprep rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stringprep\",\n      \"id\": 3272,\n      \"milestones\":
+        {},\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n
+        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
+        \     \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stun\",\n      \"id\": 3273,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n
+        \     \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
+        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_utils rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\",\n
+        \     \"id\": 3275,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_utils\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
+        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"peter\",\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_xmlrpc\",\n      \"id\": 3277,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_yaml\",\n      \"id\": 3278,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-p1_zlib rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_zlib\",\n      \"id\": 3279,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-proper rpms\",\n      \"fullname\":
+        \"rpms/erlang-proper\",\n      \"id\": 3283,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-proper\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784751\",\n      \"description\": \"The erlang-stringprep rpms\",\n
+        \     \"fullname\": \"rpms/erlang-stringprep\",\n      \"id\": 3307,\n      \"milestones\":
+        {},\n      \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n
+        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
+        \     \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
+        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784752\",\n      \"description\": \"The erlang-stun rpms\",\n      \"fullname\":
+        \"rpms/erlang-stun\",\n      \"id\": 3308,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-stun\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"jcline\",\n
+        \         \"bowlofeggs\",\n          \"jortel\",\n          \"pcreech17\"\n
+        \       ],\n        \"owner\": [\n          \"ipanova\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785931\",\n      \"description\": \"The pulp rpms\",\n      \"fullname\":
+        \"rpms/pulp\",\n      \"id\": 16269,\n      \"milestones\": {},\n      \"name\":
+        \"pulp\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n
+        \       \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"ipanova\",\n          \"asmacdo\",\n          \"jcline\",\n
+        \         \"jortel\",\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"pcreech17\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785929\",\n      \"description\": \"The pulp-docker rpms\",\n      \"fullname\":
+        \"rpms/pulp-docker\",\n      \"id\": 16264,\n      \"milestones\": {},\n      \"name\":
+        \"pulp-docker\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"ipanova\",\n          \"asmacdo\",\n
+        \         \"jcline\",\n          \"jortel\",\n          \"bowlofeggs\"\n        ],\n
+        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785929\",\n      \"description\": \"The pulp-ostree rpms\",\n      \"fullname\":
+        \"rpms/pulp-ostree\",\n      \"id\": 16265,\n      \"milestones\": {},\n      \"name\":
+        \"pulp-ostree\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"ipanova\",\n          \"asmacdo\",\n
+        \         \"jcline\",\n          \"jortel\",\n          \"bowlofeggs\"\n        ],\n
+        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785929\",\n      \"description\": \"The pulp-puppet rpms\",\n      \"fullname\":
+        \"rpms/pulp-puppet\",\n      \"id\": 16266,\n      \"milestones\": {},\n      \"name\":
+        \"pulp-puppet\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"jcline\",\n
+        \         \"bowlofeggs\",\n          \"jortel\",\n          \"pcreech17\"\n
+        \       ],\n        \"owner\": [\n          \"ipanova\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785930\",\n      \"description\": \"The pulp-python rpms\",\n      \"fullname\":
+        \"rpms/pulp-python\",\n      \"id\": 16267,\n      \"milestones\": {},\n      \"name\":
+        \"pulp-python\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"ipanova\",\n        \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"asmacdo\",\n          \"jcline\",\n          \"bowlofeggs\",\n
+        \         \"jortel\",\n          \"pcreech17\"\n        ],\n        \"owner\":
+        [\n          \"ipanova\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499785930\",\n
+        \     \"description\": \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n
+        \     \"id\": 16268,\n      \"milestones\": {},\n      \"name\": \"pulp-rpm\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n
+        \       \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785955\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
+        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
+        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
+        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
+        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"ipanova\",\n          \"asmacdo\",\n
+        \         \"jcline\",\n          \"jortel\",\n          \"bowlofeggs\"\n        ],\n
+        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785970\",\n      \"description\": \"The python-crane rpms\",\n      \"fullname\":
+        \"rpms/python-crane\",\n      \"id\": 16726,\n      \"milestones\": {},\n
+        \     \"name\": \"python-crane\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
+        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
+        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"dscott\",\n          \"jcline\",\n          \"jmatthews\",\n
+        \         \"dcallagh\"\n        ],\n        \"owner\": [\n          \"jlaska\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786003\",\n      \"description\":
+        \"The python-isodate rpms\",\n      \"fullname\": \"rpms/python-isodate\",\n
+        \     \"id\": 17130,\n      \"milestones\": {},\n      \"name\": \"python-isodate\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jlaska\",\n
+        \       \"name\": \"jlaska\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
+        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
+        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"apevec\",\n          \"jcline\",\n          \"cstratak\",\n
+        \         \"amcnabb\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786039\",\n      \"description\":
+        \"The python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\",\n
+        \     \"id\": 17575,\n      \"milestones\": {},\n      \"name\": \"python-pymongo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
+        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786046\",\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
+        \"rpms/python-rpdb\",\n      \"id\": 17711,\n      \"milestones\": {},\n      \"name\":
+        \"python-rpdb\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"williamjmorenor\",\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
+        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
+        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
+        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
+        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=5075979]
+      connection: [Keep-Alive]
+      content-length: ['33870']
+      content-type: [application/json]
+      date: ['Wed, 12 Jul 2017 18:32:10 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEf8rw.HN3HXGtUDMEOMswjCJgSP9zmkfo;
+          Expires=Sat, 12-Aug-2017 18:32:15 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&namespace=rpms
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        \"rpms\",\n    \"owner\": \"jcline\",\n    \"pattern\": null,\n    \"short\":
+        false,\n    \"tags\": [],\n    \"username\": null\n  },\n  \"projects\": [\n
+        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784743\",\n
+        \     \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
+        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
+        \     \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n
+        \     \"id\": 3271,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_sip\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
+        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
+        \     \"id\": 3272,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stringprep\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
+        \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
+        \     \"id\": 3273,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stun\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
+        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
+        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n
+        \     \"id\": 3278,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_yaml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785955\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
+        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
+        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
+        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
+        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
+        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
+        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
+        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
+        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
+        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"williamjmorenor\",\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
+        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
+        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
+        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
+        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 15\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=3211221]
+      connection: [Keep-Alive]
+      content-length: ['10797']
+      content-type: [application/json]
+      date: ['Wed, 12 Jul 2017 18:32:15 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEf8sw.4rqLneoYWzzl9eVwVFr151qq3fQ;
+          Expires=Sat, 12-Aug-2017 18:32:19 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"pattern\": null,\n    \"short\": false,\n
+        \   \"tags\": [],\n    \"username\": \"jcline\"\n  },\n  \"projects\": [\n
+        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"bowlofeggs\",\n
+        \         \"martinlanghoff\"\n        ],\n        \"owner\": [\n          \"peter\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784730\",\n      \"description\":
+        \"The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"id\":
+        3062,\n      \"milestones\": {},\n      \"name\": \"ejabberd\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"peter\",\n        \"name\":
+        \"peter\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784743\",\n      \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
+        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784744\",\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
+        \"rpms/erlang-esip\",\n      \"id\": 3230,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784744\",\n      \"description\": \"The erlang-ezlib rpms\",\n      \"fullname\":
+        \"rpms/erlang-ezlib\",\n      \"id\": 3233,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784745\",\n      \"description\": \"The erlang-fast_tls rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_tls\",\n      \"id\": 3234,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784745\",\n      \"description\":
+        \"The erlang-fast_xml rpms\",\n      \"fullname\": \"rpms/erlang-fast_xml\",\n
+        \     \"id\": 3235,\n      \"milestones\": {},\n      \"name\": \"erlang-fast_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784745\",\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_yaml\",\n      \"id\": 3236,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784745\",\n      \"description\":
+        \"The erlang-goldrush rpms\",\n      \"fullname\": \"rpms/erlang-goldrush\",\n
+        \     \"id\": 3241,\n      \"milestones\": {},\n      \"name\": \"erlang-goldrush\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784746\",\n      \"description\": \"The erlang-iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-iconv\",\n      \"id\": 3246,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784747\",\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\":
+        \"rpms/erlang-luerl\",\n      \"id\": 3255,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-luerl\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-oauth2 rpms\",\n      \"fullname\":
+        \"rpms/erlang-oauth2\",\n      \"id\": 3265,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_iconv\",\n      \"id\": 3266,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_mysql rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_mysql\",\n      \"id\": 3267,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_oauth2 rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_oauth2\",\n      \"id\": 3268,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pam\",\n      \"id\": 3269,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_pgsql rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pgsql\",\n      \"id\": 3270,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_sip\",\n      \"id\": 3271,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
+        \     \"description\": \"The erlang-p1_stringprep rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stringprep\",\n      \"id\": 3272,\n      \"milestones\":
+        {},\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n
+        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
+        \     \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stun\",\n      \"id\": 3273,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n
+        \     \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
+        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_utils rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\",\n
+        \     \"id\": 3275,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_utils\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
+        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_xmlrpc\",\n      \"id\": 3277,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_yaml\",\n      \"id\": 3278,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-p1_zlib rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_zlib\",\n      \"id\": 3279,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-proper rpms\",\n      \"fullname\": \"rpms/erlang-proper\",\n
+        \     \"id\": 3283,\n      \"milestones\": {},\n      \"name\": \"erlang-proper\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784751\",\n      \"description\": \"The erlang-stringprep rpms\",\n
+        \     \"fullname\": \"rpms/erlang-stringprep\",\n      \"id\": 3307,\n      \"milestones\":
+        {},\n      \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n
+        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
+        \     \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
+        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784752\",\n      \"description\":
+        \"The erlang-stun rpms\",\n      \"fullname\": \"rpms/erlang-stun\",\n      \"id\":
+        3308,\n      \"milestones\": {},\n      \"name\": \"erlang-stun\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
+        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"bowlofeggs\",\n          \"jortel\",\n          \"pcreech17\",\n
+        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785931\",\n      \"description\":
+        \"The pulp rpms\",\n      \"fullname\": \"rpms/pulp\",\n      \"id\": 16269,\n
+        \     \"milestones\": {},\n      \"name\": \"pulp\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
+        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"asmacdo\",\n
+        \         \"jcline\",\n          \"bowlofeggs\",\n          \"ipanova\",\n
+        \         \"jortel\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785929\",\n      \"description\":
+        \"The pulp-docker rpms\",\n      \"fullname\": \"rpms/pulp-docker\",\n      \"id\":
+        16264,\n      \"milestones\": {},\n      \"name\": \"pulp-docker\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
+        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"asmacdo\",\n
+        \         \"jcline\",\n          \"bowlofeggs\",\n          \"ipanova\",\n
+        \         \"jortel\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785929\",\n      \"description\":
+        \"The pulp-ostree rpms\",\n      \"fullname\": \"rpms/pulp-ostree\",\n      \"id\":
+        16265,\n      \"milestones\": {},\n      \"name\": \"pulp-ostree\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
+        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"asmacdo\",\n
+        \         \"jcline\",\n          \"bowlofeggs\",\n          \"ipanova\",\n
+        \         \"jortel\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785929\",\n      \"description\":
+        \"The pulp-puppet rpms\",\n      \"fullname\": \"rpms/pulp-puppet\",\n      \"id\":
+        16266,\n      \"milestones\": {},\n      \"name\": \"pulp-puppet\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
+        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"bowlofeggs\",\n          \"jortel\",\n          \"pcreech17\",\n
+        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785930\",\n      \"description\":
+        \"The pulp-python rpms\",\n      \"fullname\": \"rpms/pulp-python\",\n      \"id\":
+        16267,\n      \"milestones\": {},\n      \"name\": \"pulp-python\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
+        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"bowlofeggs\",\n          \"jortel\",\n          \"pcreech17\",\n
+        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785930\",\n      \"description\":
+        \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n      \"id\":
+        16268,\n      \"milestones\": {},\n      \"name\": \"pulp-rpm\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
+        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"owner\": [\n
+        \         \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499785955\",\n
+        \     \"description\": \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n
+        \     \"id\": 16563,\n      \"milestones\": {},\n      \"name\": \"python-args\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
+        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
+        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"jcline\",\n
+        \         \"bowlofeggs\",\n          \"ipanova\",\n          \"jortel\"\n
+        \       ],\n        \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785970\",\n      \"description\": \"The python-crane rpms\",\n      \"fullname\":
+        \"rpms/python-crane\",\n      \"id\": 16726,\n      \"milestones\": {},\n
+        \     \"name\": \"python-crane\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
+        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
+        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"dcallagh\",\n          \"dscott\",\n          \"jmatthews\",\n
+        \         \"jcline\"\n        ],\n        \"owner\": [\n          \"jlaska\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786003\",\n      \"description\":
+        \"The python-isodate rpms\",\n      \"fullname\": \"rpms/python-isodate\",\n
+        \     \"id\": 17130,\n      \"milestones\": {},\n      \"name\": \"python-isodate\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jlaska\",\n
+        \       \"name\": \"jlaska\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
+        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
+        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"apevec\",\n          \"cstratak\",\n          \"amcnabb\",\n
+        \         \"jcline\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786039\",\n      \"description\":
+        \"The python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\",\n
+        \     \"id\": 17575,\n      \"milestones\": {},\n      \"name\": \"python-pymongo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
+        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786046\",\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
+        \"rpms/python-rpdb\",\n      \"id\": 17711,\n      \"milestones\": {},\n      \"name\":
+        \"python-rpdb\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"williamjmorenor\",\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
+        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
+        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
+        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
+        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=5131740]
+      connection: [Keep-Alive]
+      content-length: ['33868']
+      content-type: [application/json]
+      date: ['Wed, 12 Jul 2017 18:50:48 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEgBDQ.9gRx7NbfTvCV3UH3Hx6H6N9nyFU;
+          Expires=Sat, 12-Aug-2017 18:50:53 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": \"jcline\",\n    \"pattern\": null,\n    \"short\":
+        false,\n    \"tags\": [],\n    \"username\": null\n  },\n  \"projects\": [\n
+        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784743\",\n
+        \     \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
+        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
+        \     \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n
+        \     \"id\": 3271,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_sip\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
+        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
+        \     \"id\": 3272,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stringprep\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
+        \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
+        \     \"id\": 3273,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stun\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
+        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
+        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n
+        \     \"id\": 3278,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_yaml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785955\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
+        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
+        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
+        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
+        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
+        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
+        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
+        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
+        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
+        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
+        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
+        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
+        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
+        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 15\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=855936]
+      connection: [Keep-Alive]
+      content-length: ['10795']
+      content-type: [application/json]
+      date: ['Wed, 12 Jul 2017 18:50:54 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEgBDg.WLeuXtUpDfqTUAPsxkJ16NMxyuQ;
+          Expires=Sat, 12-Aug-2017 18:50:54 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?page=1&owner=jcline
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": \"jcline\",\n    \"page\": 1,\n    \"pattern\": null,\n
+        \   \"per_page\": 20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\":
+        null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&page=1\",\n
+        \   \"next\": null,\n    \"page\": 1,\n    \"pages\": 1,\n    \"per_page\":
+        20,\n    \"prev\": null\n  },\n  \"projects\": [\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069208\",\n      \"description\":
+        \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
+        \     \"id\": 3207,\n      \"milestones\": {},\n      \"name\": \"erlang-cache_tab\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n      \"description\":
+        \"The erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n
+        \     \"id\": 3271,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_sip\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n      \"description\":
+        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
+        \     \"id\": 3272,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stringprep\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n      \"description\":
+        \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
+        \     \"id\": 3273,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stun\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
+        \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
+        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
+        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
+        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
+        \"The erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n
+        \     \"id\": 3278,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_yaml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070924\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
+        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
+        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070941\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
+        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
+        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070977\",\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070991\",\n      \"description\":
+        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
+        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500071033\",\n      \"description\":
+        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
+        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500071049\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
+        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500071066\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
+        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500071080\",\n      \"description\":
+        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
+        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
+        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 15\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=1277857]
+      connection: [Keep-Alive]
+      content-length: ['11146']
+      content-type: [application/json]
+      date: ['Thu, 20 Jul 2017 19:00:09 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPOg.BViCt_D7YnUm_cG_l_HuvFbr5CA;
+          Expires=Sun, 20-Aug-2017 19:00:10 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&page=1
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"page\": 1,\n    \"pattern\": null,\n    \"per_page\":
+        20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
+        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
+        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=2\",\n
+        \   \"page\": 1,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
+        null\n  },\n  \"projects\": [\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\",\n
+        \         \"jcline\",\n          \"martinlanghoff\"\n        ],\n        \"owner\":
+        [\n          \"peter\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500069194\",\n
+        \     \"description\": \"The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n
+        \     \"id\": 3062,\n      \"milestones\": {},\n      \"name\": \"ejabberd\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"peter\",\n
+        \       \"name\": \"peter\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069208\",\n      \"description\":
+        \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
+        \     \"id\": 3207,\n      \"milestones\": {},\n      \"name\": \"erlang-cache_tab\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069209\",\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
+        \"rpms/erlang-esip\",\n      \"id\": 3230,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069209\",\n      \"description\": \"The erlang-ezlib rpms\",\n      \"fullname\":
+        \"rpms/erlang-ezlib\",\n      \"id\": 3233,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069209\",\n      \"description\": \"The erlang-fast_tls rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_tls\",\n      \"id\": 3234,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069210\",\n      \"description\":
+        \"The erlang-fast_xml rpms\",\n      \"fullname\": \"rpms/erlang-fast_xml\",\n
+        \     \"id\": 3235,\n      \"milestones\": {},\n      \"name\": \"erlang-fast_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069210\",\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_yaml\",\n      \"id\": 3236,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069210\",\n      \"description\":
+        \"The erlang-goldrush rpms\",\n      \"fullname\": \"rpms/erlang-goldrush\",\n
+        \     \"id\": 3241,\n      \"milestones\": {},\n      \"name\": \"erlang-goldrush\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069211\",\n      \"description\": \"The erlang-iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-iconv\",\n      \"id\": 3246,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069212\",\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\":
+        \"rpms/erlang-luerl\",\n      \"id\": 3255,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-luerl\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069212\",\n      \"description\": \"The erlang-oauth2 rpms\",\n      \"fullname\":
+        \"rpms/erlang-oauth2\",\n      \"id\": 3265,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_iconv\",\n      \"id\": 3266,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_mysql rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_mysql\",\n      \"id\": 3267,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_oauth2 rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_oauth2\",\n      \"id\": 3268,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pam\",\n      \"id\": 3269,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_pgsql rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pgsql\",\n      \"id\": 3270,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_sip\",\n      \"id\": 3271,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n
+        \     \"description\": \"The erlang-p1_stringprep rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stringprep\",\n      \"id\": 3272,\n      \"milestones\":
+        {},\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n
+        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
+        \     \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stun\",\n      \"id\": 3273,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n
+        \     \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
+        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\":
+        46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=1947390]
+      connection: [Keep-Alive]
+      content-length: ['15136']
+      content-type: [application/json]
+      date: ['Thu, 20 Jul 2017 19:00:10 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPPA.lslyRp86RVwK10YqJWA7khce5b4;
+          Expires=Sun, 20-Aug-2017 19:00:12 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=2
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"page\": 2,\n    \"pattern\": null,\n    \"per_page\":
+        20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
+        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
+        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
+        \   \"page\": 2,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
+        \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\"\n
+        \ },\n  \"projects\": [\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069214\",\n      \"description\": \"The erlang-p1_utils rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_utils\",\n      \"id\": 3275,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_utils\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069214\",\n      \"description\": \"The erlang-p1_xml rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_xml\",\n      \"id\": 3276,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_xml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069214\",\n      \"description\": \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_xmlrpc\",\n      \"id\": 3277,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069214\",\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_yaml\",\n      \"id\": 3278,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069214\",\n      \"description\": \"The erlang-p1_zlib rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_zlib\",\n      \"id\": 3279,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069214\",\n      \"description\": \"The erlang-proper rpms\",\n      \"fullname\":
+        \"rpms/erlang-proper\",\n      \"id\": 3283,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-proper\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069218\",\n      \"description\": \"The erlang-stringprep rpms\",\n
+        \     \"fullname\": \"rpms/erlang-stringprep\",\n      \"id\": 3307,\n      \"milestones\":
+        {},\n      \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n
+        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
+        \     \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
+        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069218\",\n      \"description\": \"The erlang-stun rpms\",\n      \"fullname\":
+        \"rpms/erlang-stun\",\n      \"id\": 3308,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-stun\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"bowlofeggs\",\n
+        \         \"jortel\",\n          \"jcline\",\n          \"pcreech17\"\n        ],\n
+        \       \"owner\": [\n          \"ipanova\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070895\",\n      \"description\": \"The pulp rpms\",\n      \"fullname\":
+        \"rpms/pulp\",\n      \"id\": 16269,\n      \"milestones\": {},\n      \"name\":
+        \"pulp\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n
+        \       \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"asmacdo\",\n          \"ipanova\",\n          \"jortel\",\n
+        \         \"jcline\",\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"pcreech17\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070892\",\n      \"description\": \"The pulp-docker rpms\",\n      \"fullname\":
+        \"rpms/pulp-docker\",\n      \"id\": 16264,\n      \"milestones\": {},\n      \"name\":
+        \"pulp-docker\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"ipanova\",\n
+        \         \"jortel\",\n          \"jcline\",\n          \"bowlofeggs\"\n        ],\n
+        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070893\",\n      \"description\": \"The pulp-ostree rpms\",\n      \"fullname\":
+        \"rpms/pulp-ostree\",\n      \"id\": 16265,\n      \"milestones\": {},\n      \"name\":
+        \"pulp-ostree\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"ipanova\",\n
+        \         \"jortel\",\n          \"jcline\",\n          \"bowlofeggs\"\n        ],\n
+        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070893\",\n      \"description\": \"The pulp-puppet rpms\",\n      \"fullname\":
+        \"rpms/pulp-puppet\",\n      \"id\": 16266,\n      \"milestones\": {},\n      \"name\":
+        \"pulp-puppet\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"bowlofeggs\",\n
+        \         \"jortel\",\n          \"jcline\",\n          \"pcreech17\"\n        ],\n
+        \       \"owner\": [\n          \"ipanova\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070894\",\n      \"description\": \"The pulp-python rpms\",\n      \"fullname\":
+        \"rpms/pulp-python\",\n      \"id\": 16267,\n      \"milestones\": {},\n      \"name\":
+        \"pulp-python\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"ipanova\",\n        \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"asmacdo\",\n          \"bowlofeggs\",\n          \"jortel\",\n
+        \         \"jcline\",\n          \"pcreech17\"\n        ],\n        \"owner\":
+        [\n          \"ipanova\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500070894\",\n
+        \     \"description\": \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n
+        \     \"id\": 16268,\n      \"milestones\": {},\n      \"name\": \"pulp-rpm\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n
+        \       \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070924\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
+        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
+        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070941\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
+        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
+        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"ipanova\",\n
+        \         \"jortel\",\n          \"jcline\",\n          \"bowlofeggs\"\n        ],\n
+        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070947\",\n      \"description\": \"The python-crane rpms\",\n      \"fullname\":
+        \"rpms/python-crane\",\n      \"id\": 16726,\n      \"milestones\": {},\n
+        \     \"name\": \"python-crane\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070977\",\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070991\",\n      \"description\":
+        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
+        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"dcallagh\",\n          \"jmatthews\",\n          \"jcline\",\n
+        \         \"dscott\"\n        ],\n        \"owner\": [\n          \"jlaska\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070992\",\n      \"description\":
+        \"The python-isodate rpms\",\n      \"fullname\": \"rpms/python-isodate\",\n
+        \     \"id\": 17130,\n      \"milestones\": {},\n      \"name\": \"python-isodate\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jlaska\",\n
+        \       \"name\": \"jlaska\"\n      }\n    }\n  ],\n  \"total_projects\":
+        46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=1876365]
+      connection: [Keep-Alive]
+      content-length: ['15550']
+      content-type: [application/json]
+      date: ['Thu, 20 Jul 2017 19:00:13 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPPw.q-_GE6s8XEf21yBtLBoEmdNeGYo;
+          Expires=Sun, 20-Aug-2017 19:00:15 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"page\": 3,\n    \"pattern\": null,\n    \"per_page\":
+        20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
+        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
+        \   \"next\": null,\n    \"page\": 3,\n    \"pages\": 3,\n    \"per_page\":
+        20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=2\"\n
+        \ },\n  \"projects\": [\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500071033\",\n      \"description\": \"The python-pkginfo rpms\",\n      \"fullname\":
+        \"rpms/python-pkginfo\",\n      \"id\": 17492,\n      \"milestones\": {},\n
+        \     \"name\": \"python-pkginfo\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"cstratak\",\n
+        \         \"apevec\",\n          \"amcnabb\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500071041\",\n      \"description\": \"The python-pymongo rpms\",\n      \"fullname\":
+        \"rpms/python-pymongo\",\n      \"id\": 17575,\n      \"milestones\": {},\n
+        \     \"name\": \"python-pymongo\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"owner\": [\n
+        \         \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500071049\",\n
+        \     \"description\": \"The python-releases rpms\",\n      \"fullname\":
+        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500071056\",\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
+        \"rpms/python-rpdb\",\n      \"id\": 17711,\n      \"milestones\": {},\n      \"name\":
+        \"python-rpdb\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500071066\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
+        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500071080\",\n      \"description\":
+        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
+        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
+        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=1349584]
+      connection: [Keep-Alive]
+      content-length: ['5015']
+      content-type: [application/json]
+      date: ['Thu, 20 Jul 2017 19:00:16 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPQQ.TTbxsWjtehnSojTNgzkyauID0sQ;
+          Expires=Sun, 20-Aug-2017 19:00:17 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=true&username=jcline&page=1
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"page\": 1,\n    \"pattern\": null,\n    \"per_page\":
+        20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
+        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
+        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=2\",\n
+        \   \"page\": 1,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
+        null\n  },\n  \"projects\": [\n    {\n      \"description\": \"The ejabberd
+        rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"name\": \"ejabberd\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
+        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
+        \"rpms/erlang-esip\",\n      \"name\": \"erlang-esip\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-ezlib rpms\",\n
+        \     \"fullname\": \"rpms/erlang-ezlib\",\n      \"name\": \"erlang-ezlib\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-fast_tls rpms\",\n      \"fullname\": \"rpms/erlang-fast_tls\",\n      \"name\":
+        \"erlang-fast_tls\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The erlang-fast_xml rpms\",\n      \"fullname\": \"rpms/erlang-fast_xml\",\n
+        \     \"name\": \"erlang-fast_xml\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_yaml\",\n      \"name\": \"erlang-fast_yaml\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-goldrush rpms\",\n
+        \     \"fullname\": \"rpms/erlang-goldrush\",\n      \"name\": \"erlang-goldrush\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-iconv rpms\",\n      \"fullname\": \"rpms/erlang-iconv\",\n      \"name\":
+        \"erlang-iconv\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The erlang-luerl rpms\",\n      \"fullname\": \"rpms/erlang-luerl\",\n      \"name\":
+        \"erlang-luerl\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The erlang-oauth2 rpms\",\n      \"fullname\": \"rpms/erlang-oauth2\",\n
+        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_iconv\",\n      \"name\": \"erlang-p1_iconv\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_mysql rpms\",\n
+        \     \"fullname\": \"rpms/erlang-p1_mysql\",\n      \"name\": \"erlang-p1_mysql\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-p1_oauth2 rpms\",\n      \"fullname\": \"rpms/erlang-p1_oauth2\",\n
+        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pam\",\n      \"name\": \"erlang-p1_pam\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_pgsql rpms\",\n
+        \     \"fullname\": \"rpms/erlang-p1_pgsql\",\n      \"name\": \"erlang-p1_pgsql\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n      \"name\":
+        \"erlang-p1_sip\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
+        \     \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\"\n
+        \   },\n    {\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stun\",\n      \"name\": \"erlang-p1_stun\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_tls rpms\",\n
+        \     \"fullname\": \"rpms/erlang-p1_tls\",\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=2775561]
+      connection: [Keep-Alive]
+      content-length: ['3879']
+      content-type: [application/json]
+      date: ['Fri, 21 Jul 2017 16:46:46 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBeA.60ygyslc95-xclCmjA5nTO64-w8;
+          Expires=Mon, 21-Aug-2017 16:46:48 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=2
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"page\": 2,\n    \"pattern\": null,\n    \"per_page\":
+        20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
+        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
+        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
+        \   \"page\": 2,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
+        \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\"\n
+        \ },\n  \"projects\": [\n    {\n      \"description\": \"The erlang-p1_utils
+        rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\",\n      \"name\": \"erlang-p1_utils\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n      \"name\":
+        \"erlang-p1_xml\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\": \"rpms/erlang-p1_xmlrpc\",\n
+        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_yaml\",\n      \"name\": \"erlang-p1_yaml\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_zlib rpms\",\n
+        \     \"fullname\": \"rpms/erlang-p1_zlib\",\n      \"name\": \"erlang-p1_zlib\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-proper rpms\",\n      \"fullname\": \"rpms/erlang-proper\",\n      \"name\":
+        \"erlang-proper\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The erlang-stringprep rpms\",\n      \"fullname\": \"rpms/erlang-stringprep\",\n
+        \     \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-stun rpms\",\n      \"fullname\":
+        \"rpms/erlang-stun\",\n      \"name\": \"erlang-stun\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The pulp rpms\",\n      \"fullname\":
+        \"rpms/pulp\",\n      \"name\": \"pulp\",\n      \"namespace\": \"rpms\"\n
+        \   },\n    {\n      \"description\": \"The pulp-docker rpms\",\n      \"fullname\":
+        \"rpms/pulp-docker\",\n      \"name\": \"pulp-docker\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The pulp-ostree rpms\",\n
+        \     \"fullname\": \"rpms/pulp-ostree\",\n      \"name\": \"pulp-ostree\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        pulp-puppet rpms\",\n      \"fullname\": \"rpms/pulp-puppet\",\n      \"name\":
+        \"pulp-puppet\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The pulp-python rpms\",\n      \"fullname\": \"rpms/pulp-python\",\n      \"name\":
+        \"pulp-python\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n      \"name\":
+        \"pulp-rpm\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n      \"name\":
+        \"python-args\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-clint rpms\",\n      \"fullname\": \"rpms/python-clint\",\n      \"name\":
+        \"python-clint\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-crane rpms\",\n      \"fullname\": \"rpms/python-crane\",\n      \"name\":
+        \"python-crane\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"name\": \"python-flower\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The python-invocations rpms\",\n      \"fullname\":
+        \"rpms/python-invocations\",\n      \"name\": \"python-invocations\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The python-isodate rpms\",\n
+        \     \"fullname\": \"rpms/python-isodate\",\n      \"name\": \"python-isodate\",\n
+        \     \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=2567971]
+      connection: [Keep-Alive]
+      content-length: ['3888']
+      content-type: [application/json]
+      date: ['Fri, 21 Jul 2017 16:46:49 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBew.FAwnmZGNRXGORs72JyZeFEXrvCM;
+          Expires=Mon, 21-Aug-2017 16:46:51 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"page\": 3,\n    \"pattern\": null,\n    \"per_page\":
+        20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
+        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
+        \   \"next\": null,\n    \"page\": 3,\n    \"pages\": 3,\n    \"per_page\":
+        20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=2\"\n
+        \ },\n  \"projects\": [\n    {\n      \"description\": \"The python-pkginfo
+        rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\",\n      \"name\":
+        \"python-pymongo\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-releases rpms\",\n      \"fullname\": \"rpms/python-releases\",\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
+        \"rpms/python-rpdb\",\n      \"name\": \"python-rpdb\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"name\":
+        \"python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The python-twine rpms\",\n      \"fullname\":
+        \"rpms/python-twine\",\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\"\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=909745]
+      connection: [Keep-Alive]
+      content-length: ['1672']
+      content-type: [application/json]
+      date: ['Fri, 21 Jul 2017 16:46:52 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBfQ.GREIBSForxrNntCAXfGY8uhv2BQ;
+          Expires=Mon, 21-Aug-2017 16:46:53 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=true&owner=jcline&page=1
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": \"jcline\",\n    \"page\": 1,\n    \"pattern\": null,\n
+        \   \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\":
+        null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=true&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=true&page=1\",\n
+        \   \"next\": null,\n    \"page\": 1,\n    \"pages\": 1,\n    \"per_page\":
+        20,\n    \"prev\": null\n  },\n  \"projects\": [\n    {\n      \"description\":
+        \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
+        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_sip\",\n      \"name\": \"erlang-p1_sip\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_stringprep
+        rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n      \"name\":
+        \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\"\n    },\n    {\n
+        \     \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
+        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_tls\",\n      \"name\": \"erlang-p1_tls\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_xml rpms\",\n
+        \     \"fullname\": \"rpms/erlang-p1_xml\",\n      \"name\": \"erlang-p1_xml\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n      \"name\":
+        \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n      \"name\":
+        \"python-args\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-clint rpms\",\n      \"fullname\": \"rpms/python-clint\",\n      \"name\":
+        \"python-clint\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"name\": \"python-flower\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The python-invocations rpms\",\n      \"fullname\":
+        \"rpms/python-invocations\",\n      \"name\": \"python-invocations\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The python-pkginfo rpms\",\n
+        \     \"fullname\": \"rpms/python-pkginfo\",\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        python-releases rpms\",\n      \"fullname\": \"rpms/python-releases\",\n      \"name\":
+        \"python-releases\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-sphinxcontrib-fulltoc rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n
+        \     \"name\": \"python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\"\n
+        \   },\n    {\n      \"description\": \"The python-twine rpms\",\n      \"fullname\":
+        \"rpms/python-twine\",\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\"\n    }\n  ],\n  \"total_projects\": 15\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=2757199]
+      connection: [Keep-Alive]
+      content-length: ['3025']
+      content-type: [application/json]
+      date: ['Fri, 21 Jul 2017 16:46:53 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBgA.N0x0EHE9TYpCdWuSZvgjty0mxLU;
+          Expires=Mon, 21-Aug-2017 16:46:56 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_bad_response
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_bad_response
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.2]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=True&page=1&username=thisisnotausername123
+  response:
+    body: {string: !!python/unicode "{\n  \"error\": \"No projects found\",\n  \"\
+        error_code\": \"ENOPROJECTS\"\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=255695]
+      connection: [Keep-Alive]
+      content-length: ['65']
+      content-type: [application/json]
+      date: ['Mon, 31 Jul 2017 13:23:22 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DGDAyw.AIfh3SfRoN9TICzszmaw-wr4ttg;
+          Expires=Thu, 31-Aug-2017 13:23:23 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 404, message: NOT FOUND}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_comaintained
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_comaintained
@@ -5,492 +5,79 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
+      User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&namespace=rpms
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=True&page=1&username=jcline
   response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        \"rpms\",\n    \"owner\": null,\n    \"pattern\": null,\n    \"short\": false,\n
-        \   \"tags\": [],\n    \"username\": \"jcline\"\n  },\n  \"projects\": [\n
-        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"jcline\",\n
-        \         \"martinlanghoff\"\n        ],\n        \"owner\": [\n          \"peter\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784730\",\n      \"description\":
-        \"The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"id\":
-        3062,\n      \"milestones\": {},\n      \"name\": \"ejabberd\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"peter\",\n        \"name\":
-        \"peter\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784743\",\n      \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
-        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784744\",\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
-        \"rpms/erlang-esip\",\n      \"id\": 3230,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784744\",\n      \"description\": \"The erlang-ezlib rpms\",\n      \"fullname\":
-        \"rpms/erlang-ezlib\",\n      \"id\": 3233,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784745\",\n      \"description\": \"The erlang-fast_tls rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_tls\",\n      \"id\": 3234,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784745\",\n      \"description\": \"The erlang-fast_xml rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_xml\",\n      \"id\": 3235,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_xml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784745\",\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_yaml\",\n      \"id\": 3236,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784745\",\n      \"description\": \"The erlang-goldrush rpms\",\n      \"fullname\":
-        \"rpms/erlang-goldrush\",\n      \"id\": 3241,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-goldrush\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784746\",\n      \"description\": \"The erlang-iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-iconv\",\n      \"id\": 3246,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784747\",\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\":
-        \"rpms/erlang-luerl\",\n      \"id\": 3255,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-luerl\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-oauth2 rpms\",\n      \"fullname\":
-        \"rpms/erlang-oauth2\",\n      \"id\": 3265,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_iconv\",\n      \"id\": 3266,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_mysql rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_mysql\",\n      \"id\": 3267,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_oauth2 rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_oauth2\",\n      \"id\": 3268,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pam\",\n      \"id\": 3269,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_pgsql rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pgsql\",\n      \"id\": 3270,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_sip\",\n      \"id\": 3271,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
-        \     \"description\": \"The erlang-p1_stringprep rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stringprep\",\n      \"id\": 3272,\n      \"milestones\":
-        {},\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n
-        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
-        \     \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stun\",\n      \"id\": 3273,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n
-        \     \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
-        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_utils rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\",\n
-        \     \"id\": 3275,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_utils\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
-        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"peter\",\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_xmlrpc\",\n      \"id\": 3277,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_yaml\",\n      \"id\": 3278,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-p1_zlib rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_zlib\",\n      \"id\": 3279,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-proper rpms\",\n      \"fullname\":
-        \"rpms/erlang-proper\",\n      \"id\": 3283,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-proper\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784751\",\n      \"description\": \"The erlang-stringprep rpms\",\n
-        \     \"fullname\": \"rpms/erlang-stringprep\",\n      \"id\": 3307,\n      \"milestones\":
-        {},\n      \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n
-        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
-        \     \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
-        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
-        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784752\",\n      \"description\": \"The erlang-stun rpms\",\n      \"fullname\":
-        \"rpms/erlang-stun\",\n      \"id\": 3308,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-stun\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"pcreech17\",\n
-        \         \"asmacdo\",\n          \"jortel\",\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"ipanova\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785931\",\n      \"description\": \"The pulp rpms\",\n      \"fullname\":
-        \"rpms/pulp\",\n      \"id\": 16269,\n      \"milestones\": {},\n      \"name\":
-        \"pulp\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n
-        \       \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"ipanova\",\n          \"bowlofeggs\",\n          \"asmacdo\",\n
-        \         \"jcline\",\n          \"jortel\"\n        ],\n        \"owner\":
-        [\n          \"pcreech17\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785929\",\n      \"description\": \"The pulp-docker rpms\",\n      \"fullname\":
-        \"rpms/pulp-docker\",\n      \"id\": 16264,\n      \"milestones\": {},\n      \"name\":
-        \"pulp-docker\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"ipanova\",\n          \"bowlofeggs\",\n
-        \         \"asmacdo\",\n          \"jcline\",\n          \"jortel\"\n        ],\n
-        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785929\",\n      \"description\": \"The pulp-ostree rpms\",\n      \"fullname\":
-        \"rpms/pulp-ostree\",\n      \"id\": 16265,\n      \"milestones\": {},\n      \"name\":
-        \"pulp-ostree\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"ipanova\",\n          \"bowlofeggs\",\n
-        \         \"asmacdo\",\n          \"jcline\",\n          \"jortel\"\n        ],\n
-        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785929\",\n      \"description\": \"The pulp-puppet rpms\",\n      \"fullname\":
-        \"rpms/pulp-puppet\",\n      \"id\": 16266,\n      \"milestones\": {},\n      \"name\":
-        \"pulp-puppet\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"pcreech17\",\n
-        \         \"asmacdo\",\n          \"jortel\",\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"ipanova\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785930\",\n      \"description\": \"The pulp-python rpms\",\n      \"fullname\":
-        \"rpms/pulp-python\",\n      \"id\": 16267,\n      \"milestones\": {},\n      \"name\":
-        \"pulp-python\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"ipanova\",\n        \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"pcreech17\",\n          \"asmacdo\",\n
-        \         \"jortel\",\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"ipanova\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499785930\",\n
-        \     \"description\": \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n
-        \     \"id\": 16268,\n      \"milestones\": {},\n      \"name\": \"pulp-rpm\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n
-        \       \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785955\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
-        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
-        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
-        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
-        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"ipanova\",\n          \"bowlofeggs\",\n
-        \         \"asmacdo\",\n          \"jcline\",\n          \"jortel\"\n        ],\n
-        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785970\",\n      \"description\": \"The python-crane rpms\",\n      \"fullname\":
-        \"rpms/python-crane\",\n      \"id\": 16726,\n      \"milestones\": {},\n
-        \     \"name\": \"python-crane\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
-        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
-        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"dcallagh\",\n          \"jcline\",\n          \"dscott\",\n
-        \         \"jmatthews\"\n        ],\n        \"owner\": [\n          \"jlaska\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786003\",\n      \"description\":
-        \"The python-isodate rpms\",\n      \"fullname\": \"rpms/python-isodate\",\n
-        \     \"id\": 17130,\n      \"milestones\": {},\n      \"name\": \"python-isodate\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jlaska\",\n
-        \       \"name\": \"jlaska\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
-        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
-        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"amcnabb\",\n          \"cstratak\",\n          \"jcline\",\n
-        \         \"apevec\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786039\",\n      \"description\":
-        \"The python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\",\n
-        \     \"id\": 17575,\n      \"milestones\": {},\n      \"name\": \"python-pymongo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
-        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786046\",\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
-        \"rpms/python-rpdb\",\n      \"id\": 17711,\n      \"milestones\": {},\n      \"name\":
-        \"python-rpdb\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
-        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
-        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
-        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
-        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
+        namespace\": null,\n    \"owner\": null,\n    \"page\": 1,\n    \"pattern\"\
+        : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
+        \    \"username\": \"jcline\"\n  },\n  \"pagination\": {\n    \"first\": \"\
+        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
+        ,\n    \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=2\"\
+        ,\n    \"page\": 1,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\"\
+        : null\n  },\n  \"projects\": [\n    {\n      \"description\": \"The bodhi\
+        \ rpms\",\n      \"fullname\": \"rpms/bodhi\",\n      \"name\": \"bodhi\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"name\"\
+        : \"ejabberd\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\"\
+        : \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\"\
+        ,\n      \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\"\n\
+        \    },\n    {\n      \"description\": \"The erlang-esip rpms\",\n      \"\
+        fullname\": \"rpms/erlang-esip\",\n      \"name\": \"erlang-esip\",\n    \
+        \  \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-ezlib\
+        \ rpms\",\n      \"fullname\": \"rpms/erlang-ezlib\",\n      \"name\": \"\
+        erlang-ezlib\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\"\
+        : \"The erlang-fast_tls rpms\",\n      \"fullname\": \"rpms/erlang-fast_tls\"\
+        ,\n      \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\"\n \
+        \   },\n    {\n      \"description\": \"The erlang-fast_xml rpms\",\n    \
+        \  \"fullname\": \"rpms/erlang-fast_xml\",\n      \"name\": \"erlang-fast_xml\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-fast_yaml rpms\",\n      \"fullname\": \"rpms/erlang-fast_yaml\"\
+        ,\n      \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\"\n\
+        \    },\n    {\n      \"description\": \"The erlang-goldrush rpms\",\n   \
+        \   \"fullname\": \"rpms/erlang-goldrush\",\n      \"name\": \"erlang-goldrush\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-iconv rpms\",\n      \"fullname\": \"rpms/erlang-iconv\",\n   \
+        \   \"name\": \"erlang-iconv\",\n      \"namespace\": \"rpms\"\n    },\n \
+        \   {\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\"\
+        : \"rpms/erlang-luerl\",\n      \"name\": \"erlang-luerl\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-oauth2 rpms\"\
+        ,\n      \"fullname\": \"rpms/erlang-oauth2\",\n      \"name\": \"erlang-oauth2\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-p1_iconv rpms\",\n      \"fullname\": \"rpms/erlang-p1_iconv\"\
+        ,\n      \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\"\n \
+        \   },\n    {\n      \"description\": \"The erlang-p1_mysql rpms\",\n    \
+        \  \"fullname\": \"rpms/erlang-p1_mysql\",\n      \"name\": \"erlang-p1_mysql\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-p1_oauth2 rpms\",\n      \"fullname\": \"rpms/erlang-p1_oauth2\"\
+        ,\n      \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\"\n\
+        \    },\n    {\n      \"description\": \"The erlang-p1_pam rpms\",\n     \
+        \ \"fullname\": \"rpms/erlang-p1_pam\",\n      \"name\": \"erlang-p1_pam\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-p1_pgsql rpms\",\n      \"fullname\": \"rpms/erlang-p1_pgsql\"\
+        ,\n      \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\"\n \
+        \   },\n    {\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"\
+        fullname\": \"rpms/erlang-p1_sip\",\n      \"name\": \"erlang-p1_sip\",\n\
+        \      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The\
+        \ erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\"\
+        ,\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\"\
+        \n    },\n    {\n      \"description\": \"The erlang-p1_stun rpms\",\n   \
+        \   \"fullname\": \"rpms/erlang-p1_stun\",\n      \"name\": \"erlang-p1_stun\"\
+        ,\n      \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 49\n}"}
     headers:
       appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=2505099]
+      apptime: [D=1027017]
       connection: [Keep-Alive]
-      content-length: ['33870']
+      content-length: ['3855']
       content-type: [application/json]
-      date: ['Wed, 12 Jul 2017 18:32:20 GMT']
+      date: ['Mon, 31 Jul 2017 13:23:23 GMT']
       keep-alive: ['timeout=15, max=500']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
           mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEf8tg.83f6H0bsMNV0lvw6WrsF9nbh-rs;
-          Expires=Sat, 12-Aug-2017 18:32:22 GMT; Secure; HttpOnly; Path=/pagure']
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DGDAzA.Aekf2v_pGMiBYzkYWONwKa1iTQ0;
+          Expires=Thu, 31-Aug-2017 13:23:24 GMT; Secure; HttpOnly; Path=/pagure']
       strict-transport-security: [max-age=15768000; includeSubDomains; preload]
     status: {code: 200, message: OK}
 - request:
@@ -499,496 +86,80 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
+      User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=2
   response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"pattern\": null,\n    \"short\": false,\n
-        \   \"tags\": [],\n    \"username\": \"jcline\"\n  },\n  \"projects\": [\n
-        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"bowlofeggs\",\n
-        \         \"martinlanghoff\"\n        ],\n        \"owner\": [\n          \"peter\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784730\",\n      \"description\":
-        \"The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"id\":
-        3062,\n      \"milestones\": {},\n      \"name\": \"ejabberd\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"peter\",\n        \"name\":
-        \"peter\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784743\",\n      \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
-        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784744\",\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
-        \"rpms/erlang-esip\",\n      \"id\": 3230,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784744\",\n      \"description\": \"The erlang-ezlib rpms\",\n      \"fullname\":
-        \"rpms/erlang-ezlib\",\n      \"id\": 3233,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784745\",\n      \"description\": \"The erlang-fast_tls rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_tls\",\n      \"id\": 3234,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784745\",\n      \"description\":
-        \"The erlang-fast_xml rpms\",\n      \"fullname\": \"rpms/erlang-fast_xml\",\n
-        \     \"id\": 3235,\n      \"milestones\": {},\n      \"name\": \"erlang-fast_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784745\",\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_yaml\",\n      \"id\": 3236,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784745\",\n      \"description\":
-        \"The erlang-goldrush rpms\",\n      \"fullname\": \"rpms/erlang-goldrush\",\n
-        \     \"id\": 3241,\n      \"milestones\": {},\n      \"name\": \"erlang-goldrush\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784746\",\n      \"description\": \"The erlang-iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-iconv\",\n      \"id\": 3246,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784747\",\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\":
-        \"rpms/erlang-luerl\",\n      \"id\": 3255,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-luerl\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-oauth2 rpms\",\n      \"fullname\":
-        \"rpms/erlang-oauth2\",\n      \"id\": 3265,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_iconv\",\n      \"id\": 3266,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_mysql rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_mysql\",\n      \"id\": 3267,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_oauth2 rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_oauth2\",\n      \"id\": 3268,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pam\",\n      \"id\": 3269,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_pgsql rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pgsql\",\n      \"id\": 3270,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_sip\",\n      \"id\": 3271,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
-        \     \"description\": \"The erlang-p1_stringprep rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stringprep\",\n      \"id\": 3272,\n      \"milestones\":
-        {},\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n
-        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
-        \     \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784748\",\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stun\",\n      \"id\": 3273,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n
-        \     \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
-        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_utils rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\",\n
-        \     \"id\": 3275,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_utils\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
-        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_xmlrpc\",\n      \"id\": 3277,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_yaml\",\n      \"id\": 3278,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784749\",\n      \"description\": \"The erlang-p1_zlib rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_zlib\",\n      \"id\": 3279,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-proper rpms\",\n      \"fullname\": \"rpms/erlang-proper\",\n
-        \     \"id\": 3283,\n      \"milestones\": {},\n      \"name\": \"erlang-proper\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499784751\",\n      \"description\": \"The erlang-stringprep rpms\",\n
-        \     \"fullname\": \"rpms/erlang-stringprep\",\n      \"id\": 3307,\n      \"milestones\":
-        {},\n      \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n
-        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
-        \     \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
-        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784752\",\n      \"description\":
-        \"The erlang-stun rpms\",\n      \"fullname\": \"rpms/erlang-stun\",\n      \"id\":
-        3308,\n      \"milestones\": {},\n      \"name\": \"erlang-stun\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
-        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\",\n
-        \         \"jortel\",\n          \"bowlofeggs\",\n          \"jcline\",\n
-        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785931\",\n      \"description\":
-        \"The pulp rpms\",\n      \"fullname\": \"rpms/pulp\",\n      \"id\": 16269,\n
-        \     \"milestones\": {},\n      \"name\": \"pulp\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
-        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jortel\",\n
-        \         \"ipanova\",\n          \"bowlofeggs\",\n          \"jcline\",\n
-        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785929\",\n      \"description\":
-        \"The pulp-docker rpms\",\n      \"fullname\": \"rpms/pulp-docker\",\n      \"id\":
-        16264,\n      \"milestones\": {},\n      \"name\": \"pulp-docker\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
-        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jortel\",\n
-        \         \"ipanova\",\n          \"bowlofeggs\",\n          \"jcline\",\n
-        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785929\",\n      \"description\":
-        \"The pulp-ostree rpms\",\n      \"fullname\": \"rpms/pulp-ostree\",\n      \"id\":
-        16265,\n      \"milestones\": {},\n      \"name\": \"pulp-ostree\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
-        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jortel\",\n
-        \         \"ipanova\",\n          \"bowlofeggs\",\n          \"jcline\",\n
-        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785929\",\n      \"description\":
-        \"The pulp-puppet rpms\",\n      \"fullname\": \"rpms/pulp-puppet\",\n      \"id\":
-        16266,\n      \"milestones\": {},\n      \"name\": \"pulp-puppet\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
-        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\",\n
-        \         \"jortel\",\n          \"bowlofeggs\",\n          \"jcline\",\n
-        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785930\",\n      \"description\":
-        \"The pulp-python rpms\",\n      \"fullname\": \"rpms/pulp-python\",\n      \"id\":
-        16267,\n      \"milestones\": {},\n      \"name\": \"pulp-python\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
-        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\",\n
-        \         \"jortel\",\n          \"bowlofeggs\",\n          \"jcline\",\n
-        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785930\",\n      \"description\":
-        \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n      \"id\":
-        16268,\n      \"milestones\": {},\n      \"name\": \"pulp-rpm\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
-        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"owner\": [\n
-        \         \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499785955\",\n
-        \     \"description\": \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n
-        \     \"id\": 16563,\n      \"milestones\": {},\n      \"name\": \"python-args\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
-        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
-        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jortel\",\n          \"ipanova\",\n
-        \         \"bowlofeggs\",\n          \"jcline\",\n          \"asmacdo\"\n
-        \       ],\n        \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785970\",\n      \"description\": \"The python-crane rpms\",\n      \"fullname\":
-        \"rpms/python-crane\",\n      \"id\": 16726,\n      \"milestones\": {},\n
-        \     \"name\": \"python-crane\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
-        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
-        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"dscott\",\n          \"jmatthews\",\n          \"jcline\",\n
-        \         \"dcallagh\"\n        ],\n        \"owner\": [\n          \"jlaska\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786003\",\n      \"description\":
-        \"The python-isodate rpms\",\n      \"fullname\": \"rpms/python-isodate\",\n
-        \     \"id\": 17130,\n      \"milestones\": {},\n      \"name\": \"python-isodate\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jlaska\",\n
-        \       \"name\": \"jlaska\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
-        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
-        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"apevec\",\n          \"amcnabb\",\n
-        \         \"cstratak\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786039\",\n      \"description\":
-        \"The python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\",\n
-        \     \"id\": 17575,\n      \"milestones\": {},\n      \"name\": \"python-pymongo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
-        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786046\",\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
-        \"rpms/python-rpdb\",\n      \"id\": 17711,\n      \"milestones\": {},\n      \"name\":
-        \"python-rpdb\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
-        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
-        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
-        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
-        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
+        namespace\": null,\n    \"owner\": null,\n    \"page\": 2,\n    \"pattern\"\
+        : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
+        \    \"username\": \"jcline\"\n  },\n  \"pagination\": {\n    \"first\": \"\
+        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
+        ,\n    \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
+        ,\n    \"page\": 2,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\"\
+        : \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
+        \n  },\n  \"projects\": [\n    {\n      \"description\": \"The erlang-p1_tls\
+        \ rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n      \"name\": \"\
+        erlang-p1_tls\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\"\
+        : \"The erlang-p1_utils rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\"\
+        ,\n      \"name\": \"erlang-p1_utils\",\n      \"namespace\": \"rpms\"\n \
+        \   },\n    {\n      \"description\": \"The erlang-p1_xml rpms\",\n      \"\
+        fullname\": \"rpms/erlang-p1_xml\",\n      \"name\": \"erlang-p1_xml\",\n\
+        \      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The\
+        \ erlang-p1_xmlrpc rpms\",\n      \"fullname\": \"rpms/erlang-p1_xmlrpc\"\
+        ,\n      \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\"\n\
+        \    },\n    {\n      \"description\": \"The erlang-p1_yaml rpms\",\n    \
+        \  \"fullname\": \"rpms/erlang-p1_yaml\",\n      \"name\": \"erlang-p1_yaml\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-p1_zlib rpms\",\n      \"fullname\": \"rpms/erlang-p1_zlib\",\n\
+        \      \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\"\n    },\n\
+        \    {\n      \"description\": \"The erlang-proper rpms\",\n      \"fullname\"\
+        : \"rpms/erlang-proper\",\n      \"name\": \"erlang-proper\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-stringprep\
+        \ rpms\",\n      \"fullname\": \"rpms/erlang-stringprep\",\n      \"name\"\
+        : \"erlang-stringprep\",\n      \"namespace\": \"rpms\"\n    },\n    {\n \
+        \     \"description\": \"The erlang-stun rpms\",\n      \"fullname\": \"rpms/erlang-stun\"\
+        ,\n      \"name\": \"erlang-stun\",\n      \"namespace\": \"rpms\"\n    },\n\
+        \    {\n      \"description\": \"The python-args rpms\",\n      \"fullname\"\
+        : \"rpms/python-args\",\n      \"name\": \"python-args\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The python-chardet rpms\"\
+        ,\n      \"fullname\": \"rpms/python-chardet\",\n      \"name\": \"python-chardet\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The python-clint rpms\",\n      \"fullname\": \"rpms/python-clint\",\n   \
+        \   \"name\": \"python-clint\",\n      \"namespace\": \"rpms\"\n    },\n \
+        \   {\n      \"description\": \"The python-crane rpms\",\n      \"fullname\"\
+        : \"rpms/python-crane\",\n      \"name\": \"python-crane\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The python-cryptography\
+        \ rpms\",\n      \"fullname\": \"rpms/python-cryptography\",\n      \"name\"\
+        : \"python-cryptography\",\n      \"namespace\": \"rpms\"\n    },\n    {\n\
+        \      \"description\": \"The python-cryptography-vectors rpms\",\n      \"\
+        fullname\": \"rpms/python-cryptography-vectors\",\n      \"name\": \"python-cryptography-vectors\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n \
+        \     \"name\": \"python-flower\",\n      \"namespace\": \"rpms\"\n    },\n\
+        \    {\n      \"description\": \"The python-idna rpms\",\n      \"fullname\"\
+        : \"rpms/python-idna\",\n      \"name\": \"python-idna\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The python-invocations\
+        \ rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n      \"name\"\
+        : \"python-invocations\",\n      \"namespace\": \"rpms\"\n    },\n    {\n\
+        \      \"description\": \"The python-ipdb rpms\",\n      \"fullname\": \"\
+        rpms/python-ipdb\",\n      \"name\": \"python-ipdb\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The python-isodate rpms\"\
+        ,\n      \"fullname\": \"rpms/python-isodate\",\n      \"name\": \"python-isodate\"\
+        ,\n      \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 49\n}"}
     headers:
       appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=5176802]
+      apptime: [D=940681]
       connection: [Keep-Alive]
-      content-length: ['33868']
+      content-length: ['4005']
       content-type: [application/json]
-      date: ['Wed, 12 Jul 2017 18:50:56 GMT']
+      date: ['Mon, 31 Jul 2017 13:23:25 GMT']
       keep-alive: ['timeout=15, max=500']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
           mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEgBFQ.5IVil49rCu9yl6YEBFUv3hfICqU;
-          Expires=Sat, 12-Aug-2017 18:51:01 GMT; Secure; HttpOnly; Path=/pagure']
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DGDAzg.0MIxvstK8x82rHZN5-cbOEpznIw;
+          Expires=Thu, 31-Aug-2017 13:23:26 GMT; Secure; HttpOnly; Path=/pagure']
       strict-transport-security: [max-age=15768000; includeSubDomains; preload]
     status: {code: 200, message: OK}
 - request:
@@ -997,766 +168,53 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
+      User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&page=1
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3
   response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"page\": 1,\n    \"pattern\": null,\n    \"per_page\":
-        20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
-        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
-        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=2\",\n
-        \   \"page\": 1,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
-        null\n  },\n  \"projects\": [\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\",\n
-        \         \"martinlanghoff\",\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"peter\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500069194\",\n
-        \     \"description\": \"The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n
-        \     \"id\": 3062,\n      \"milestones\": {},\n      \"name\": \"ejabberd\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"peter\",\n
-        \       \"name\": \"peter\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069208\",\n      \"description\":
-        \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
-        \     \"id\": 3207,\n      \"milestones\": {},\n      \"name\": \"erlang-cache_tab\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069209\",\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
-        \"rpms/erlang-esip\",\n      \"id\": 3230,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069209\",\n      \"description\": \"The erlang-ezlib rpms\",\n      \"fullname\":
-        \"rpms/erlang-ezlib\",\n      \"id\": 3233,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069209\",\n      \"description\": \"The erlang-fast_tls rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_tls\",\n      \"id\": 3234,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069210\",\n      \"description\":
-        \"The erlang-fast_xml rpms\",\n      \"fullname\": \"rpms/erlang-fast_xml\",\n
-        \     \"id\": 3235,\n      \"milestones\": {},\n      \"name\": \"erlang-fast_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069210\",\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_yaml\",\n      \"id\": 3236,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069210\",\n      \"description\":
-        \"The erlang-goldrush rpms\",\n      \"fullname\": \"rpms/erlang-goldrush\",\n
-        \     \"id\": 3241,\n      \"milestones\": {},\n      \"name\": \"erlang-goldrush\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069211\",\n      \"description\": \"The erlang-iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-iconv\",\n      \"id\": 3246,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069212\",\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\":
-        \"rpms/erlang-luerl\",\n      \"id\": 3255,\n      \"milestones\": {},\n      \"name\":
-        \"erlang-luerl\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069212\",\n      \"description\": \"The erlang-oauth2 rpms\",\n      \"fullname\":
-        \"rpms/erlang-oauth2\",\n      \"id\": 3265,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_iconv\",\n      \"id\": 3266,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_mysql rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_mysql\",\n      \"id\": 3267,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_oauth2 rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_oauth2\",\n      \"id\": 3268,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pam\",\n      \"id\": 3269,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_pgsql rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pgsql\",\n      \"id\": 3270,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_sip\",\n      \"id\": 3271,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n
-        \     \"description\": \"The erlang-p1_stringprep rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stringprep\",\n      \"id\": 3272,\n      \"milestones\":
-        {},\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n
-        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
-        \     \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069213\",\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stun\",\n      \"id\": 3273,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n
-        \     \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
-        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\":
-        46\n}"}
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
+        namespace\": null,\n    \"owner\": null,\n    \"page\": 3,\n    \"pattern\"\
+        : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
+        \    \"username\": \"jcline\"\n  },\n  \"pagination\": {\n    \"first\": \"\
+        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
+        ,\n    \"next\": null,\n    \"page\": 3,\n    \"pages\": 3,\n    \"per_page\"\
+        : 20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=2\"\
+        \n  },\n  \"projects\": [\n    {\n      \"description\": \"The python-pkginfo\
+        \ rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n      \"name\": \"\
+        python-pkginfo\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"\
+        description\": \"The python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\"\
+        ,\n      \"name\": \"python-pymongo\",\n      \"namespace\": \"rpms\"\n  \
+        \  },\n    {\n      \"description\": \"The python-pytoml rpms\",\n      \"\
+        fullname\": \"rpms/python-pytoml\",\n      \"name\": \"python-pytoml\",\n\
+        \      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The\
+        \ python-releases rpms\",\n      \"fullname\": \"rpms/python-releases\",\n\
+        \      \"name\": \"python-releases\",\n      \"namespace\": \"rpms\"\n   \
+        \ },\n    {\n      \"description\": \"The python-requests rpms\",\n      \"\
+        fullname\": \"rpms/python-requests\",\n      \"name\": \"python-requests\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The python-rpdb rpms\",\n      \"fullname\": \"rpms/python-rpdb\",\n     \
+        \ \"name\": \"python-rpdb\",\n      \"namespace\": \"rpms\"\n    },\n    {\n\
+        \      \"description\": \"The python-sphinxcontrib-fulltoc rpms\",\n     \
+        \ \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"name\": \"\
+        python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\"\n    },\n \
+        \   {\n      \"description\": \"The python-twine rpms\",\n      \"fullname\"\
+        : \"rpms/python-twine\",\n      \"name\": \"python-twine\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The python-urllib3 rpms\"\
+        ,\n      \"fullname\": \"rpms/python-urllib3\",\n      \"name\": \"python-urllib3\"\
+        ,\n      \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 49\n}"}
     headers:
       appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=1915229]
+      apptime: [D=1008575]
       connection: [Keep-Alive]
-      content-length: ['15136']
+      content-length: ['2152']
       content-type: [application/json]
-      date: ['Thu, 20 Jul 2017 19:00:18 GMT']
+      date: ['Mon, 31 Jul 2017 13:23:26 GMT']
       keep-alive: ['timeout=15, max=500']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
           mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPRA.Pj98nmpe8g0HygS0M50kVPts3m4;
-          Expires=Sun, 20-Aug-2017 19:00:20 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=2
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"page\": 2,\n    \"pattern\": null,\n    \"per_page\":
-        20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
-        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
-        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
-        \   \"page\": 2,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
-        \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\"\n
-        \ },\n  \"projects\": [\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069214\",\n      \"description\": \"The erlang-p1_utils rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_utils\",\n      \"id\": 3275,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_utils\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069214\",\n      \"description\": \"The erlang-p1_xml rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_xml\",\n      \"id\": 3276,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_xml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
-        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069214\",\n      \"description\": \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_xmlrpc\",\n      \"id\": 3277,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069214\",\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_yaml\",\n      \"id\": 3278,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069214\",\n      \"description\": \"The erlang-p1_zlib rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_zlib\",\n      \"id\": 3279,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
-        \"The erlang-proper rpms\",\n      \"fullname\": \"rpms/erlang-proper\",\n
-        \     \"id\": 3283,\n      \"milestones\": {},\n      \"name\": \"erlang-proper\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
-        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500069218\",\n      \"description\": \"The erlang-stringprep rpms\",\n
-        \     \"fullname\": \"rpms/erlang-stringprep\",\n      \"id\": 3307,\n      \"milestones\":
-        {},\n      \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n
-        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
-        \     \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
-        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
-        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069218\",\n      \"description\":
-        \"The erlang-stun rpms\",\n      \"fullname\": \"rpms/erlang-stun\",\n      \"id\":
-        3308,\n      \"milestones\": {},\n      \"name\": \"erlang-stun\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
-        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\",\n
-        \         \"jortel\",\n          \"jcline\",\n          \"bowlofeggs\",\n
-        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070895\",\n      \"description\":
-        \"The pulp rpms\",\n      \"fullname\": \"rpms/pulp\",\n      \"id\": 16269,\n
-        \     \"milestones\": {},\n      \"name\": \"pulp\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
-        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"asmacdo\",\n
-        \         \"ipanova\",\n          \"jcline\",\n          \"bowlofeggs\",\n
-        \         \"jortel\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070892\",\n      \"description\":
-        \"The pulp-docker rpms\",\n      \"fullname\": \"rpms/pulp-docker\",\n      \"id\":
-        16264,\n      \"milestones\": {},\n      \"name\": \"pulp-docker\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
-        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"asmacdo\",\n
-        \         \"ipanova\",\n          \"jcline\",\n          \"bowlofeggs\",\n
-        \         \"jortel\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070893\",\n      \"description\":
-        \"The pulp-ostree rpms\",\n      \"fullname\": \"rpms/pulp-ostree\",\n      \"id\":
-        16265,\n      \"milestones\": {},\n      \"name\": \"pulp-ostree\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
-        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"asmacdo\",\n
-        \         \"ipanova\",\n          \"jcline\",\n          \"bowlofeggs\",\n
-        \         \"jortel\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070893\",\n      \"description\":
-        \"The pulp-puppet rpms\",\n      \"fullname\": \"rpms/pulp-puppet\",\n      \"id\":
-        16266,\n      \"milestones\": {},\n      \"name\": \"pulp-puppet\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
-        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\",\n
-        \         \"jortel\",\n          \"jcline\",\n          \"bowlofeggs\",\n
-        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070894\",\n      \"description\":
-        \"The pulp-python rpms\",\n      \"fullname\": \"rpms/pulp-python\",\n      \"id\":
-        16267,\n      \"milestones\": {},\n      \"name\": \"pulp-python\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
-        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\",\n
-        \         \"jortel\",\n          \"jcline\",\n          \"bowlofeggs\",\n
-        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070894\",\n      \"description\":
-        \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n      \"id\":
-        16268,\n      \"milestones\": {},\n      \"name\": \"pulp-rpm\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
-        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"owner\": [\n
-        \         \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500070924\",\n
-        \     \"description\": \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n
-        \     \"id\": 16563,\n      \"milestones\": {},\n      \"name\": \"python-args\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070941\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
-        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
-        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"ipanova\",\n
-        \         \"jcline\",\n          \"bowlofeggs\",\n          \"jortel\"\n        ],\n
-        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070947\",\n      \"description\": \"The python-crane rpms\",\n      \"fullname\":
-        \"rpms/python-crane\",\n      \"id\": 16726,\n      \"milestones\": {},\n
-        \     \"name\": \"python-crane\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070977\",\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070991\",\n      \"description\":
-        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
-        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"dscott\",\n          \"jcline\",\n          \"jmatthews\",\n
-        \         \"dcallagh\"\n        ],\n        \"owner\": [\n          \"jlaska\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070992\",\n      \"description\":
-        \"The python-isodate rpms\",\n      \"fullname\": \"rpms/python-isodate\",\n
-        \     \"id\": 17130,\n      \"milestones\": {},\n      \"name\": \"python-isodate\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jlaska\",\n
-        \       \"name\": \"jlaska\"\n      }\n    }\n  ],\n  \"total_projects\":
-        46\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=1441714]
-      connection: [Keep-Alive]
-      content-length: ['15550']
-      content-type: [application/json]
-      date: ['Thu, 20 Jul 2017 19:00:21 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPRg.uC7CFnbrg5x-JXWCLosxi6AV96s;
-          Expires=Sun, 20-Aug-2017 19:00:22 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"page\": 3,\n    \"pattern\": null,\n    \"per_page\":
-        20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
-        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
-        \   \"next\": null,\n    \"page\": 3,\n    \"pages\": 3,\n    \"per_page\":
-        20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=2\"\n
-        \ },\n  \"projects\": [\n    {\n      \"access_groups\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500071033\",\n      \"description\": \"The python-pkginfo rpms\",\n      \"fullname\":
-        \"rpms/python-pkginfo\",\n      \"id\": 17492,\n      \"milestones\": {},\n
-        \     \"name\": \"python-pkginfo\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"apevec\",\n          \"cstratak\",\n
-        \         \"amcnabb\",\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500071041\",\n      \"description\": \"The python-pymongo rpms\",\n      \"fullname\":
-        \"rpms/python-pymongo\",\n      \"id\": 17575,\n      \"milestones\": {},\n
-        \     \"name\": \"python-pymongo\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
-        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
-        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"owner\": [\n
-        \         \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500071049\",\n
-        \     \"description\": \"The python-releases rpms\",\n      \"fullname\":
-        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
-        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500071056\",\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
-        \"rpms/python-rpdb\",\n      \"id\": 17711,\n      \"milestones\": {},\n      \"name\":
-        \"python-rpdb\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
-        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
-        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"williamjmorenor\",\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500071066\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
-        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500071080\",\n      \"description\":
-        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
-        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
-        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 46\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=1615410]
-      connection: [Keep-Alive]
-      content-length: ['5015']
-      content-type: [application/json]
-      date: ['Thu, 20 Jul 2017 19:00:23 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPSA.rUGjVWvpxS5vO3X7_LSL-bw9VUU;
-          Expires=Sun, 20-Aug-2017 19:00:24 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=true&username=jcline&page=1
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"page\": 1,\n    \"pattern\": null,\n    \"per_page\":
-        20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
-        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
-        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=2\",\n
-        \   \"page\": 1,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
-        null\n  },\n  \"projects\": [\n    {\n      \"description\": \"The ejabberd
-        rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"name\": \"ejabberd\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
-        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
-        \"rpms/erlang-esip\",\n      \"name\": \"erlang-esip\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-ezlib rpms\",\n
-        \     \"fullname\": \"rpms/erlang-ezlib\",\n      \"name\": \"erlang-ezlib\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-fast_tls rpms\",\n      \"fullname\": \"rpms/erlang-fast_tls\",\n      \"name\":
-        \"erlang-fast_tls\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The erlang-fast_xml rpms\",\n      \"fullname\": \"rpms/erlang-fast_xml\",\n
-        \     \"name\": \"erlang-fast_xml\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-fast_yaml\",\n      \"name\": \"erlang-fast_yaml\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-goldrush rpms\",\n
-        \     \"fullname\": \"rpms/erlang-goldrush\",\n      \"name\": \"erlang-goldrush\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-iconv rpms\",\n      \"fullname\": \"rpms/erlang-iconv\",\n      \"name\":
-        \"erlang-iconv\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The erlang-luerl rpms\",\n      \"fullname\": \"rpms/erlang-luerl\",\n      \"name\":
-        \"erlang-luerl\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The erlang-oauth2 rpms\",\n      \"fullname\": \"rpms/erlang-oauth2\",\n
-        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_iconv\",\n      \"name\": \"erlang-p1_iconv\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_mysql rpms\",\n
-        \     \"fullname\": \"rpms/erlang-p1_mysql\",\n      \"name\": \"erlang-p1_mysql\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-p1_oauth2 rpms\",\n      \"fullname\": \"rpms/erlang-p1_oauth2\",\n
-        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_pam\",\n      \"name\": \"erlang-p1_pam\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_pgsql rpms\",\n
-        \     \"fullname\": \"rpms/erlang-p1_pgsql\",\n      \"name\": \"erlang-p1_pgsql\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n      \"name\":
-        \"erlang-p1_sip\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
-        \     \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\"\n
-        \   },\n    {\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_stun\",\n      \"name\": \"erlang-p1_stun\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_tls rpms\",\n
-        \     \"fullname\": \"rpms/erlang-p1_tls\",\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 46\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=1027258]
-      connection: [Keep-Alive]
-      content-length: ['3879']
-      content-type: [application/json]
-      date: ['Fri, 21 Jul 2017 16:46:57 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBgg.bLsal-e46I8A08jtHXOVT8T3EYY;
-          Expires=Mon, 21-Aug-2017 16:46:58 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=2
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"page\": 2,\n    \"pattern\": null,\n    \"per_page\":
-        20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
-        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
-        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
-        \   \"page\": 2,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
-        \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\"\n
-        \ },\n  \"projects\": [\n    {\n      \"description\": \"The erlang-p1_utils
-        rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\",\n      \"name\": \"erlang-p1_utils\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n      \"name\":
-        \"erlang-p1_xml\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\": \"rpms/erlang-p1_xmlrpc\",\n
-        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_yaml\",\n      \"name\": \"erlang-p1_yaml\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_zlib rpms\",\n
-        \     \"fullname\": \"rpms/erlang-p1_zlib\",\n      \"name\": \"erlang-p1_zlib\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-proper rpms\",\n      \"fullname\": \"rpms/erlang-proper\",\n      \"name\":
-        \"erlang-proper\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The erlang-stringprep rpms\",\n      \"fullname\": \"rpms/erlang-stringprep\",\n
-        \     \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-stun rpms\",\n      \"fullname\":
-        \"rpms/erlang-stun\",\n      \"name\": \"erlang-stun\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The pulp rpms\",\n      \"fullname\":
-        \"rpms/pulp\",\n      \"name\": \"pulp\",\n      \"namespace\": \"rpms\"\n
-        \   },\n    {\n      \"description\": \"The pulp-docker rpms\",\n      \"fullname\":
-        \"rpms/pulp-docker\",\n      \"name\": \"pulp-docker\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The pulp-ostree rpms\",\n
-        \     \"fullname\": \"rpms/pulp-ostree\",\n      \"name\": \"pulp-ostree\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        pulp-puppet rpms\",\n      \"fullname\": \"rpms/pulp-puppet\",\n      \"name\":
-        \"pulp-puppet\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The pulp-python rpms\",\n      \"fullname\": \"rpms/pulp-python\",\n      \"name\":
-        \"pulp-python\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n      \"name\":
-        \"pulp-rpm\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n      \"name\":
-        \"python-args\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-clint rpms\",\n      \"fullname\": \"rpms/python-clint\",\n      \"name\":
-        \"python-clint\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-crane rpms\",\n      \"fullname\": \"rpms/python-crane\",\n      \"name\":
-        \"python-crane\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"name\": \"python-flower\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The python-invocations rpms\",\n      \"fullname\":
-        \"rpms/python-invocations\",\n      \"name\": \"python-invocations\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The python-isodate rpms\",\n
-        \     \"fullname\": \"rpms/python-isodate\",\n      \"name\": \"python-isodate\",\n
-        \     \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 46\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=3207851]
-      connection: [Keep-Alive]
-      content-length: ['3888']
-      content-type: [application/json]
-      date: ['Fri, 21 Jul 2017 16:46:59 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBhg.rV6GwIH7OvnFZgKBsX3QQlOs4_w;
-          Expires=Mon, 21-Aug-2017 16:47:02 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": null,\n    \"page\": 3,\n    \"pattern\": null,\n    \"per_page\":
-        20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
-        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
-        \   \"next\": null,\n    \"page\": 3,\n    \"pages\": 3,\n    \"per_page\":
-        20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=2\"\n
-        \ },\n  \"projects\": [\n    {\n      \"description\": \"The python-pkginfo
-        rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\",\n      \"name\":
-        \"python-pymongo\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-releases rpms\",\n      \"fullname\": \"rpms/python-releases\",\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
-        \"rpms/python-rpdb\",\n      \"name\": \"python-rpdb\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"name\":
-        \"python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The python-twine rpms\",\n      \"fullname\":
-        \"rpms/python-twine\",\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\"\n    }\n  ],\n  \"total_projects\": 46\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=940724]
-      connection: [Keep-Alive]
-      content-length: ['1672']
-      content-type: [application/json]
-      date: ['Fri, 21 Jul 2017 16:47:02 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBhw.tvdXemYniw7P9cPgs5t8tiWCyK8;
-          Expires=Mon, 21-Aug-2017 16:47:03 GMT; Secure; HttpOnly; Path=/pagure']
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DGDAzw.M04WcDfEU0jXUECPUeRPCpU-YnU;
+          Expires=Thu, 31-Aug-2017 13:23:27 GMT; Secure; HttpOnly; Path=/pagure']
       strict-transport-security: [max-age=15768000; includeSubDomains; preload]
     status: {code: 200, message: OK}
 version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_comaintained
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_comaintained
@@ -1,0 +1,1762 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&namespace=rpms
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        \"rpms\",\n    \"owner\": null,\n    \"pattern\": null,\n    \"short\": false,\n
+        \   \"tags\": [],\n    \"username\": \"jcline\"\n  },\n  \"projects\": [\n
+        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"jcline\",\n
+        \         \"martinlanghoff\"\n        ],\n        \"owner\": [\n          \"peter\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784730\",\n      \"description\":
+        \"The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"id\":
+        3062,\n      \"milestones\": {},\n      \"name\": \"ejabberd\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"peter\",\n        \"name\":
+        \"peter\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784743\",\n      \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
+        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784744\",\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
+        \"rpms/erlang-esip\",\n      \"id\": 3230,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784744\",\n      \"description\": \"The erlang-ezlib rpms\",\n      \"fullname\":
+        \"rpms/erlang-ezlib\",\n      \"id\": 3233,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784745\",\n      \"description\": \"The erlang-fast_tls rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_tls\",\n      \"id\": 3234,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784745\",\n      \"description\": \"The erlang-fast_xml rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_xml\",\n      \"id\": 3235,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_xml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784745\",\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_yaml\",\n      \"id\": 3236,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784745\",\n      \"description\": \"The erlang-goldrush rpms\",\n      \"fullname\":
+        \"rpms/erlang-goldrush\",\n      \"id\": 3241,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-goldrush\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784746\",\n      \"description\": \"The erlang-iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-iconv\",\n      \"id\": 3246,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784747\",\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\":
+        \"rpms/erlang-luerl\",\n      \"id\": 3255,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-luerl\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-oauth2 rpms\",\n      \"fullname\":
+        \"rpms/erlang-oauth2\",\n      \"id\": 3265,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_iconv\",\n      \"id\": 3266,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_mysql rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_mysql\",\n      \"id\": 3267,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_oauth2 rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_oauth2\",\n      \"id\": 3268,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pam\",\n      \"id\": 3269,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_pgsql rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pgsql\",\n      \"id\": 3270,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_sip\",\n      \"id\": 3271,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
+        \     \"description\": \"The erlang-p1_stringprep rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stringprep\",\n      \"id\": 3272,\n      \"milestones\":
+        {},\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n
+        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
+        \     \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stun\",\n      \"id\": 3273,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n
+        \     \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
+        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_utils rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\",\n
+        \     \"id\": 3275,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_utils\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
+        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"peter\",\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_xmlrpc\",\n      \"id\": 3277,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_yaml\",\n      \"id\": 3278,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-p1_zlib rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_zlib\",\n      \"id\": 3279,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-proper rpms\",\n      \"fullname\":
+        \"rpms/erlang-proper\",\n      \"id\": 3283,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-proper\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784751\",\n      \"description\": \"The erlang-stringprep rpms\",\n
+        \     \"fullname\": \"rpms/erlang-stringprep\",\n      \"id\": 3307,\n      \"milestones\":
+        {},\n      \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n
+        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
+        \     \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
+        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"peter\",\n          \"jcline\"\n
+        \       ],\n        \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784752\",\n      \"description\": \"The erlang-stun rpms\",\n      \"fullname\":
+        \"rpms/erlang-stun\",\n      \"id\": 3308,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-stun\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"pcreech17\",\n
+        \         \"asmacdo\",\n          \"jortel\",\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"ipanova\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785931\",\n      \"description\": \"The pulp rpms\",\n      \"fullname\":
+        \"rpms/pulp\",\n      \"id\": 16269,\n      \"milestones\": {},\n      \"name\":
+        \"pulp\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n
+        \       \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"ipanova\",\n          \"bowlofeggs\",\n          \"asmacdo\",\n
+        \         \"jcline\",\n          \"jortel\"\n        ],\n        \"owner\":
+        [\n          \"pcreech17\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785929\",\n      \"description\": \"The pulp-docker rpms\",\n      \"fullname\":
+        \"rpms/pulp-docker\",\n      \"id\": 16264,\n      \"milestones\": {},\n      \"name\":
+        \"pulp-docker\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"ipanova\",\n          \"bowlofeggs\",\n
+        \         \"asmacdo\",\n          \"jcline\",\n          \"jortel\"\n        ],\n
+        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785929\",\n      \"description\": \"The pulp-ostree rpms\",\n      \"fullname\":
+        \"rpms/pulp-ostree\",\n      \"id\": 16265,\n      \"milestones\": {},\n      \"name\":
+        \"pulp-ostree\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"ipanova\",\n          \"bowlofeggs\",\n
+        \         \"asmacdo\",\n          \"jcline\",\n          \"jortel\"\n        ],\n
+        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785929\",\n      \"description\": \"The pulp-puppet rpms\",\n      \"fullname\":
+        \"rpms/pulp-puppet\",\n      \"id\": 16266,\n      \"milestones\": {},\n      \"name\":
+        \"pulp-puppet\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"pcreech17\",\n
+        \         \"asmacdo\",\n          \"jortel\",\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"ipanova\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785930\",\n      \"description\": \"The pulp-python rpms\",\n      \"fullname\":
+        \"rpms/pulp-python\",\n      \"id\": 16267,\n      \"milestones\": {},\n      \"name\":
+        \"pulp-python\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"ipanova\",\n        \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"pcreech17\",\n          \"asmacdo\",\n
+        \         \"jortel\",\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"ipanova\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499785930\",\n
+        \     \"description\": \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n
+        \     \"id\": 16268,\n      \"milestones\": {},\n      \"name\": \"pulp-rpm\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n
+        \       \"name\": \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785955\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
+        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
+        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
+        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
+        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"ipanova\",\n          \"bowlofeggs\",\n
+        \         \"asmacdo\",\n          \"jcline\",\n          \"jortel\"\n        ],\n
+        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785970\",\n      \"description\": \"The python-crane rpms\",\n      \"fullname\":
+        \"rpms/python-crane\",\n      \"id\": 16726,\n      \"milestones\": {},\n
+        \     \"name\": \"python-crane\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
+        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
+        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"dcallagh\",\n          \"jcline\",\n          \"dscott\",\n
+        \         \"jmatthews\"\n        ],\n        \"owner\": [\n          \"jlaska\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786003\",\n      \"description\":
+        \"The python-isodate rpms\",\n      \"fullname\": \"rpms/python-isodate\",\n
+        \     \"id\": 17130,\n      \"milestones\": {},\n      \"name\": \"python-isodate\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jlaska\",\n
+        \       \"name\": \"jlaska\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
+        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
+        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"amcnabb\",\n          \"cstratak\",\n          \"jcline\",\n
+        \         \"apevec\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786039\",\n      \"description\":
+        \"The python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\",\n
+        \     \"id\": 17575,\n      \"milestones\": {},\n      \"name\": \"python-pymongo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
+        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786046\",\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
+        \"rpms/python-rpdb\",\n      \"id\": 17711,\n      \"milestones\": {},\n      \"name\":
+        \"python-rpdb\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
+        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
+        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
+        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
+        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=2505099]
+      connection: [Keep-Alive]
+      content-length: ['33870']
+      content-type: [application/json]
+      date: ['Wed, 12 Jul 2017 18:32:20 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEf8tg.83f6H0bsMNV0lvw6WrsF9nbh-rs;
+          Expires=Sat, 12-Aug-2017 18:32:22 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"pattern\": null,\n    \"short\": false,\n
+        \   \"tags\": [],\n    \"username\": \"jcline\"\n  },\n  \"projects\": [\n
+        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"bowlofeggs\",\n
+        \         \"martinlanghoff\"\n        ],\n        \"owner\": [\n          \"peter\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784730\",\n      \"description\":
+        \"The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"id\":
+        3062,\n      \"milestones\": {},\n      \"name\": \"ejabberd\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"peter\",\n        \"name\":
+        \"peter\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784743\",\n      \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
+        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784744\",\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
+        \"rpms/erlang-esip\",\n      \"id\": 3230,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784744\",\n      \"description\": \"The erlang-ezlib rpms\",\n      \"fullname\":
+        \"rpms/erlang-ezlib\",\n      \"id\": 3233,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784745\",\n      \"description\": \"The erlang-fast_tls rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_tls\",\n      \"id\": 3234,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784745\",\n      \"description\":
+        \"The erlang-fast_xml rpms\",\n      \"fullname\": \"rpms/erlang-fast_xml\",\n
+        \     \"id\": 3235,\n      \"milestones\": {},\n      \"name\": \"erlang-fast_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784745\",\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_yaml\",\n      \"id\": 3236,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784745\",\n      \"description\":
+        \"The erlang-goldrush rpms\",\n      \"fullname\": \"rpms/erlang-goldrush\",\n
+        \     \"id\": 3241,\n      \"milestones\": {},\n      \"name\": \"erlang-goldrush\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784746\",\n      \"description\": \"The erlang-iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-iconv\",\n      \"id\": 3246,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784747\",\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\":
+        \"rpms/erlang-luerl\",\n      \"id\": 3255,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-luerl\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-oauth2 rpms\",\n      \"fullname\":
+        \"rpms/erlang-oauth2\",\n      \"id\": 3265,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_iconv\",\n      \"id\": 3266,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_mysql rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_mysql\",\n      \"id\": 3267,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_oauth2 rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_oauth2\",\n      \"id\": 3268,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pam\",\n      \"id\": 3269,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_pgsql rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pgsql\",\n      \"id\": 3270,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_sip\",\n      \"id\": 3271,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
+        \     \"description\": \"The erlang-p1_stringprep rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stringprep\",\n      \"id\": 3272,\n      \"milestones\":
+        {},\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n
+        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
+        \     \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784748\",\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stun\",\n      \"id\": 3273,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n
+        \     \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
+        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_utils rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\",\n
+        \     \"id\": 3275,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_utils\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
+        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_xmlrpc\",\n      \"id\": 3277,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_yaml\",\n      \"id\": 3278,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784749\",\n      \"description\": \"The erlang-p1_zlib rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_zlib\",\n      \"id\": 3279,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-proper rpms\",\n      \"fullname\": \"rpms/erlang-proper\",\n
+        \     \"id\": 3283,\n      \"milestones\": {},\n      \"name\": \"erlang-proper\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499784751\",\n      \"description\": \"The erlang-stringprep rpms\",\n
+        \     \"fullname\": \"rpms/erlang-stringprep\",\n      \"id\": 3307,\n      \"milestones\":
+        {},\n      \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n
+        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
+        \     \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
+        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784752\",\n      \"description\":
+        \"The erlang-stun rpms\",\n      \"fullname\": \"rpms/erlang-stun\",\n      \"id\":
+        3308,\n      \"milestones\": {},\n      \"name\": \"erlang-stun\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
+        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\",\n
+        \         \"jortel\",\n          \"bowlofeggs\",\n          \"jcline\",\n
+        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785931\",\n      \"description\":
+        \"The pulp rpms\",\n      \"fullname\": \"rpms/pulp\",\n      \"id\": 16269,\n
+        \     \"milestones\": {},\n      \"name\": \"pulp\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
+        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jortel\",\n
+        \         \"ipanova\",\n          \"bowlofeggs\",\n          \"jcline\",\n
+        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785929\",\n      \"description\":
+        \"The pulp-docker rpms\",\n      \"fullname\": \"rpms/pulp-docker\",\n      \"id\":
+        16264,\n      \"milestones\": {},\n      \"name\": \"pulp-docker\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
+        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jortel\",\n
+        \         \"ipanova\",\n          \"bowlofeggs\",\n          \"jcline\",\n
+        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785929\",\n      \"description\":
+        \"The pulp-ostree rpms\",\n      \"fullname\": \"rpms/pulp-ostree\",\n      \"id\":
+        16265,\n      \"milestones\": {},\n      \"name\": \"pulp-ostree\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
+        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jortel\",\n
+        \         \"ipanova\",\n          \"bowlofeggs\",\n          \"jcline\",\n
+        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785929\",\n      \"description\":
+        \"The pulp-puppet rpms\",\n      \"fullname\": \"rpms/pulp-puppet\",\n      \"id\":
+        16266,\n      \"milestones\": {},\n      \"name\": \"pulp-puppet\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
+        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\",\n
+        \         \"jortel\",\n          \"bowlofeggs\",\n          \"jcline\",\n
+        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785930\",\n      \"description\":
+        \"The pulp-python rpms\",\n      \"fullname\": \"rpms/pulp-python\",\n      \"id\":
+        16267,\n      \"milestones\": {},\n      \"name\": \"pulp-python\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
+        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\",\n
+        \         \"jortel\",\n          \"bowlofeggs\",\n          \"jcline\",\n
+        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785930\",\n      \"description\":
+        \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n      \"id\":
+        16268,\n      \"milestones\": {},\n      \"name\": \"pulp-rpm\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
+        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"owner\": [\n
+        \         \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499785955\",\n
+        \     \"description\": \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n
+        \     \"id\": 16563,\n      \"milestones\": {},\n      \"name\": \"python-args\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
+        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
+        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jortel\",\n          \"ipanova\",\n
+        \         \"bowlofeggs\",\n          \"jcline\",\n          \"asmacdo\"\n
+        \       ],\n        \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785970\",\n      \"description\": \"The python-crane rpms\",\n      \"fullname\":
+        \"rpms/python-crane\",\n      \"id\": 16726,\n      \"milestones\": {},\n
+        \     \"name\": \"python-crane\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
+        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
+        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"dscott\",\n          \"jmatthews\",\n          \"jcline\",\n
+        \         \"dcallagh\"\n        ],\n        \"owner\": [\n          \"jlaska\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786003\",\n      \"description\":
+        \"The python-isodate rpms\",\n      \"fullname\": \"rpms/python-isodate\",\n
+        \     \"id\": 17130,\n      \"milestones\": {},\n      \"name\": \"python-isodate\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jlaska\",\n
+        \       \"name\": \"jlaska\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
+        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
+        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"apevec\",\n          \"amcnabb\",\n
+        \         \"cstratak\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786039\",\n      \"description\":
+        \"The python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\",\n
+        \     \"id\": 17575,\n      \"milestones\": {},\n      \"name\": \"python-pymongo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
+        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786046\",\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
+        \"rpms/python-rpdb\",\n      \"id\": 17711,\n      \"milestones\": {},\n      \"name\":
+        \"python-rpdb\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
+        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
+        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
+        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
+        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=5176802]
+      connection: [Keep-Alive]
+      content-length: ['33868']
+      content-type: [application/json]
+      date: ['Wed, 12 Jul 2017 18:50:56 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEgBFQ.5IVil49rCu9yl6YEBFUv3hfICqU;
+          Expires=Sat, 12-Aug-2017 18:51:01 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&page=1
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"page\": 1,\n    \"pattern\": null,\n    \"per_page\":
+        20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
+        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
+        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=2\",\n
+        \   \"page\": 1,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
+        null\n  },\n  \"projects\": [\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\",\n
+        \         \"martinlanghoff\",\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"peter\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500069194\",\n
+        \     \"description\": \"The ejabberd rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n
+        \     \"id\": 3062,\n      \"milestones\": {},\n      \"name\": \"ejabberd\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"peter\",\n
+        \       \"name\": \"peter\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069208\",\n      \"description\":
+        \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
+        \     \"id\": 3207,\n      \"milestones\": {},\n      \"name\": \"erlang-cache_tab\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069209\",\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
+        \"rpms/erlang-esip\",\n      \"id\": 3230,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-esip\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069209\",\n      \"description\": \"The erlang-ezlib rpms\",\n      \"fullname\":
+        \"rpms/erlang-ezlib\",\n      \"id\": 3233,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-ezlib\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069209\",\n      \"description\": \"The erlang-fast_tls rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_tls\",\n      \"id\": 3234,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_tls\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069210\",\n      \"description\":
+        \"The erlang-fast_xml rpms\",\n      \"fullname\": \"rpms/erlang-fast_xml\",\n
+        \     \"id\": 3235,\n      \"milestones\": {},\n      \"name\": \"erlang-fast_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069210\",\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_yaml\",\n      \"id\": 3236,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-fast_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069210\",\n      \"description\":
+        \"The erlang-goldrush rpms\",\n      \"fullname\": \"rpms/erlang-goldrush\",\n
+        \     \"id\": 3241,\n      \"milestones\": {},\n      \"name\": \"erlang-goldrush\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069211\",\n      \"description\": \"The erlang-iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-iconv\",\n      \"id\": 3246,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069212\",\n      \"description\": \"The erlang-luerl rpms\",\n      \"fullname\":
+        \"rpms/erlang-luerl\",\n      \"id\": 3255,\n      \"milestones\": {},\n      \"name\":
+        \"erlang-luerl\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069212\",\n      \"description\": \"The erlang-oauth2 rpms\",\n      \"fullname\":
+        \"rpms/erlang-oauth2\",\n      \"id\": 3265,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_iconv\",\n      \"id\": 3266,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_iconv\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_mysql rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_mysql\",\n      \"id\": 3267,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_mysql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_oauth2 rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_oauth2\",\n      \"id\": 3268,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pam\",\n      \"id\": 3269,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_pam\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_pgsql rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pgsql\",\n      \"id\": 3270,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_pgsql\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_sip\",\n      \"id\": 3271,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_sip\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n
+        \     \"description\": \"The erlang-p1_stringprep rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stringprep\",\n      \"id\": 3272,\n      \"milestones\":
+        {},\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\",\n
+        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
+        \     \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069213\",\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stun\",\n      \"id\": 3273,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n
+        \     \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
+        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\":
+        46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=1915229]
+      connection: [Keep-Alive]
+      content-length: ['15136']
+      content-type: [application/json]
+      date: ['Thu, 20 Jul 2017 19:00:18 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPRA.Pj98nmpe8g0HygS0M50kVPts3m4;
+          Expires=Sun, 20-Aug-2017 19:00:20 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=2
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"page\": 2,\n    \"pattern\": null,\n    \"per_page\":
+        20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
+        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
+        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
+        \   \"page\": 2,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
+        \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\"\n
+        \ },\n  \"projects\": [\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069214\",\n      \"description\": \"The erlang-p1_utils rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_utils\",\n      \"id\": 3275,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_utils\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069214\",\n      \"description\": \"The erlang-p1_xml rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_xml\",\n      \"id\": 3276,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_xml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\",\n          \"peter\"\n        ],\n
+        \       \"owner\": [\n          \"bowlofeggs\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069214\",\n      \"description\": \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_xmlrpc\",\n      \"id\": 3277,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069214\",\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_yaml\",\n      \"id\": 3278,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069214\",\n      \"description\": \"The erlang-p1_zlib rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_zlib\",\n      \"id\": 3279,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-p1_zlib\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
+        \"The erlang-proper rpms\",\n      \"fullname\": \"rpms/erlang-proper\",\n
+        \     \"id\": 3283,\n      \"milestones\": {},\n      \"name\": \"erlang-proper\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n
+        \       \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"jcline\",\n          \"peter\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500069218\",\n      \"description\": \"The erlang-stringprep rpms\",\n
+        \     \"fullname\": \"rpms/erlang-stringprep\",\n      \"id\": 3307,\n      \"milestones\":
+        {},\n      \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\",\n
+        \     \"parent\": null,\n      \"priorities\": {},\n      \"tags\": [],\n
+        \     \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
+        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"jcline\",\n
+        \         \"peter\"\n        ],\n        \"owner\": [\n          \"bowlofeggs\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069218\",\n      \"description\":
+        \"The erlang-stun rpms\",\n      \"fullname\": \"rpms/erlang-stun\",\n      \"id\":
+        3308,\n      \"milestones\": {},\n      \"name\": \"erlang-stun\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"bowlofeggs\",\n        \"name\":
+        \"bowlofeggs\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\",\n
+        \         \"jortel\",\n          \"jcline\",\n          \"bowlofeggs\",\n
+        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070895\",\n      \"description\":
+        \"The pulp rpms\",\n      \"fullname\": \"rpms/pulp\",\n      \"id\": 16269,\n
+        \     \"milestones\": {},\n      \"name\": \"pulp\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
+        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"asmacdo\",\n
+        \         \"ipanova\",\n          \"jcline\",\n          \"bowlofeggs\",\n
+        \         \"jortel\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070892\",\n      \"description\":
+        \"The pulp-docker rpms\",\n      \"fullname\": \"rpms/pulp-docker\",\n      \"id\":
+        16264,\n      \"milestones\": {},\n      \"name\": \"pulp-docker\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
+        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"asmacdo\",\n
+        \         \"ipanova\",\n          \"jcline\",\n          \"bowlofeggs\",\n
+        \         \"jortel\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070893\",\n      \"description\":
+        \"The pulp-ostree rpms\",\n      \"fullname\": \"rpms/pulp-ostree\",\n      \"id\":
+        16265,\n      \"milestones\": {},\n      \"name\": \"pulp-ostree\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
+        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"asmacdo\",\n
+        \         \"ipanova\",\n          \"jcline\",\n          \"bowlofeggs\",\n
+        \         \"jortel\"\n        ],\n        \"owner\": [\n          \"pcreech17\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070893\",\n      \"description\":
+        \"The pulp-puppet rpms\",\n      \"fullname\": \"rpms/pulp-puppet\",\n      \"id\":
+        16266,\n      \"milestones\": {},\n      \"name\": \"pulp-puppet\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"pcreech17\",\n        \"name\":
+        \"pcreech17\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\",\n
+        \         \"jortel\",\n          \"jcline\",\n          \"bowlofeggs\",\n
+        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070894\",\n      \"description\":
+        \"The pulp-python rpms\",\n      \"fullname\": \"rpms/pulp-python\",\n      \"id\":
+        16267,\n      \"milestones\": {},\n      \"name\": \"pulp-python\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
+        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\",\n
+        \         \"jortel\",\n          \"jcline\",\n          \"bowlofeggs\",\n
+        \         \"asmacdo\"\n        ],\n        \"owner\": [\n          \"ipanova\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070894\",\n      \"description\":
+        \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n      \"id\":
+        16268,\n      \"milestones\": {},\n      \"name\": \"pulp-rpm\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"ipanova\",\n        \"name\":
+        \"ipanova\"\n      }\n    },\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"owner\": [\n
+        \         \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500070924\",\n
+        \     \"description\": \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n
+        \     \"id\": 16563,\n      \"milestones\": {},\n      \"name\": \"python-args\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070941\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
+        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
+        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"asmacdo\",\n          \"ipanova\",\n
+        \         \"jcline\",\n          \"bowlofeggs\",\n          \"jortel\"\n        ],\n
+        \       \"owner\": [\n          \"pcreech17\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070947\",\n      \"description\": \"The python-crane rpms\",\n      \"fullname\":
+        \"rpms/python-crane\",\n      \"id\": 16726,\n      \"milestones\": {},\n
+        \     \"name\": \"python-crane\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"pcreech17\",\n        \"name\": \"pcreech17\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070977\",\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070991\",\n      \"description\":
+        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
+        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"dscott\",\n          \"jcline\",\n          \"jmatthews\",\n
+        \         \"dcallagh\"\n        ],\n        \"owner\": [\n          \"jlaska\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070992\",\n      \"description\":
+        \"The python-isodate rpms\",\n      \"fullname\": \"rpms/python-isodate\",\n
+        \     \"id\": 17130,\n      \"milestones\": {},\n      \"name\": \"python-isodate\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jlaska\",\n
+        \       \"name\": \"jlaska\"\n      }\n    }\n  ],\n  \"total_projects\":
+        46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=1441714]
+      connection: [Keep-Alive]
+      content-length: ['15550']
+      content-type: [application/json]
+      date: ['Thu, 20 Jul 2017 19:00:21 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPRg.uC7CFnbrg5x-JXWCLosxi6AV96s;
+          Expires=Sun, 20-Aug-2017 19:00:22 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"page\": 3,\n    \"pattern\": null,\n    \"per_page\":
+        20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
+        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=3\",\n
+        \   \"next\": null,\n    \"page\": 3,\n    \"pages\": 3,\n    \"per_page\":
+        20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&page=2\"\n
+        \ },\n  \"projects\": [\n    {\n      \"access_groups\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [\n          \"pcreech17\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500071033\",\n      \"description\": \"The python-pkginfo rpms\",\n      \"fullname\":
+        \"rpms/python-pkginfo\",\n      \"id\": 17492,\n      \"milestones\": {},\n
+        \     \"name\": \"python-pkginfo\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"apevec\",\n          \"cstratak\",\n
+        \         \"amcnabb\",\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500071041\",\n      \"description\": \"The python-pymongo rpms\",\n      \"fullname\":
+        \"rpms/python-pymongo\",\n      \"id\": 17575,\n      \"milestones\": {},\n
+        \     \"name\": \"python-pymongo\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n
+        \     }\n    },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n
+        \       \"commit\": [],\n        \"ticket\": []\n      },\n      \"access_users\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"owner\": [\n
+        \         \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1500071049\",\n
+        \     \"description\": \"The python-releases rpms\",\n      \"fullname\":
+        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"jcline\"\n        ],\n        \"owner\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"ticket\": []\n      },\n
+        \     \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500071056\",\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
+        \"rpms/python-rpdb\",\n      \"id\": 17711,\n      \"milestones\": {},\n      \"name\":
+        \"python-rpdb\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"bowlofeggs\",\n        \"name\": \"bowlofeggs\"\n      }\n    },\n    {\n
+        \     \"access_groups\": {\n        \"admin\": [],\n        \"commit\": [],\n
+        \       \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"williamjmorenor\",\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500071066\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
+        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500071080\",\n      \"description\":
+        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
+        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
+        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=1615410]
+      connection: [Keep-Alive]
+      content-length: ['5015']
+      content-type: [application/json]
+      date: ['Thu, 20 Jul 2017 19:00:23 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPSA.rUGjVWvpxS5vO3X7_LSL-bw9VUU;
+          Expires=Sun, 20-Aug-2017 19:00:24 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=true&username=jcline&page=1
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"page\": 1,\n    \"pattern\": null,\n    \"per_page\":
+        20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
+        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
+        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=2\",\n
+        \   \"page\": 1,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
+        null\n  },\n  \"projects\": [\n    {\n      \"description\": \"The ejabberd
+        rpms\",\n      \"fullname\": \"rpms/ejabberd\",\n      \"name\": \"ejabberd\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
+        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-esip rpms\",\n      \"fullname\":
+        \"rpms/erlang-esip\",\n      \"name\": \"erlang-esip\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-ezlib rpms\",\n
+        \     \"fullname\": \"rpms/erlang-ezlib\",\n      \"name\": \"erlang-ezlib\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-fast_tls rpms\",\n      \"fullname\": \"rpms/erlang-fast_tls\",\n      \"name\":
+        \"erlang-fast_tls\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The erlang-fast_xml rpms\",\n      \"fullname\": \"rpms/erlang-fast_xml\",\n
+        \     \"name\": \"erlang-fast_xml\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-fast_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-fast_yaml\",\n      \"name\": \"erlang-fast_yaml\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-goldrush rpms\",\n
+        \     \"fullname\": \"rpms/erlang-goldrush\",\n      \"name\": \"erlang-goldrush\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-iconv rpms\",\n      \"fullname\": \"rpms/erlang-iconv\",\n      \"name\":
+        \"erlang-iconv\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The erlang-luerl rpms\",\n      \"fullname\": \"rpms/erlang-luerl\",\n      \"name\":
+        \"erlang-luerl\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The erlang-oauth2 rpms\",\n      \"fullname\": \"rpms/erlang-oauth2\",\n
+        \     \"name\": \"erlang-oauth2\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-p1_iconv rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_iconv\",\n      \"name\": \"erlang-p1_iconv\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_mysql rpms\",\n
+        \     \"fullname\": \"rpms/erlang-p1_mysql\",\n      \"name\": \"erlang-p1_mysql\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-p1_oauth2 rpms\",\n      \"fullname\": \"rpms/erlang-p1_oauth2\",\n
+        \     \"name\": \"erlang-p1_oauth2\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-p1_pam rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_pam\",\n      \"name\": \"erlang-p1_pam\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_pgsql rpms\",\n
+        \     \"fullname\": \"rpms/erlang-p1_pgsql\",\n      \"name\": \"erlang-p1_pgsql\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n      \"name\":
+        \"erlang-p1_sip\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
+        \     \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\"\n
+        \   },\n    {\n      \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_stun\",\n      \"name\": \"erlang-p1_stun\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_tls rpms\",\n
+        \     \"fullname\": \"rpms/erlang-p1_tls\",\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=1027258]
+      connection: [Keep-Alive]
+      content-length: ['3879']
+      content-type: [application/json]
+      date: ['Fri, 21 Jul 2017 16:46:57 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBgg.bLsal-e46I8A08jtHXOVT8T3EYY;
+          Expires=Mon, 21-Aug-2017 16:46:58 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=2
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"page\": 2,\n    \"pattern\": null,\n    \"per_page\":
+        20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
+        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
+        \   \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
+        \   \"page\": 2,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\":
+        \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\"\n
+        \ },\n  \"projects\": [\n    {\n      \"description\": \"The erlang-p1_utils
+        rpms\",\n      \"fullname\": \"rpms/erlang-p1_utils\",\n      \"name\": \"erlang-p1_utils\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n      \"name\":
+        \"erlang-p1_xml\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The erlang-p1_xmlrpc rpms\",\n      \"fullname\": \"rpms/erlang-p1_xmlrpc\",\n
+        \     \"name\": \"erlang-p1_xmlrpc\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-p1_yaml rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_yaml\",\n      \"name\": \"erlang-p1_yaml\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_zlib rpms\",\n
+        \     \"fullname\": \"rpms/erlang-p1_zlib\",\n      \"name\": \"erlang-p1_zlib\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-proper rpms\",\n      \"fullname\": \"rpms/erlang-proper\",\n      \"name\":
+        \"erlang-proper\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The erlang-stringprep rpms\",\n      \"fullname\": \"rpms/erlang-stringprep\",\n
+        \     \"name\": \"erlang-stringprep\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-stun rpms\",\n      \"fullname\":
+        \"rpms/erlang-stun\",\n      \"name\": \"erlang-stun\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The pulp rpms\",\n      \"fullname\":
+        \"rpms/pulp\",\n      \"name\": \"pulp\",\n      \"namespace\": \"rpms\"\n
+        \   },\n    {\n      \"description\": \"The pulp-docker rpms\",\n      \"fullname\":
+        \"rpms/pulp-docker\",\n      \"name\": \"pulp-docker\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The pulp-ostree rpms\",\n
+        \     \"fullname\": \"rpms/pulp-ostree\",\n      \"name\": \"pulp-ostree\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        pulp-puppet rpms\",\n      \"fullname\": \"rpms/pulp-puppet\",\n      \"name\":
+        \"pulp-puppet\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The pulp-python rpms\",\n      \"fullname\": \"rpms/pulp-python\",\n      \"name\":
+        \"pulp-python\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The pulp-rpm rpms\",\n      \"fullname\": \"rpms/pulp-rpm\",\n      \"name\":
+        \"pulp-rpm\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n      \"name\":
+        \"python-args\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-clint rpms\",\n      \"fullname\": \"rpms/python-clint\",\n      \"name\":
+        \"python-clint\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-crane rpms\",\n      \"fullname\": \"rpms/python-crane\",\n      \"name\":
+        \"python-crane\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"name\": \"python-flower\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The python-invocations rpms\",\n      \"fullname\":
+        \"rpms/python-invocations\",\n      \"name\": \"python-invocations\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The python-isodate rpms\",\n
+        \     \"fullname\": \"rpms/python-isodate\",\n      \"name\": \"python-isodate\",\n
+        \     \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=3207851]
+      connection: [Keep-Alive]
+      content-length: ['3888']
+      content-type: [application/json]
+      date: ['Fri, 21 Jul 2017 16:46:59 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBhg.rV6GwIH7OvnFZgKBsX3QQlOs4_w;
+          Expires=Mon, 21-Aug-2017 16:47:02 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": null,\n    \"page\": 3,\n    \"pattern\": null,\n    \"per_page\":
+        20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\": \"jcline\"\n
+        \ },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=3\",\n
+        \   \"next\": null,\n    \"page\": 3,\n    \"pages\": 3,\n    \"per_page\":
+        20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=true&page=2\"\n
+        \ },\n  \"projects\": [\n    {\n      \"description\": \"The python-pkginfo
+        rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        python-pymongo rpms\",\n      \"fullname\": \"rpms/python-pymongo\",\n      \"name\":
+        \"python-pymongo\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-releases rpms\",\n      \"fullname\": \"rpms/python-releases\",\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The python-rpdb rpms\",\n      \"fullname\":
+        \"rpms/python-rpdb\",\n      \"name\": \"python-rpdb\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"name\":
+        \"python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The python-twine rpms\",\n      \"fullname\":
+        \"rpms/python-twine\",\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\"\n    }\n  ],\n  \"total_projects\": 46\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=940724]
+      connection: [Keep-Alive]
+      content-length: ['1672']
+      content-type: [application/json]
+      date: ['Fri, 21 Jul 2017 16:47:02 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBhw.tvdXemYniw7P9cPgs5t8tiWCyK8;
+          Expires=Mon, 21-Aug-2017 16:47:03 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_point_of_contact
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_point_of_contact
@@ -5,592 +5,71 @@ interactions:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
+      User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&namespace=rpms
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&short=True&page=1
   response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        \"rpms\",\n    \"owner\": \"jcline\",\n    \"pattern\": null,\n    \"short\":
-        false,\n    \"tags\": [],\n    \"username\": null\n  },\n  \"projects\": [\n
-        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784743\",\n
-        \     \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
-        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
-        \     \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n
-        \     \"id\": 3271,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_sip\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
-        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
-        \     \"id\": 3272,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stringprep\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
-        \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
-        \     \"id\": 3273,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stun\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
-        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
-        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n
-        \     \"id\": 3278,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_yaml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785955\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
-        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
-        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
-        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
-        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
-        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
-        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
-        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
-        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
-        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
-        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
-        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
-        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
-        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 15\n}"}
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
+        namespace\": null,\n    \"owner\": \"jcline\",\n    \"page\": 1,\n    \"pattern\"\
+        : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
+        \    \"username\": null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=True&page=1\"\
+        ,\n    \"next\": null,\n    \"page\": 1,\n    \"pages\": 1,\n    \"per_page\"\
+        : 20,\n    \"prev\": null\n  },\n  \"projects\": [\n    {\n      \"description\"\
+        : \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\"\
+        ,\n      \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\"\n\
+        \    },\n    {\n      \"description\": \"The erlang-p1_sip rpms\",\n     \
+        \ \"fullname\": \"rpms/erlang-p1_sip\",\n      \"name\": \"erlang-p1_sip\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\"\
+        ,\n      \"name\": \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\"\
+        \n    },\n    {\n      \"description\": \"The erlang-p1_stun rpms\",\n   \
+        \   \"fullname\": \"rpms/erlang-p1_stun\",\n      \"name\": \"erlang-p1_stun\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n \
+        \     \"name\": \"erlang-p1_tls\",\n      \"namespace\": \"rpms\"\n    },\n\
+        \    {\n      \"description\": \"The erlang-p1_xml rpms\",\n      \"fullname\"\
+        : \"rpms/erlang-p1_xml\",\n      \"name\": \"erlang-p1_xml\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_yaml rpms\"\
+        ,\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n      \"name\": \"erlang-p1_yaml\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n     \
+        \ \"name\": \"python-args\",\n      \"namespace\": \"rpms\"\n    },\n    {\n\
+        \      \"description\": \"The python-clint rpms\",\n      \"fullname\": \"\
+        rpms/python-clint\",\n      \"name\": \"python-clint\",\n      \"namespace\"\
+        : \"rpms\"\n    },\n    {\n      \"description\": \"The python-cryptography\
+        \ rpms\",\n      \"fullname\": \"rpms/python-cryptography\",\n      \"name\"\
+        : \"python-cryptography\",\n      \"namespace\": \"rpms\"\n    },\n    {\n\
+        \      \"description\": \"The python-cryptography-vectors rpms\",\n      \"\
+        fullname\": \"rpms/python-cryptography-vectors\",\n      \"name\": \"python-cryptography-vectors\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n \
+        \     \"name\": \"python-flower\",\n      \"namespace\": \"rpms\"\n    },\n\
+        \    {\n      \"description\": \"The python-invocations rpms\",\n      \"\
+        fullname\": \"rpms/python-invocations\",\n      \"name\": \"python-invocations\"\
+        ,\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"\
+        The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n\
+        \      \"name\": \"python-pkginfo\",\n      \"namespace\": \"rpms\"\n    },\n\
+        \    {\n      \"description\": \"The python-releases rpms\",\n      \"fullname\"\
+        : \"rpms/python-releases\",\n      \"name\": \"python-releases\",\n      \"\
+        namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The python-sphinxcontrib-fulltoc\
+        \ rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n  \
+        \    \"name\": \"python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"\
+        rpms\"\n    },\n    {\n      \"description\": \"The python-twine rpms\",\n\
+        \      \"fullname\": \"rpms/python-twine\",\n      \"name\": \"python-twine\"\
+        ,\n      \"namespace\": \"rpms\"\n    }\n  ],\n  \"total_projects\": 17\n}"}
     headers:
       appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=708673]
+      apptime: [D=135713]
       connection: [Keep-Alive]
-      content-length: ['10797']
+      content-length: ['3399']
       content-type: [application/json]
-      date: ['Wed, 12 Jul 2017 18:32:23 GMT']
+      date: ['Mon, 31 Jul 2017 13:23:28 GMT']
       keep-alive: ['timeout=15, max=500']
       server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
           mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEf8uA.hlmGiJSYzxwukW6vLYgS4s3778U;
-          Expires=Sat, 12-Aug-2017 18:32:24 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": \"jcline\",\n    \"pattern\": null,\n    \"short\":
-        false,\n    \"tags\": [],\n    \"username\": null\n  },\n  \"projects\": [\n
-        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784743\",\n
-        \     \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
-        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
-        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
-        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
-        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
-        \     \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n
-        \     \"id\": 3271,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_sip\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
-        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
-        \     \"id\": 3272,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stringprep\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
-        \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
-        \     \"id\": 3273,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stun\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
-        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
-        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
-        \"The erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n
-        \     \"id\": 3278,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_yaml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785955\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
-        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
-        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
-        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
-        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
-        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
-        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
-        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
-        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
-        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
-        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
-        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
-        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
-        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 15\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=873071]
-      connection: [Keep-Alive]
-      content-length: ['10795']
-      content-type: [application/json]
-      date: ['Wed, 12 Jul 2017 18:51:02 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEgBFg.lM5huOORpa55M0ButUDvPwrSPhA;
-          Expires=Sat, 12-Aug-2017 18:51:02 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?page=1&owner=jcline
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": \"jcline\",\n    \"page\": 1,\n    \"pattern\": null,\n
-        \   \"per_page\": 20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\":
-        null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&page=1\",\n
-        \   \"next\": null,\n    \"page\": 1,\n    \"pages\": 1,\n    \"per_page\":
-        20,\n    \"prev\": null\n  },\n  \"projects\": [\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069208\",\n      \"description\":
-        \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
-        \     \"id\": 3207,\n      \"milestones\": {},\n      \"name\": \"erlang-cache_tab\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n      \"description\":
-        \"The erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n
-        \     \"id\": 3271,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_sip\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n      \"description\":
-        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
-        \     \"id\": 3272,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stringprep\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n      \"description\":
-        \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
-        \     \"id\": 3273,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stun\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
-        \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
-        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
-        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
-        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
-        \"The erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n
-        \     \"id\": 3278,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_yaml\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070924\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
-        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
-        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
-        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
-        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500070941\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
-        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
-        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070977\",\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500070991\",\n      \"description\":
-        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
-        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500071033\",\n      \"description\":
-        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
-        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500071049\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
-        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
-        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
-        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
-        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
-        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
-        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
-        [],\n        \"commit\": [\n          \"williamjmorenor\",\n          \"bowlofeggs\"\n
-        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
-        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
-        \"1500071066\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
-        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
-        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
-        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
-        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
-        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
-        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
-        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
-        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
-        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
-        \     \"custom_keys\": [],\n      \"date_created\": \"1500071080\",\n      \"description\":
-        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
-        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
-        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
-        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 15\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=897482]
-      connection: [Keep-Alive]
-      content-length: ['11146']
-      content-type: [application/json]
-      date: ['Thu, 20 Jul 2017 19:00:25 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPSg.0gK6hfUQO4_XIUPHP9BRmYXVrlc;
-          Expires=Sun, 20-Aug-2017 19:00:26 GMT; Secure; HttpOnly; Path=/pagure']
-      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.1]
-    method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=true&owner=jcline&page=1
-  response:
-    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
-        null,\n    \"owner\": \"jcline\",\n    \"page\": 1,\n    \"pattern\": null,\n
-        \   \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\":
-        null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=true&page=1\",\n
-        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=true&page=1\",\n
-        \   \"next\": null,\n    \"page\": 1,\n    \"pages\": 1,\n    \"per_page\":
-        20,\n    \"prev\": null\n  },\n  \"projects\": [\n    {\n      \"description\":
-        \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
-        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_sip\",\n      \"name\": \"erlang-p1_sip\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_stringprep
-        rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n      \"name\":
-        \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\"\n    },\n    {\n
-        \     \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
-        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\":
-        \"rpms/erlang-p1_tls\",\n      \"name\": \"erlang-p1_tls\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_xml rpms\",\n
-        \     \"fullname\": \"rpms/erlang-p1_xml\",\n      \"name\": \"erlang-p1_xml\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n      \"name\":
-        \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n      \"name\":
-        \"python-args\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-clint rpms\",\n      \"fullname\": \"rpms/python-clint\",\n      \"name\":
-        \"python-clint\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
-        \     \"name\": \"python-flower\",\n      \"namespace\": \"rpms\"\n    },\n
-        \   {\n      \"description\": \"The python-invocations rpms\",\n      \"fullname\":
-        \"rpms/python-invocations\",\n      \"name\": \"python-invocations\",\n      \"namespace\":
-        \"rpms\"\n    },\n    {\n      \"description\": \"The python-pkginfo rpms\",\n
-        \     \"fullname\": \"rpms/python-pkginfo\",\n      \"name\": \"python-pkginfo\",\n
-        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
-        python-releases rpms\",\n      \"fullname\": \"rpms/python-releases\",\n      \"name\":
-        \"python-releases\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
-        \"The python-sphinxcontrib-fulltoc rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n
-        \     \"name\": \"python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\"\n
-        \   },\n    {\n      \"description\": \"The python-twine rpms\",\n      \"fullname\":
-        \"rpms/python-twine\",\n      \"name\": \"python-twine\",\n      \"namespace\":
-        \"rpms\"\n    }\n  ],\n  \"total_projects\": 15\n}"}
-    headers:
-      appserver: [proxy01.stg.phx2.fedoraproject.org]
-      apptime: [D=150513]
-      connection: [Keep-Alive]
-      content-length: ['3025']
-      content-type: [application/json]
-      date: ['Fri, 21 Jul 2017 16:47:04 GMT']
-      keep-alive: ['timeout=15, max=500']
-      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
-          mod_wsgi/3.4 Python/2.7.5]
-      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBiA.odChespeDQib-YUtlyGhStzkz-g;
-          Expires=Mon, 21-Aug-2017 16:47:04 GMT; Secure; HttpOnly; Path=/pagure']
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DGDA0A.lHdfvgjM0o3ywuyk0qxIVvhHd5M;
+          Expires=Thu, 31-Aug-2017 13:23:28 GMT; Secure; HttpOnly; Path=/pagure']
       strict-transport-security: [max-age=15768000; includeSubDomains; preload]
     status: {code: 200, message: OK}
 version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_point_of_contact
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_point_of_contact
@@ -1,0 +1,596 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&namespace=rpms
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        \"rpms\",\n    \"owner\": \"jcline\",\n    \"pattern\": null,\n    \"short\":
+        false,\n    \"tags\": [],\n    \"username\": null\n  },\n  \"projects\": [\n
+        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784743\",\n
+        \     \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
+        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
+        \     \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n
+        \     \"id\": 3271,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_sip\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
+        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
+        \     \"id\": 3272,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stringprep\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
+        \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
+        \     \"id\": 3273,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stun\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
+        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
+        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n
+        \     \"id\": 3278,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_yaml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785955\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
+        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
+        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
+        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
+        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
+        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
+        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
+        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
+        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
+        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
+        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
+        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
+        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
+        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 15\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=708673]
+      connection: [Keep-Alive]
+      content-length: ['10797']
+      content-type: [application/json]
+      date: ['Wed, 12 Jul 2017 18:32:23 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEf8uA.hlmGiJSYzxwukW6vLYgS4s3778U;
+          Expires=Sat, 12-Aug-2017 18:32:24 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": \"jcline\",\n    \"pattern\": null,\n    \"short\":
+        false,\n    \"tags\": [],\n    \"username\": null\n  },\n  \"projects\": [\n
+        \   {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784743\",\n
+        \     \"description\": \"The erlang-cache_tab rpms\",\n      \"fullname\":
+        \"rpms/erlang-cache_tab\",\n      \"id\": 3207,\n      \"milestones\": {},\n
+        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\"\n        ],\n        \"owner\":
+        [\n          \"jcline\"\n        ],\n        \"ticket\": []\n      },\n      \"close_status\":
+        [],\n      \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n
+        \     \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n
+        \     \"id\": 3271,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_sip\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
+        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
+        \     \"id\": 3272,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stringprep\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784748\",\n      \"description\":
+        \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
+        \     \"id\": 3273,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stun\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
+        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
+        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499784749\",\n      \"description\":
+        \"The erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n
+        \     \"id\": 3278,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_yaml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785955\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
+        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
+        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499785966\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
+        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
+        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499785992\",\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786002\",\n      \"description\":
+        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
+        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786034\",\n      \"description\":
+        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
+        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786043\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
+        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"bowlofeggs\",\n          \"williamjmorenor\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1499786055\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
+        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1499786064\",\n      \"description\":
+        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
+        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
+        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 15\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=873071]
+      connection: [Keep-Alive]
+      content-length: ['10795']
+      content-type: [application/json]
+      date: ['Wed, 12 Jul 2017 18:51:02 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DEgBFg.lM5huOORpa55M0ButUDvPwrSPhA;
+          Expires=Sat, 12-Aug-2017 18:51:02 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?page=1&owner=jcline
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": \"jcline\",\n    \"page\": 1,\n    \"pattern\": null,\n
+        \   \"per_page\": 20,\n    \"short\": false,\n    \"tags\": [],\n    \"username\":
+        null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&page=1\",\n
+        \   \"next\": null,\n    \"page\": 1,\n    \"pages\": 1,\n    \"per_page\":
+        20,\n    \"prev\": null\n  },\n  \"projects\": [\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069208\",\n      \"description\":
+        \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
+        \     \"id\": 3207,\n      \"milestones\": {},\n      \"name\": \"erlang-cache_tab\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n      \"description\":
+        \"The erlang-p1_sip rpms\",\n      \"fullname\": \"rpms/erlang-p1_sip\",\n
+        \     \"id\": 3271,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_sip\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n      \"description\":
+        \"The erlang-p1_stringprep rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n
+        \     \"id\": 3272,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stringprep\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069213\",\n      \"description\":
+        \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
+        \     \"id\": 3273,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_stun\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
+        \"The erlang-p1_tls rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n
+        \     \"id\": 3274,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_tls\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
+        \"The erlang-p1_xml rpms\",\n      \"fullname\": \"rpms/erlang-p1_xml\",\n
+        \     \"id\": 3276,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_xml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500069214\",\n      \"description\":
+        \"The erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n
+        \     \"id\": 3278,\n      \"milestones\": {},\n      \"name\": \"erlang-p1_yaml\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070924\",\n      \"description\": \"The python-args rpms\",\n      \"fullname\":
+        \"rpms/python-args\",\n      \"id\": 16563,\n      \"milestones\": {},\n      \"name\":
+        \"python-args\",\n      \"namespace\": \"rpms\",\n      \"parent\": null,\n
+        \     \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\":
+        \"jcline\",\n        \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500070941\",\n      \"description\": \"The python-clint rpms\",\n      \"fullname\":
+        \"rpms/python-clint\",\n      \"id\": 16685,\n      \"milestones\": {},\n
+        \     \"name\": \"python-clint\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070977\",\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"id\": 16983,\n      \"milestones\": {},\n      \"name\": \"python-flower\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500070991\",\n      \"description\":
+        \"The python-invocations rpms\",\n      \"fullname\": \"rpms/python-invocations\",\n
+        \     \"id\": 17115,\n      \"milestones\": {},\n      \"name\": \"python-invocations\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"pcreech17\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500071033\",\n      \"description\":
+        \"The python-pkginfo rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n
+        \     \"id\": 17492,\n      \"milestones\": {},\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500071049\",\n      \"description\": \"The python-releases rpms\",\n      \"fullname\":
+        \"rpms/python-releases\",\n      \"id\": 17658,\n      \"milestones\": {},\n
+        \     \"name\": \"python-releases\",\n      \"namespace\": \"rpms\",\n      \"parent\":
+        null,\n      \"priorities\": {},\n      \"tags\": [],\n      \"user\": {\n
+        \       \"fullname\": \"jcline\",\n        \"name\": \"jcline\"\n      }\n
+        \   },\n    {\n      \"access_groups\": {\n        \"admin\": [],\n        \"commit\":
+        [],\n        \"ticket\": []\n      },\n      \"access_users\": {\n        \"admin\":
+        [],\n        \"commit\": [\n          \"williamjmorenor\",\n          \"bowlofeggs\"\n
+        \       ],\n        \"owner\": [\n          \"jcline\"\n        ],\n        \"ticket\":
+        []\n      },\n      \"close_status\": [],\n      \"custom_keys\": [],\n      \"date_created\":
+        \"1500071066\",\n      \"description\": \"The python-sphinxcontrib-fulltoc
+        rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n      \"id\":
+        17808,\n      \"milestones\": {},\n      \"name\": \"python-sphinxcontrib-fulltoc\",\n
+        \     \"namespace\": \"rpms\",\n      \"parent\": null,\n      \"priorities\":
+        {},\n      \"tags\": [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n
+        \       \"name\": \"jcline\"\n      }\n    },\n    {\n      \"access_groups\":
+        {\n        \"admin\": [],\n        \"commit\": [],\n        \"ticket\": []\n
+        \     },\n      \"access_users\": {\n        \"admin\": [],\n        \"commit\":
+        [\n          \"bowlofeggs\"\n        ],\n        \"owner\": [\n          \"jcline\"\n
+        \       ],\n        \"ticket\": []\n      },\n      \"close_status\": [],\n
+        \     \"custom_keys\": [],\n      \"date_created\": \"1500071080\",\n      \"description\":
+        \"The python-twine rpms\",\n      \"fullname\": \"rpms/python-twine\",\n      \"id\":
+        17942,\n      \"milestones\": {},\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\",\n      \"parent\": null,\n      \"priorities\": {},\n      \"tags\":
+        [],\n      \"user\": {\n        \"fullname\": \"jcline\",\n        \"name\":
+        \"jcline\"\n      }\n    }\n  ],\n  \"total_projects\": 15\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=897482]
+      connection: [Keep-Alive]
+      content-length: ['11146']
+      content-type: [application/json]
+      date: ['Thu, 20 Jul 2017 19:00:25 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFKPSg.0gK6hfUQO4_XIUPHP9BRmYXVrlc;
+          Expires=Sun, 20-Aug-2017 19:00:26 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.1]
+    method: GET
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=true&owner=jcline&page=1
+  response:
+    body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"namespace\":
+        null,\n    \"owner\": \"jcline\",\n    \"page\": 1,\n    \"pattern\": null,\n
+        \   \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n    \"username\":
+        null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=true&page=1\",\n
+        \   \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=true&page=1\",\n
+        \   \"next\": null,\n    \"page\": 1,\n    \"pages\": 1,\n    \"per_page\":
+        20,\n    \"prev\": null\n  },\n  \"projects\": [\n    {\n      \"description\":
+        \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\",\n
+        \     \"name\": \"erlang-cache_tab\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-p1_sip rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_sip\",\n      \"name\": \"erlang-p1_sip\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_stringprep
+        rpms\",\n      \"fullname\": \"rpms/erlang-p1_stringprep\",\n      \"name\":
+        \"erlang-p1_stringprep\",\n      \"namespace\": \"rpms\"\n    },\n    {\n
+        \     \"description\": \"The erlang-p1_stun rpms\",\n      \"fullname\": \"rpms/erlang-p1_stun\",\n
+        \     \"name\": \"erlang-p1_stun\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The erlang-p1_tls rpms\",\n      \"fullname\":
+        \"rpms/erlang-p1_tls\",\n      \"name\": \"erlang-p1_tls\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The erlang-p1_xml rpms\",\n
+        \     \"fullname\": \"rpms/erlang-p1_xml\",\n      \"name\": \"erlang-p1_xml\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        erlang-p1_yaml rpms\",\n      \"fullname\": \"rpms/erlang-p1_yaml\",\n      \"name\":
+        \"erlang-p1_yaml\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-args rpms\",\n      \"fullname\": \"rpms/python-args\",\n      \"name\":
+        \"python-args\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-clint rpms\",\n      \"fullname\": \"rpms/python-clint\",\n      \"name\":
+        \"python-clint\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-flower rpms\",\n      \"fullname\": \"rpms/python-flower\",\n
+        \     \"name\": \"python-flower\",\n      \"namespace\": \"rpms\"\n    },\n
+        \   {\n      \"description\": \"The python-invocations rpms\",\n      \"fullname\":
+        \"rpms/python-invocations\",\n      \"name\": \"python-invocations\",\n      \"namespace\":
+        \"rpms\"\n    },\n    {\n      \"description\": \"The python-pkginfo rpms\",\n
+        \     \"fullname\": \"rpms/python-pkginfo\",\n      \"name\": \"python-pkginfo\",\n
+        \     \"namespace\": \"rpms\"\n    },\n    {\n      \"description\": \"The
+        python-releases rpms\",\n      \"fullname\": \"rpms/python-releases\",\n      \"name\":
+        \"python-releases\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\":
+        \"The python-sphinxcontrib-fulltoc rpms\",\n      \"fullname\": \"rpms/python-sphinxcontrib-fulltoc\",\n
+        \     \"name\": \"python-sphinxcontrib-fulltoc\",\n      \"namespace\": \"rpms\"\n
+        \   },\n    {\n      \"description\": \"The python-twine rpms\",\n      \"fullname\":
+        \"rpms/python-twine\",\n      \"name\": \"python-twine\",\n      \"namespace\":
+        \"rpms\"\n    }\n  ],\n  \"total_projects\": 15\n}"}
+    headers:
+      appserver: [proxy01.stg.phx2.fedoraproject.org]
+      apptime: [D=150513]
+      connection: [Keep-Alive]
+      content-length: ['3025']
+      content-type: [application/json]
+      date: ['Fri, 21 Jul 2017 16:47:04 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0
+          mod_wsgi/3.4 Python/2.7.5]
+      set-cookie: ['disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlfQ.DFPBiA.odChespeDQib-YUtlyGhStzkz-g;
+          Expires=Mon, 21-Aug-2017 16:47:04 GMT; Secure; HttpOnly; Path=/pagure']
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagersForTests.test_error_response
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagersForTests.test_error_response
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.2]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/package/notanamespace/orapackage
+  response:
+    body: {string: !!python/unicode "{\n  \"error\": \"Package: notanamespace/orapackage\
+        \ not found\",\n  \"output\": \"notok\"\n}"}
+    headers:
+      age: ['0']
+      appserver: [proxy03.fedoraproject.org]
+      apptime: [D=62401]
+      connection: [Keep-Alive]
+      content-length: ['81']
+      content-type: [application/json]
+      date: ['Mon, 31 Jul 2017 14:33:00 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['71665427']
+    status: {code: 404, message: NOT FOUND}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagersForTests.test_groups
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagersForTests.test_groups
@@ -1,0 +1,627 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.2]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/package/rpms/python-urllib3
+  response:
+    body: {string: !!python/unicode "{\n  \"output\": \"ok\",\n  \"packages\": [\n\
+        \    {\n      \"acls\": [\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"ralph\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"watchbugzilla\",\n          \"\
+        fas_name\": \"ralph\",\n          \"status\": \"Approved\"\n        },\n \
+        \       {\n          \"acl\": \"commit\",\n          \"fas_name\": \"ralph\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"approveacls\",\n          \"fas_name\": \"ralph\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"sagarun\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"sagarun\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"watchcommits\",\n          \"fas_name\": \"sagarun\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"commit\",\n          \"fas_name\": \"toshio\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"toshio\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"toshio\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\"\
+        : \"toshio\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"watchcommits\",\n          \"fas_name\": \"terminalmage\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"terminalmage\",\n   \
+        \       \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\"\
+        : \"commit\",\n          \"fas_name\": \"group::infra-sig\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"group::infra-sig\",\n          \"status\": \"\
+        Approved\"\n        },\n        {\n          \"acl\": \"watchbugzilla\",\n\
+        \          \"fas_name\": \"group::infra-sig\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"jcline\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\"\
+        : \"jcline\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"jcline\",\n   \
+        \       \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"commit\",\n          \"fas_name\": \"cstratak\",\n          \"status\"\
+        : \"Denied\"\n        },\n        {\n          \"acl\": \"commit\",\n    \
+        \      \"fas_name\": \"group::provenpackager\",\n          \"status\": \"\
+        Approved\"\n        }\n      ],\n      \"collection\": {\n        \"allow_retire\"\
+        : true,\n        \"branchname\": \"master\",\n        \"date_created\": \"\
+        2014-05-14 12:36:15\",\n        \"date_updated\": \"2017-02-28 20:24:14\"\
+        ,\n        \"dist_tag\": \".fc27\",\n        \"koji_name\": \"rawhide\",\n\
+        \        \"name\": \"Fedora\",\n        \"status\": \"Under Development\"\
+        ,\n        \"version\": \"devel\"\n      },\n      \"critpath\": true,\n \
+        \     \"package\": {\n        \"acls\": [],\n        \"creation_date\": 1400070978.0,\n\
+        \        \"description\": \"Python HTTP module with connection pooling and\
+        \ file POST abilities.\",\n        \"koschei_monitor\": false,\n        \"\
+        monitor\": true,\n        \"name\": \"python-urllib3\",\n        \"namespace\"\
+        : \"rpms\",\n        \"review_url\": null,\n        \"status\": \"Approved\"\
+        ,\n        \"summary\": \"Python HTTP library with thread-safe connection\
+        \ pooling and file post\",\n        \"upstream_url\": \"https://github.com/shazow/urllib3\"\
+        \n      },\n      \"point_of_contact\": \"group::infra-sig\",\n      \"status\"\
+        : \"Approved\",\n      \"status_change\": 1476977100.0\n    },\n    {\n  \
+        \    \"acls\": [\n        {\n          \"acl\": \"commit\",\n          \"\
+        fas_name\": \"sagarun\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\"\
+        : \"sagarun\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"toshio\",\n   \
+        \       \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\"\
+        : \"approveacls\",\n          \"fas_name\": \"toshio\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"toshio\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"toshio\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\":\
+        \ \"sagarun\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"watchcommits\",\n          \"fas_name\": \"ralph\",\n\
+        \          \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\"\
+        : \"watchcommits\",\n          \"fas_name\": \"terminalmage\",\n         \
+        \ \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"terminalmage\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"ralph\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"ralph\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"approveacls\",\n          \"fas_name\": \"ralph\",\n          \"\
+        status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"commit\"\
+        ,\n          \"fas_name\": \"group::infra-sig\",\n          \"status\": \"\
+        Approved\"\n        },\n        {\n          \"acl\": \"watchcommits\",\n\
+        \          \"fas_name\": \"group::infra-sig\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"group::infra-sig\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"cstratak\",\n          \"status\": \"Awaiting Review\"\n        },\n \
+        \       {\n          \"acl\": \"commit\",\n          \"fas_name\": \"group::provenpackager\"\
+        ,\n          \"status\": \"Approved\"\n        }\n      ],\n      \"collection\"\
+        : {\n        \"allow_retire\": true,\n        \"branchname\": \"el6\",\n \
+        \       \"date_created\": \"2014-05-14 12:36:15\",\n        \"date_updated\"\
+        : \"2015-12-08 15:17:58\",\n        \"dist_tag\": \".el6\",\n        \"koji_name\"\
+        : \"dist-6E-epel\",\n        \"name\": \"Fedora EPEL\",\n        \"status\"\
+        : \"Active\",\n        \"version\": \"6\"\n      },\n      \"critpath\": false,\n\
+        \      \"package\": {\n        \"acls\": [],\n        \"creation_date\": 1400070978.0,\n\
+        \        \"description\": \"Python HTTP module with connection pooling and\
+        \ file POST abilities.\",\n        \"koschei_monitor\": false,\n        \"\
+        monitor\": true,\n        \"name\": \"python-urllib3\",\n        \"namespace\"\
+        : \"rpms\",\n        \"review_url\": null,\n        \"status\": \"Approved\"\
+        ,\n        \"summary\": \"Python HTTP library with thread-safe connection\
+        \ pooling and file post\",\n        \"upstream_url\": \"https://github.com/shazow/urllib3\"\
+        \n      },\n      \"point_of_contact\": \"orphan\",\n      \"status\": \"\
+        Retired\",\n      \"status_change\": 1442348140.0\n    },\n    {\n      \"\
+        acls\": [\n        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\"\
+        : \"sagarun\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"sagarun\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"approveacls\",\n          \"fas_name\": \"sagarun\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"commit\"\
+        ,\n          \"fas_name\": \"sagarun\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"toshio\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\"\
+        : \"toshio\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"toshio\",\n   \
+        \       \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\"\
+        : \"approveacls\",\n          \"fas_name\": \"toshio\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"ralph\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"watchbugzilla\",\n          \"\
+        fas_name\": \"ralph\",\n          \"status\": \"Approved\"\n        },\n \
+        \       {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"\
+        ralph\",\n          \"status\": \"Approved\"\n        },\n        {\n    \
+        \      \"acl\": \"commit\",\n          \"fas_name\": \"ralph\",\n        \
+        \  \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"\
+        watchcommits\",\n          \"fas_name\": \"terminalmage\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"terminalmage\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"group::infra-sig\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\":\
+        \ \"group::infra-sig\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\"\
+        : \"group::infra-sig\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"abompard\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"abompard\",\n       \
+        \   \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"\
+        watchcommits\",\n          \"fas_name\": \"abompard\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"abompard\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"cstratak\",\n          \"status\": \"Denied\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"group::provenpackager\"\
+        ,\n          \"status\": \"Approved\"\n        }\n      ],\n      \"collection\"\
+        : {\n        \"allow_retire\": true,\n        \"branchname\": \"epel7\",\n\
+        \        \"date_created\": \"2014-05-14 12:36:15\",\n        \"date_updated\"\
+        : \"2015-12-08 15:16:41\",\n        \"dist_tag\": \".el7\",\n        \"koji_name\"\
+        : \"epel7\",\n        \"name\": \"Fedora EPEL\",\n        \"status\": \"Active\"\
+        ,\n        \"version\": \"7\"\n      },\n      \"critpath\": false,\n    \
+        \  \"package\": {\n        \"acls\": [],\n        \"creation_date\": 1400070978.0,\n\
+        \        \"description\": \"Python HTTP module with connection pooling and\
+        \ file POST abilities.\",\n        \"koschei_monitor\": false,\n        \"\
+        monitor\": true,\n        \"name\": \"python-urllib3\",\n        \"namespace\"\
+        : \"rpms\",\n        \"review_url\": null,\n        \"status\": \"Approved\"\
+        ,\n        \"summary\": \"Python HTTP library with thread-safe connection\
+        \ pooling and file post\",\n        \"upstream_url\": \"https://github.com/shazow/urllib3\"\
+        \n      },\n      \"point_of_contact\": \"abompard\",\n      \"status\": \"\
+        Approved\",\n      \"status_change\": 1473855839.0\n    },\n    {\n      \"\
+        acls\": [\n        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\"\
+        : \"ralph\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"ralph\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"commit\",\n          \"fas_name\": \"ralph\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"ralph\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"watchbugzilla\",\n          \"\
+        fas_name\": \"sagarun\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"sagarun\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"sagarun\",\n         \
+        \ \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"commit\"\
+        ,\n          \"fas_name\": \"toshio\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"approveacls\",\n          \"\
+        fas_name\": \"toshio\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\":\
+        \ \"toshio\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"toshio\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"terminalmage\",\n    \
+        \      \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\"\
+        : \"watchbugzilla\",\n          \"fas_name\": \"terminalmage\",\n        \
+        \  \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"\
+        commit\",\n          \"fas_name\": \"group::infra-sig\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"group::infra-sig\",\n          \"status\": \"\
+        Approved\"\n        },\n        {\n          \"acl\": \"watchbugzilla\",\n\
+        \          \"fas_name\": \"group::infra-sig\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"jcline\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\"\
+        : \"jcline\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"jcline\",\n   \
+        \       \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"commit\",\n          \"fas_name\": \"cstratak\",\n          \"status\"\
+        : \"Denied\"\n        },\n        {\n          \"acl\": \"commit\",\n    \
+        \      \"fas_name\": \"group::provenpackager\",\n          \"status\": \"\
+        Approved\"\n        }\n      ],\n      \"collection\": {\n        \"allow_retire\"\
+        : false,\n        \"branchname\": \"f24\",\n        \"date_created\": \"2016-02-23\
+        \ 22:57:55\",\n        \"date_updated\": \"2016-06-21 13:54:27\",\n      \
+        \  \"dist_tag\": \".fc24\",\n        \"koji_name\": \"f24\",\n        \"name\"\
+        : \"Fedora\",\n        \"status\": \"Active\",\n        \"version\": \"24\"\
+        \n      },\n      \"critpath\": true,\n      \"package\": {\n        \"acls\"\
+        : [],\n        \"creation_date\": 1400070978.0,\n        \"description\":\
+        \ \"Python HTTP module with connection pooling and file POST abilities.\"\
+        ,\n        \"koschei_monitor\": false,\n        \"monitor\": true,\n     \
+        \   \"name\": \"python-urllib3\",\n        \"namespace\": \"rpms\",\n    \
+        \    \"review_url\": null,\n        \"status\": \"Approved\",\n        \"\
+        summary\": \"Python HTTP library with thread-safe connection pooling and file\
+        \ post\",\n        \"upstream_url\": \"https://github.com/shazow/urllib3\"\
+        \n      },\n      \"point_of_contact\": \"group::infra-sig\",\n      \"status\"\
+        : \"Approved\",\n      \"status_change\": 1493740960.0\n    },\n    {\n  \
+        \    \"acls\": [\n        {\n          \"acl\": \"commit\",\n          \"\
+        fas_name\": \"group::infra-sig\",\n          \"status\": \"Approved\"\n  \
+        \      },\n        {\n          \"acl\": \"watchbugzilla\",\n          \"\
+        fas_name\": \"group::infra-sig\",\n          \"status\": \"Approved\"\n  \
+        \      },\n        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\"\
+        : \"group::infra-sig\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\"\
+        : \"jcline\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"watchcommits\",\n          \"fas_name\": \"jcline\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"approveacls\",\n          \"fas_name\": \"ralph\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"commit\"\
+        ,\n          \"fas_name\": \"ralph\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"watchbugzilla\",\n          \"\
+        fas_name\": \"ralph\",\n          \"status\": \"Approved\"\n        },\n \
+        \       {\n          \"acl\": \"watchcommits\",\n          \"fas_name\": \"\
+        ralph\",\n          \"status\": \"Approved\"\n        },\n        {\n    \
+        \      \"acl\": \"commit\",\n          \"fas_name\": \"sagarun\",\n      \
+        \    \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"\
+        watchbugzilla\",\n          \"fas_name\": \"sagarun\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"sagarun\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"terminalmage\",\n          \"status\": \"Obsolete\"\n  \
+        \      },\n        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\"\
+        : \"terminalmage\",\n          \"status\": \"Obsolete\"\n        },\n    \
+        \    {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"toshio\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"commit\",\n          \"fas_name\": \"toshio\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"toshio\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"toshio\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"jcline\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"commit\",\n          \"fas_name\": \"cstratak\",\n          \"status\"\
+        : \"Denied\"\n        },\n        {\n          \"acl\": \"commit\",\n    \
+        \      \"fas_name\": \"group::provenpackager\",\n          \"status\": \"\
+        Approved\"\n        }\n      ],\n      \"collection\": {\n        \"allow_retire\"\
+        : false,\n        \"branchname\": \"f25\",\n        \"date_created\": \"2016-07-26\
+        \ 13:50:32\",\n        \"date_updated\": \"2016-11-22 14:31:43\",\n      \
+        \  \"dist_tag\": \".fc25\",\n        \"koji_name\": \"f25\",\n        \"name\"\
+        : \"Fedora\",\n        \"status\": \"Active\",\n        \"version\": \"25\"\
+        \n      },\n      \"critpath\": true,\n      \"package\": {\n        \"acls\"\
+        : [],\n        \"creation_date\": 1400070978.0,\n        \"description\":\
+        \ \"Python HTTP module with connection pooling and file POST abilities.\"\
+        ,\n        \"koschei_monitor\": false,\n        \"monitor\": true,\n     \
+        \   \"name\": \"python-urllib3\",\n        \"namespace\": \"rpms\",\n    \
+        \    \"review_url\": null,\n        \"status\": \"Approved\",\n        \"\
+        summary\": \"Python HTTP library with thread-safe connection pooling and file\
+        \ post\",\n        \"upstream_url\": \"https://github.com/shazow/urllib3\"\
+        \n      },\n      \"point_of_contact\": \"group::infra-sig\",\n      \"status\"\
+        : \"Approved\",\n      \"status_change\": 1476969598.0\n    },\n    {\n  \
+        \    \"acls\": [\n        {\n          \"acl\": \"commit\",\n          \"\
+        fas_name\": \"cstratak\",\n          \"status\": \"Denied\"\n        },\n\
+        \        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"group::infra-sig\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"group::infra-sig\",\n\
+        \          \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"watchcommits\",\n          \"fas_name\": \"group::infra-sig\",\n     \
+        \     \"status\": \"Approved\"\n        },\n        {\n          \"acl\":\
+        \ \"commit\",\n          \"fas_name\": \"jcline\",\n          \"status\":\
+        \ \"Approved\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"jcline\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"jcline\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"\
+        ralph\",\n          \"status\": \"Approved\"\n        },\n        {\n    \
+        \      \"acl\": \"commit\",\n          \"fas_name\": \"ralph\",\n        \
+        \  \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"\
+        watchbugzilla\",\n          \"fas_name\": \"ralph\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"ralph\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"sagarun\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"sagarun\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"sagarun\",\n         \
+        \ \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"terminalmage\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"terminalmage\",\n          \"status\": \"Obsolete\"\n      \
+        \  },\n        {\n          \"acl\": \"approveacls\",\n          \"fas_name\"\
+        : \"toshio\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"toshio\",\n   \
+        \       \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\"\
+        : \"watchbugzilla\",\n          \"fas_name\": \"toshio\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"toshio\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"group::provenpackager\",\n          \"status\": \"Approved\"\n       \
+        \ }\n      ],\n      \"collection\": {\n        \"allow_retire\": false,\n\
+        \        \"branchname\": \"f26\",\n        \"date_created\": \"2017-02-28\
+        \ 20:24:57\",\n        \"date_updated\": \"2017-07-11 14:04:59\",\n      \
+        \  \"dist_tag\": \".fc26\",\n        \"koji_name\": \"f26\",\n        \"name\"\
+        : \"Fedora\",\n        \"status\": \"Active\",\n        \"version\": \"26\"\
+        \n      },\n      \"critpath\": true,\n      \"package\": {\n        \"acls\"\
+        : [],\n        \"creation_date\": 1400070978.0,\n        \"description\":\
+        \ \"Python HTTP module with connection pooling and file POST abilities.\"\
+        ,\n        \"koschei_monitor\": false,\n        \"monitor\": true,\n     \
+        \   \"name\": \"python-urllib3\",\n        \"namespace\": \"rpms\",\n    \
+        \    \"review_url\": null,\n        \"status\": \"Approved\",\n        \"\
+        summary\": \"Python HTTP library with thread-safe connection pooling and file\
+        \ post\",\n        \"upstream_url\": \"https://github.com/shazow/urllib3\"\
+        \n      },\n      \"point_of_contact\": \"group::infra-sig\",\n      \"status\"\
+        : \"Approved\",\n      \"status_change\": 1493738712.0\n    }\n  ]\n}"}
+    headers:
+      accept-ranges: [bytes]
+      age: ['0']
+      appserver: [proxy12.fedoraproject.org]
+      apptime: [D=3139608]
+      connection: [Keep-Alive]
+      content-length: ['20838']
+      content-type: [application/json]
+      date: ['Mon, 31 Jul 2017 14:33:00 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['65576363']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'password=supersecret&login=Login&user_name=jcline'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['98']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-agent: [Fedora Account System Client/0.9.0]
+    method: POST
+    uri: https://admin.fedoraproject.org/accounts/group/dump/provenpackager
+  response:
+    body: {string: "{\"tg_flash\": null, \"people\": [[\"abompard\", \"aurelien@bompard.org\"\
+        , \"Aurelien Bompard\", \"user\", 0], [\"adamwill\", \"awilliam@redhat.com\"\
+        , \"Adam Williamson\", \"user\", 0], [\"adrian\", \"adrian@lisas.de\", \"\
+        Adrian Reber\", \"user\", 0], [\"airlied\", \"airlied@redhat.com\", \"Dave\
+        \ Airlie\", \"user\", 0], [\"ajax\", \"ajax@redhat.com\", \"Adam Jackson\"\
+        , \"user\", 0], [\"akurtakov\", \"akurtako@redhat.com\", \"Alexander Kurtakov\"\
+        , \"user\", 0], [\"alexl\", \"alexl@redhat.com\", \"Alexander Larsson\", \"\
+        user\", 0], [\"alexlan\", \"alexl@users.sourceforge.net\", \"\", \"user\"\
+        , 0], [\"amigadave\", \"amigadave@amigadave.com\", \"David King\", \"user\"\
+        , 0], [\"arg\", \"agrimm@gmail.com\", \"Andy Grimm\", \"user\", 0], [\"athimm\"\
+        , \"Axel.Thimm@ATrpms.net\", \"Axel Thimm\", \"user\", 0], [\"atkac\", \"\
+        vonsch@gmail.com\", \"Adam Tkac\", \"user\", 0], [\"ausil\", \"dennis@ausil.us\"\
+        , \"Dennis Gilmore\", \"administrator\", 0], [\"averi\", \"andrea.veri@gmail.com\"\
+        , \"\", \"user\", 0], [\"awjb\", \"andreas.bierfert@lowlatency.de\", \"Andreas\
+        \ Bierfert\", \"user\", 0], [\"bernie\", \"bernie+fedora@codewiz.org\", \"\
+        Bernie Innocenti\", \"user\", 0], [\"besser82\", \"fedora@besser82.io\", \"\
+        Bj\xF6rn Esser\", \"user\", 0], [\"bkabrda\", \"bkabrda@redhat.com\", \"Bohuslav\
+        \ Kabrda\", \"user\", 0], [\"bpepple\", \"bdpepple@gmail.com\", \"Brian Pepple\"\
+        , \"administrator\", 1], [\"bruno\", \"bruno@wolff.to\", \"Bruno Wolff III\"\
+        , \"user\", 0], [\"c4chris\", \"Christian.Iseli@unil.ch\", \"Christian Iseli\"\
+        , \"user\", 0], [\"caillon\", \"caillon+fedoraproject@gmail.com\", \"Christopher\
+        \ Aillon\", \"user\", 0], [\"caolanm\", \"caolanm@redhat.com\", \"Caol\xE1\
+        n McNamara\", \"user\", 0], [\"cebbert\", \"cebbert@redhat.com\", \"Chuck\
+        \ Ebbert\", \"user\", 0], [\"chitlesh\", \"chitlesh@gmail.com\", \"Chitlesh\
+        \ GOORAH\", \"user\", 0], [\"chkr\", \"chkr@plauener.de\", \"Christian Krause\"\
+        , \"user\", 0], [\"churchyard\", \"mhroncok@redhat.com\", \"Miro Hron\u010D\
+        ok\", \"user\", 0], [\"codeblock\", \"codeblock@elrod.me\", \"Ricky Elrod\"\
+        , \"user\", 0], [\"corsepiu\", \"rc040203@freenet.de\", \"\", \"user\", 0],\
+        \ [\"crobinso\", \"crobinso@redhat.com\", \"Cole Robinson\", \"user\", 0],\
+        \ [\"cstratak\", \"cstratak@redhat.com\", \"\", \"user\", 0], [\"cweyl\",\
+        \ \"cweyl@alumni.drew.edu\", \"Chris Weyl\", \"user\", 0], [\"cwickert\",\
+        \ \"christoph.wickert@gmail.com\", \"Christoph Wickert\", \"user\", 0], [\"\
+        davej\", \"davej@codemonkey.org.uk\", \"Dave Jones\", \"user\", 0], [\"dbhole\"\
+        , \"dbhole@redhat.com\", \"Deepak Bhole\", \"user\", 0], [\"dcbw\", \"dcbw@redhat.com\"\
+        , \"Daniel Williams\", \"user\", 0], [\"denis\", \"denis@poolshark.org\",\
+        \ \"Denis Leroy\", \"user\", 0], [\"denisarnaud\", \"denis.arnaud_fedora@m4x.org\"\
+        , \"Denis Arnaud\", \"user\", 0], [\"devrim\", \"devrim@gunduz.org\", \"Devrim\
+        \ G\xDCND\xDCZ\", \"user\", 0], [\"dgregor\", \"dgregor@redhat.com\", \"Dennis\
+        \ Gregorovic\", \"user\", 0], [\"dmalcolm\", \"dmalcolm@redhat.com\", \"\"\
+        , \"user\", 0], [\"drago01\", \"adel.gadllah@gmail.com\", \"\", \"user\",\
+        \ 0], [\"dsd\", \"dsd@laptop.org\", \"Daniel Drake\", \"user\", 0], [\"dtardon\"\
+        , \"dtardon@redhat.com\", \"David Tardon\", \"user\", 0], [\"dwmw2\", \"dwmw2@infradead.org\"\
+        , \"David Woodhouse\", \"administrator\", 0], [\"echevemaster\", \"echevemaster@gmail.com\"\
+        , \"Eduardo Javier Echeverria Alvarado\", \"user\", 0], [\"ecik\", \"mr.ecik@gmail.com\"\
+        , \"Micha\u0142 Bentkowski\", \"user\", 0], [\"ensc\", \"rh-bugzilla@ensc.de\"\
+        , \"\", \"user\", 0], [\"epienbro\", \"erik-fedora@vanpienbroek.nl\", \"Erik\
+        \ van Pienbroek\", \"user\", 0], [\"filiperosset\", \"rosset.filipe@gmail.com\"\
+        , \"Filipe Rosset\", \"user\", 0], [\"fitzsim\", \"fitzsim@fitzsim.org\",\
+        \ \"Thomas Fitzsimmons\", \"user\", 0], [\"fweimer\", \"fweimer@redhat.com\"\
+        , \"Florian Weimer\", \"user\", 0], [\"gdk\", \"greg.dekoenigsberg@gmail.com\"\
+        , \"Greg DeKoenigsberg\", \"user\", 0], [\"gemi\", \"gemi@bluewin.ch\", \"\
+        G\xE9rard Milmeister\", \"user\", 0], [\"goldmann\", \"mgoldman@redhat.com\"\
+        , \"Marek Goldmann\", \"user\", 0], [\"hadess\", \"bnocera@redhat.com\", \"\
+        Bastien Nocera\", \"user\", 0], [\"harald\", \"harald@redhat.com\", \"Harald\
+        \ Hoyer\", \"user\", 0], [\"hguemar\", \"karlthered@gmail.com\", \"Ha\xEF\
+        kel Gu\xE9mar\", \"user\", 0], [\"hobbes1069\", \"hobbes1069@gmail.com\",\
+        \ \"Richard Shaw\", \"user\", 0], [\"hubbitus\", \"pahan@hubbitus.info\",\
+        \ \"Pavel Alexeev\", \"user\", 0], [\"huzaifas\", \"huzaifas@redhat.com\"\
+        , \"Huzaifa Sidhpurwala\", \"user\", 0], [\"ianweller\", \"ian@ianweller.org\"\
+        , \"Ian Weller\", \"user\", 0], [\"iarnell\", \"iarnell@gmail.com\", \"Iain\
+        \ Arnell\", \"user\", 0], [\"ignatenkobrain\", \"ignatenko@redhat.com\", \"\
+        Igor Gnatenko\", \"user\", 0], [\"ilianaw\", \"ilianaw@buttslol.net\", \"\
+        Iliana Weller\", \"user\", 0], [\"ivazquez\", \"ivazqueznet@gmail.com\", \"\
+        Ignacio Vazquez-Abrams\", \"user\", 0], [\"ixs\", \"andreas@bawue.net\", \"\
+        Andreas Thienemann\", \"user\", 0], [\"jamatos\", \"jamatos@fc.up.pt\", \"\
+        Jos\xE9 Ab\xEDlio Oliveira Matos\", \"user\", 0], [\"jcapik\", \"jaromir.capik@email.cz\"\
+        , \"Jarom\xEDr C\xE1p\xEDk\", \"user\", 0], [\"jerboaa\", \"jerboaa@gmail.com\"\
+        , \"\", \"user\", 0], [\"jforbes\", \"jforbes@redhat.com\", \"Justin M. Forbes\"\
+        , \"user\", 0], [\"jgrulich\", \"jgrulich@redhat.com\", \"Jan Grulich\", \"\
+        user\", 0], [\"jhogarth\", \"james.hogarth@gmail.com\", \"James Hogarth\"\
+        , \"user\", 0], [\"jjames\", \"loganjerry@gmail.com\", \"Jerry James\", \"\
+        user\", 0], [\"jkeating\", \"jkeating@j2solutions.net\", \"Jesse Keating\"\
+        , \"user\", 0], [\"jnovy\", \"novyjindrich@gmail.com\", \"Jindrich Novy\"\
+        , \"user\", 0], [\"johnp\", \"john.j5live@gmail.com\", \"\", \"user\", 0],\
+        \ [\"jorton\", \"jorton@redhat.com\", \"\", \"user\", 0], [\"jplesnik\", \"\
+        jplesnik@redhat.com\", \"Jitka Plesnikova\", \"user\", 0], [\"jpo\", \"jose.p.oliveira.oss@gmail.com\"\
+        , \"Jose Pedro Oliveira\", \"user\", 0], [\"jreznik\", \"jreznik@redhat.com\"\
+        , \"Jaroslav Reznik\", \"user\", 0], [\"jskarvad\", \"jskarvad@redhat.com\"\
+        , \"Jaroslav \u0160karvada\", \"user\", 0], [\"jsmith\", \"jsmith.fedora@gmail.com\"\
+        , \"Jared Smith\", \"user\", 0], [\"jspaleta\", \"jspaleta@gmail.com\", \"\
+        Jef Spaleta\", \"user\", 0], [\"jstanley\", \"jonstanley@gmail.com\", \"Jon\
+        \ Stanley\", \"administrator\", 53], [\"jsteffan\", \"jonathansteffan@gmail.com\"\
+        , \"Jonathan Steffan\", \"user\", 0], [\"jussilehtola\", \"susi.lehtola@iki.fi\"\
+        , \"Susi Lehtola\", \"user\", 0], [\"jvanek\", \"jvanek@redhat.com\", \"jiri\
+        \ vanek\", \"user\", 0], [\"jwakely\", \"jwakely@redhat.com\", \"Jonathan\
+        \ Wakely\", \"user\", 0], [\"jwboyer\", \"jwboyer@gmail.com\", \"Josh Boyer\"\
+        , \"administrator\", 1], [\"jwilson\", \"jarodwilson@gmail.com\", \"Jarod\
+        \ Wilson\", \"administrator\", 0], [\"jwrdegoede\", \"hdegoede@redhat.com\"\
+        , \"Hans de Goede\", \"user\", 0], [\"kalev\", \"klember@redhat.com\", \"\
+        Kalev Lember\", \"user\", 0], [\"kanarip\", \"vanmeeuwen+fedora@kolabsys.com\"\
+        , \"Jeroen van Meeuwen\", \"user\", 0], [\"karsten\", \"karsten@redhat.com\"\
+        , \"Karsten Hopp\", \"user\", 0], [\"kasal\", \"kasal@ucw.cz\", \"\u0160t\u011B\
+        p\xE1n Kasal\", \"user\", 0], [\"katzj\", \"jeremy@katzbox.net\", \"\", \"\
+        user\", 0], [\"kay\", \"kay@redhat.com\", \"Kay Sievers\", \"user\", 0], [\"\
+        ke4qqq\", \"david@gnsa.us\", \"David Nalley\", \"user\", 0], [\"kengert\"\
+        , \"kengert@redhat.com\", \"Kai Engert\", \"user\", 0], [\"kevin\", \"kevin@scrye.com\"\
+        , \"Kevin Fenzi\", \"administrator\", 75], [\"kkofler\", \"kevin@tigcc.ticalc.org\"\
+        , \"Kevin Kofler\", \"user\", 0], [\"kyle\", \"kyle@infradead.org\", \"Kyle\
+        \ McMartin\", \"user\", 0], [\"kylev\", \"kylev@kylev.com\", \"Kyle VanderBeek\"\
+        , \"user\", 0], [\"laxathom\", \"lxtnow@gmail.com\", \"Xavier \u30C8\u30FC\
+        \u30DE\u30B9 Lamien\", \"user\", 0], [\"leigh123linux\", \"leigh123linux@googlemail.com\"\
+        , \"\", \"user\", 0], [\"lennart\", \"lpoetter@redhat.com\", \"Lennart Poettering\"\
+        , \"user\", 0], [\"limb\", \"limburgher@gmail.com\", \"Gwyn Ciesla\", \"user\"\
+        , 0], [\"linville\", \"linville@redhat.com\", \"John W. Linville\", \"user\"\
+        , 0], [\"lkundrak\", \"lkundrak@v3.sk\", \"Lubomir Rintel\", \"user\", 0],\
+        \ [\"lmacken\", \"lewk@openmailbox.org\", \"Luke Macken\", \"user\", 0], [\"\
+        lupinix\", \"lupinix@mailbox.org\", \"Christian Dersch\", \"user\", 0], [\"\
+        lutter\", \"lutter@watzmann.net\", \"David Lutterkort\", \"user\", 0], [\"\
+        markmc\", \"markmc@redhat.com\", \"Mark McLoughlin\", \"user\", 0], [\"maxamillion\"\
+        , \"maxamillion@gmail.com\", \"Adam Miller\", \"user\", 0], [\"mbarnes\",\
+        \ \"mbarnes@fastmail.com\", \"Matthew Barnes\", \"user\", 0], [\"mbooth\"\
+        , \"mat.booth@redhat.com\", \"Mat Booth\", \"user\", 0], [\"mcepl\", \"mcepl@redhat.com\"\
+        , \"Matej Cepl\", \"user\", 0], [\"mclasen\", \"mclasen@redhat.com\", \"Matthias\
+        \ Clasen\", \"user\", 0], [\"mdomsch\", \"matt@domsch.com\", \"Matt Domsch\"\
+        , \"user\", 0], [\"mef\", \"mefoster@gmail.com\", \"\", \"user\", 0], [\"\
+        mgieseki\", \"martin.gieseking@uos.de\", \"Martin Gieseking\", \"user\", 0],\
+        \ [\"michich\", \"mschmidt@redhat.com\", \"Michal Schmidt\", \"user\", 0],\
+        \ [\"mizdebsk\", \"mizdebsk@redhat.com\", \"Mikolaj Izdebski\", \"user\",\
+        \ 0], [\"mjakubicek\", \"xjakub@fi.muni.cz\", \"Milo\u0161 Jakub\xED\u010D\
+        ek\", \"user\", 0], [\"mjg59\", \"mjg59@srcf.ucam.org\", \"Matthew Garrett\"\
+        , \"user\", 0], [\"mkasik\", \"mkasik@redhat.com\", \"\", \"user\", 0], [\"\
+        mmahut\", \"mmahut@redhat.com\", \"Marek Mahut\", \"user\", 0], [\"mmaslano\"\
+        , \"mmaslano@redhat.com\", \"Marcela Ma\u0161l\xE1\u0148ov\xE1\", \"user\"\
+        , 0], [\"mmcgrath\", \"imlinux+fedora@gmail.com\", \"Mike McGrath\", \"user\"\
+        , 0], [\"mooninite\", \"mike@cchtml.com\", \"\", \"user\", 0], [\"mrunge\"\
+        , \"mrunge@redhat.com\", \"Matthias Runge\", \"user\", 0], [\"mschwendt\"\
+        , \"bugs.michael@gmx.net\", \"Michael Schwendt\", \"user\", 0], [\"msimacek\"\
+        , \"msimacek@redhat.com\", \"Michael \u0160im\xE1\u010Dek\", \"user\", 0],\
+        \ [\"msrb\", \"msrb@redhat.com\", \"Michal Srb\", \"user\", 0], [\"mstuchli\"\
+        , \"matej.stuchlik@gmail.com\", \"Matej Stuchlik\", \"user\", 0], [\"msuchy\"\
+        , \"msuchy@redhat.com\", \"Miroslav Such\xFD\", \"user\", 0], [\"mtasaka\"\
+        , \"mtasaka@tbz.t-com.ne.jp\", \"Mamoru TASAKA\", \"user\", 0], [\"nalin\"\
+        , \"nalin@redhat.com\", \"Nalin Dahyabhai\", \"user\", 0], [\"nb\", \"nb@nb.zone\"\
+        , \"Nick Bebout\", \"user\", 0], [\"ngompa\", \"ngompa13@gmail.com\", \"Neal\
+        \ Gompa\", \"user\", 0], [\"nhorman\", \"nhorman@redhat.com\", \"Neil Horman\"\
+        , \"user\", 0], [\"nim\", \"nicolas.mailhot@laposte.net\", \"\", \"user\"\
+        , 0], [\"nonamedotc\", \"nonamedotc@gmail.com\", \"Mukundan Ragavan\", \"\
+        user\", 0], [\"notting\", \"notting@splat.cc\", \"Bill Nottingham\", \"administrator\"\
+        , 32], [\"nphilipp\", \"nphilipp@redhat.com\", \"Nils Philippsen\", \"user\"\
+        , 0], [\"npmccallum\", \"npmccallum@redhat.com\", \"Nathaniel McCallum\",\
+        \ \"user\", 0], [\"oget\", \"oget.fedora@gmail.com\", \"Orcan Ogetbil\", \"\
+        user\", 0], [\"oliver\", \"oliver@linux-kernel.at\", \"Oliver Falk\", \"user\"\
+        , 0], [\"ondrejj\", \"ondrejj@salstar.sk\", \"J\xE1n ONDREJ\", \"user\", 0],\
+        \ [\"orion\", \"orion@cora.nwra.com\", \"Orion Poplawski\", \"user\", 0],\
+        \ [\"otaylor\", \"otaylor@redhat.com\", \"Owen Taylor\", \"user\", 0], [\"\
+        overholt\", \"overholt@gmail.com\", \"Andrew Overholt\", \"user\", 0], [\"\
+        paragn\", \"panemade@gmail.com\", \"\", \"user\", 0], [\"patches\", \"tchollingsworth@gmail.com\"\
+        , \"T.C. Hollingsworth\", \"user\", 0], [\"pbrady\", \"P@draigBrady.com\"\
+        , \"P\xE1draig Brady\", \"user\", 0], [\"pbrobinson\", \"pbrobinson@gmail.com\"\
+        , \"Peter Robinson\", \"user\", 0], [\"pertusus\", \"pertusus@free.fr\", \"\
+        \", \"user\", 0], [\"peter\", \"lemenkov@gmail.com\", \"Peter Lemenkov\",\
+        \ \"user\", 0], [\"petersen\", \"petersen@redhat.com\", \"Jens Petersen\"\
+        , \"user\", 0], [\"pghmcfc\", \"paul@city-fan.org\", \"Paul Howarth\", \"\
+        user\", 0], [\"pingou\", \"pingou@pingoured.fr\", \"Pierre-YvesChibon\", \"\
+        user\", 0], [\"pjones\", \"pjones@redhat.com\", \"Peter Jones\", \"user\"\
+        , 0], [\"pjp\", \"pj.pandit@yahoo.co.in\", \"\", \"user\", 0], [\"pmachata\"\
+        , \"pmachata@gmail.com\", \"Petr Machata\", \"user\", 0], [\"pnemade\", \"\
+        pnemade@redhat.com\", \"Parag Nemade\", \"user\", 0], [\"ppisar\", \"ppisar@redhat.com\"\
+        , \"Petr Pisar\", \"user\", 0], [\"praiskup\", \"praiskup@redhat.com\", \"\
+        Pavel Raiskup\", \"user\", 0], [\"praveenp\", \"praveenpk8484@gmail.com\"\
+        , \"Praveen K Paladugu\", \"user\", 0], [\"pravins\", \"psatpute@redhat.com\"\
+        , \"Pravin Satpute\", \"user\", 0], [\"psabata\", \"psabata@redhat.com\",\
+        \ \"Petr \u0160abata\", \"user\", 0], [\"puiterwijk\", \"puiterwijk@redhat.com\"\
+        , \"Patrick \\\"\u30DE\u30EB\u30BF\u30A4\u30F3\u30A2\u30F3\u30C9\u30EC\u30A2\
+        \u30B9\\\" Uiterwijk\", \"user\", 0], [\"pwouters\", \"pwouters@redhat.com\"\
+        , \"Paul Wouters\", \"user\", 0], [\"rakesh\", \"rakesh.pandit@gmail.com\"\
+        , \"Rakesh Pandit\", \"user\", 0], [\"rathann\", \"dominik@greysector.net\"\
+        , \"Dominik Mierzejewski\", \"user\", 0], [\"rdieter\", \"rdieter@gmail.com\"\
+        , \"Rex Dieter\", \"user\", 0], [\"remi\", \"Fedora@FamilleCollet.com\", \"\
+        Remi Collet\", \"user\", 0], [\"rhughes\", \"rhughes@redhat.com\", \"Richard\
+        \ Hughes\", \"user\", 0], [\"rishi\", \"debarshir@redhat.com\", \"Debarshi\
+        \ Ray\", \"user\", 0], [\"rjones\", \"rjones@redhat.com\", \"Richard W.M.\
+        \ Jones\", \"user\", 0], [\"rkuska\", \"rkuska@gmail.com\", \"Robert Kuska\"\
+        , \"user\", 0], [\"rmattes\", \"richmattes@gmail.com\", \"\", \"user\", 0],\
+        \ [\"robert\", \"redhat@linuxnetz.de\", \"Robert Scheck\", \"user\", 0], [\"\
+        rstrode\", \"rstrode@redhat.com\", \"Ray Strode\", \"user\", 0], [\"ruben\"\
+        , \"ruben@rubenkerkhof.com\", \"Ruben Kerkhof\", \"user\", 0], [\"rvokal\"\
+        , \"rvokal@redhat.com\", \"\", \"user\", 0], [\"s4504kr\", \"Jochen@herr-schmitt.de\"\
+        , \"Jochen Schmitt\", \"user\", 0], [\"salimma\", \"michel@michel-slm.name\"\
+        , \"Michel Alexandre Salim\", \"user\", 0], [\"scop\", \"ville.skytta@iki.fi\"\
+        , \"Ville Skytt\xE4\", \"user\", 0], [\"sdake\", \"steven.dake@gmail.com\"\
+        , \"Steven Dake\", \"user\", 0], [\"sdz\", \"sebastian@sdziallas.com\", \"\
+        Sebastian Dziallas\", \"user\", 0], [\"sgallagh\", \"sgallagh@redhat.com\"\
+        , \"Stephen Gallagher\", \"user\", 0], [\"sharkcz\", \"dan@danny.cz\", \"\
+        Dan Hor\xE1k\", \"administrator\", 0], [\"skvidal\", \"skvidal@sethdot.org\"\
+        , \"Seth Vidal\", \"user\", 0], [\"slaanesh\", \"negativo17@gmail.com\", \"\
+        Simone Caronni\", \"user\", 0], [\"smani\", \"manisandro@gmail.com\", \"Sandro\
+        \ Mani\", \"user\", 0], [\"sochotni\", \"sochotni@redhat.com\", \"Stanislav\
+        \ Ochotnicky\", \"user\", 0], [\"spot\", \"tcallawa@redhat.com\", \"Tom Callaway\"\
+        , \"user\", 0], [\"stahnma\", \"mastahnke@gmail.com\", \"Michael Stahnke\"\
+        , \"user\", 0], [\"steve\", \"steve@silug.org\", \"Steven Pritchard\", \"\
+        user\", 0], [\"stevetraylen\", \"steve.traylen@cern.ch\", \"\", \"user\",\
+        \ 0], [\"stransky\", \"stransky@redhat.com\", \"Martin Stransky\", \"user\"\
+        , 0], [\"sundaram\", \"metherid@gmail.com\", \"Rahul Sundaram\", \"user\"\
+        , 0], [\"tagoh\", \"tagoh@redhat.com\", \"Akira TAGOH\", \"user\", 0], [\"\
+        tbzatek\", \"tbzatek@redhat.com\", \"Tomas Bzatek\", \"user\", 0], [\"tdawson\"\
+        , \"tdawson@redhat.com\", \"\", \"user\", 0], [\"tflink\", \"tflink@redhat.com\"\
+        , \"Tim Flink\", \"user\", 0], [\"than\", \"than@redhat.com\", \"Than Ngo\"\
+        , \"user\", 0], [\"thias\", \"matthias@saou.eu\", \"Matthias Saou\", \"user\"\
+        , 0], [\"thl\", \"fedora@leemhuis.info\", \"Thorsten Leemhuis\", \"user\"\
+        , 0], [\"thomasvs\", \"thomas@apestaart.org\", \"Thomas Vander Stichele\"\
+        , \"user\", 0], [\"thozza\", \"thozza@redhat.com\", \"Tomas Hozza\", \"user\"\
+        , 0], [\"tibbs\", \"tibbs@math.uh.edu\", \"Jason \u30C6\u30A3\u30D3\u30C4\"\
+        , \"user\", 0], [\"till\", \"opensource@till.name\", \"Till Maas\", \"user\"\
+        , 0], [\"tmraz\", \"tmraz@redhat.com\", \"Tom\xE1\u0161 Mr\xE1z\", \"user\"\
+        , 0], [\"tomspur\", \"thomas.spura@googlemail.com\", \"Thomas Spura\", \"\
+        user\", 0], [\"torsava\", \"torsava@redhat.com\", \"Tomas Orsava\", \"user\"\
+        , 0], [\"toshio\", \"a.badger@gmail.com\", \"Toshio \u304F\u3089\u3068\u307F\
+        \", \"user\", 1], [\"tradej\", \"tradej@redhat.com\", \"Tomas Radej\", \"\
+        user\", 0], [\"tremble\", \"tremble@tremble.org.uk\", \"Mark Chappell\", \"\
+        user\", 0], [\"tstclair\", \"tstclair@heptio.com\", \"\", \"user\", 0], [\"\
+        ttomecek\", \"ttomecek@redhat.com\", \"Tomas Tomecek\", \"user\", 0], [\"\
+        tuxbrewr\", \"smparrish@gmail.com\", \"Steven M. Parrish\", \"user\", 0],\
+        \ [\"vakwetu\", \"alee@redhat.com\", \"Ade Lee\", \"user\", 0], [\"vicodan\"\
+        , \"mashalda@hotmail.com\", \"Dan Mashal\", \"user\", 0], [\"vondruch\", \"\
+        vondruch@redhat.com\", \"V\xEDt Ondruch\", \"user\", 0], [\"walters\", \"\
+        walters@redhat.com\", \"Colin Walters\", \"user\", 0], [\"wart\", \"wart@kobold.org\"\
+        , \"Michael Thomas\", \"user\", 0], [\"whot\", \"peter.hutterer@redhat.com\"\
+        , \"Peter Hutterer\", \"user\", 0], [\"willb\", \"willb@redhat.com\", \"William\
+        \ Benton\", \"user\", 0], [\"wolfy\", \"wolfy@nobugconsulting.ro\", \"\",\
+        \ \"user\", 0], [\"wtogami\", \"wtogami@gmail.com\", \"Warren Togami\", \"\
+        user\", 0], [\"xhorak\", \"jhorak@redhat.com\", \"Jan Horak\", \"user\", 0],\
+        \ [\"yselkowitz\", \"yselkowi@redhat.com\", \"Yaakov Selkowitz\", \"user\"\
+        , 0], [\"zbyszek\", \"zbyszek@in.waw.pl\", \"Zbigniew J\u0119drzejewski-Szmek\"\
+        , \"user\", 0]]}"}
+    headers:
+      appserver: [proxy10.phx2.fedoraproject.org]
+      apptime: [D=195298]
+      connection: [Keep-Alive]
+      content-length: ['15031']
+      content-type: [application/json]
+      date: ['Mon, 31 Jul 2017 14:33:04 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.2.15 (Red Hat)]
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '_csrf_token=98e8d0e36d4b7c4fcb85293e95b8ad9ef7888768&password=supersecret&login=Login&user_name=jcline'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['151']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-agent: [Fedora Account System Client/0.9.0]
+    method: POST
+    uri: https://admin.fedoraproject.org/accounts/group/dump/infra-sig
+  response:
+    body: {string: "{\"tg_flash\": null, \"people\": [[\"abompard\", \"aurelien@bompard.org\"\
+        , \"Aurelien Bompard\", \"user\", 0], [\"bochecha\", \"bochecha@daitauha.fr\"\
+        , \"Mathieu Bridon\", \"user\", 0], [\"bowlofeggs\", \"randy@electronsweatshop.com\"\
+        , \"Randy Barlow\", \"user\", 0], [\"codeblock\", \"codeblock@elrod.me\",\
+        \ \"Ricky Elrod\", \"sponsor\", 0], [\"jcline\", \"jeremy@jcline.org\", \"\
+        Jeremy Cline\", \"user\", 0], [\"kevin\", \"kevin@scrye.com\", \"Kevin Fenzi\"\
+        , \"sponsor\", 4], [\"lmacken\", \"lewk@openmailbox.org\", \"Luke Macken\"\
+        , \"sponsor\", 0], [\"pingou\", \"pingou@pingoured.fr\", \"Pierre-YvesChibon\"\
+        , \"administrator\", 7], [\"puiterwijk\", \"puiterwijk@redhat.com\", \"Patrick\
+        \ \\\"\u30DE\u30EB\u30BF\u30A4\u30F3\u30A2\u30F3\u30C9\u30EC\u30A2\u30B9\\\
+        \" Uiterwijk\", \"sponsor\", 0], [\"sayanchowdhury\", \"sayan.chowdhury2012@gmail.com\"\
+        , \"Sayan Chowdhury\", \"user\", 0], [\"toshio\", \"a.badger@gmail.com\",\
+        \ \"Toshio \u304F\u3089\u3068\u307F\", \"sponsor\", 0]]}"}
+    headers:
+      appserver: [proxy01.phx2.fedoraproject.org]
+      apptime: [D=205150]
+      connection: [Keep-Alive]
+      content-length: ['835']
+      content-type: [application/json]
+      date: ['Mon, 31 Jul 2017 14:33:04 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.2.15 (Red Hat)]
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagersForTests.test_no_groups
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagersForTests.test_no_groups
@@ -1,0 +1,401 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.2]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/package/rpms/ejabberd
+  response:
+    body: {string: !!python/unicode "{\n  \"output\": \"ok\",\n  \"packages\": [\n\
+        \    {\n      \"acls\": [\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"peter\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"watchbugzilla\",\n          \"\
+        fas_name\": \"peter\",\n          \"status\": \"Approved\"\n        },\n \
+        \       {\n          \"acl\": \"commit\",\n          \"fas_name\": \"peter\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"approveacls\",\n          \"fas_name\": \"peter\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"silfreed\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"silfreed\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"\
+        silfreed\",\n          \"status\": \"Obsolete\"\n        },\n        {\n \
+        \         \"acl\": \"commit\",\n          \"fas_name\": \"rbarlow\",\n   \
+        \       \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\"\
+        : \"commit\",\n          \"fas_name\": \"silfreed\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"jkaluza\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"jkaluza\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"\
+        jkaluza\",\n          \"status\": \"Obsolete\"\n        },\n        {\n  \
+        \        \"acl\": \"commit\",\n          \"fas_name\": \"martinlanghoff\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"martinlanghoff\",\n  \
+        \        \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"watchbugzilla\",\n          \"fas_name\": \"martinlanghoff\",\n      \
+        \    \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"\
+        watchbugzilla\",\n          \"fas_name\": \"erlang-sig\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"erlang-sig\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"approveacls\",\n          \"\
+        fas_name\": \"fale\",\n          \"status\": \"Approved\"\n        },\n  \
+        \      {\n          \"acl\": \"watchcommits\",\n          \"fas_name\": \"\
+        jcline\",\n          \"status\": \"Approved\"\n        },\n        {\n   \
+        \       \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"jcline\",\n\
+        \          \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"commit\",\n          \"fas_name\": \"jcline\",\n          \"status\":\
+        \ \"Approved\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"jcline\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"approveacls\",\n          \"\
+        fas_name\": \"bowlofeggs\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"bowlofeggs\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"bowlofeggs\",\n     \
+        \     \"status\": \"Approved\"\n        },\n        {\n          \"acl\":\
+        \ \"watchcommits\",\n          \"fas_name\": \"bowlofeggs\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"rbarlow\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"rbarlow\",\n          \"status\": \"Obsolete\"\n       \
+        \ },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"\
+        group::provenpackager\",\n          \"status\": \"Approved\"\n        }\n\
+        \      ],\n      \"collection\": {\n        \"allow_retire\": true,\n    \
+        \    \"branchname\": \"master\",\n        \"date_created\": \"2014-05-14 12:36:15\"\
+        ,\n        \"date_updated\": \"2017-02-28 20:24:14\",\n        \"dist_tag\"\
+        : \".fc27\",\n        \"koji_name\": \"rawhide\",\n        \"name\": \"Fedora\"\
+        ,\n        \"status\": \"Under Development\",\n        \"version\": \"devel\"\
+        \n      },\n      \"critpath\": false,\n      \"package\": {\n        \"acls\"\
+        : [],\n        \"creation_date\": 1400070978.0,\n        \"description\":\
+        \ \"ejabberd is a Free and Open Source distributed fault-tolerant\\nJabber/XMPP\
+        \ server. It is mostly written in Erlang, and runs on many\\nplatforms (tested\
+        \ on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n        \"koschei_monitor\": true,\n        \"monitor\": true,\n      \
+        \  \"name\": \"ejabberd\",\n        \"namespace\": \"rpms\",\n        \"review_url\"\
+        : null,\n        \"status\": \"Approved\",\n        \"summary\": \"A distributed,\
+        \ fault-tolerant Jabber/XMPP server\",\n        \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n      },\n      \"point_of_contact\": \"peter\",\n      \"status\": \"Approved\"\
+        ,\n      \"status_change\": 1400071215.0\n    },\n    {\n      \"acls\": [\n\
+        \        {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"\
+        silfreed\",\n          \"status\": \"Obsolete\"\n        },\n        {\n \
+        \         \"acl\": \"watchcommits\",\n          \"fas_name\": \"silfreed\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"silfreed\",\n       \
+        \   \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"\
+        commit\",\n          \"fas_name\": \"silfreed\",\n          \"status\": \"\
+        Obsolete\"\n        },\n        {\n          \"acl\": \"commit\",\n      \
+        \    \"fas_name\": \"mmahut\",\n          \"status\": \"Obsolete\"\n     \
+        \   },\n        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\"\
+        : \"jkaluza\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"jkaluza\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"approveacls\",\n          \"fas_name\": \"jkaluza\",\n          \"\
+        status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"mmahut\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"mmahut\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\"\
+        : \"mmahut\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"martinlanghoff\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"martinlanghoff\",\n  \
+        \        \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\"\
+        : \"commit\",\n          \"fas_name\": \"martinlanghoff\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"erlang-sig\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"erlang-sig\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\":\
+        \ \"rbarlow\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"rbarlow\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"commit\",\n          \"fas_name\": \"group::provenpackager\",\n \
+        \         \"status\": \"Approved\"\n        }\n      ],\n      \"collection\"\
+        : {\n        \"allow_retire\": true,\n        \"branchname\": \"el6\",\n \
+        \       \"date_created\": \"2014-05-14 12:36:15\",\n        \"date_updated\"\
+        : \"2015-12-08 15:17:58\",\n        \"dist_tag\": \".el6\",\n        \"koji_name\"\
+        : \"dist-6E-epel\",\n        \"name\": \"Fedora EPEL\",\n        \"status\"\
+        : \"Active\",\n        \"version\": \"6\"\n      },\n      \"critpath\": false,\n\
+        \      \"package\": {\n        \"acls\": [],\n        \"creation_date\": 1400070978.0,\n\
+        \        \"description\": \"ejabberd is a Free and Open Source distributed\
+        \ fault-tolerant\\nJabber/XMPP server. It is mostly written in Erlang, and\
+        \ runs on many\\nplatforms (tested on Linux, FreeBSD, NetBSD, Solaris, Mac\
+        \ OS X and\\nWindows NT/2000/XP).\",\n        \"koschei_monitor\": true,\n\
+        \        \"monitor\": true,\n        \"name\": \"ejabberd\",\n        \"namespace\"\
+        : \"rpms\",\n        \"review_url\": null,\n        \"status\": \"Approved\"\
+        ,\n        \"summary\": \"A distributed, fault-tolerant Jabber/XMPP server\"\
+        ,\n        \"upstream_url\": \"http://www.ejabberd.im/\"\n      },\n     \
+        \ \"point_of_contact\": \"orphan\",\n      \"status\": \"Retired\",\n    \
+        \  \"status_change\": 1418836492.0\n    },\n    {\n      \"acls\": [\n   \
+        \     {\n          \"acl\": \"commit\",\n          \"fas_name\": \"xavierb\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"commit\",\n          \"fas_name\": \"peter\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"peter\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"peter\",\n          \"status\": \"Approved\"\n        },\n \
+        \       {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"\
+        peter\",\n          \"status\": \"Approved\"\n        },\n        {\n    \
+        \      \"acl\": \"watchcommits\",\n          \"fas_name\": \"jcline\",\n \
+        \         \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"watchbugzilla\",\n          \"fas_name\": \"jcline\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"commit\",\n  \
+        \        \"fas_name\": \"jcline\",\n          \"status\": \"Approved\"\n \
+        \       },\n        {\n          \"acl\": \"approveacls\",\n          \"fas_name\"\
+        : \"fale\",\n          \"status\": \"Approved\"\n        },\n        {\n \
+        \         \"acl\": \"approveacls\",\n          \"fas_name\": \"jcline\",\n\
+        \          \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"commit\",\n          \"fas_name\": \"rbarlow\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"bowlofeggs\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"bowlofeggs\",\n          \"status\": \"Approved\"\n        },\n      \
+        \  {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"bowlofeggs\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"bowlofeggs\",\n      \
+        \    \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"\
+        watchcommits\",\n          \"fas_name\": \"rbarlow\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"rbarlow\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"group::provenpackager\",\n          \"status\": \"Approved\"\n       \
+        \ }\n      ],\n      \"collection\": {\n        \"allow_retire\": true,\n\
+        \        \"branchname\": \"epel7\",\n        \"date_created\": \"2014-05-14\
+        \ 12:36:15\",\n        \"date_updated\": \"2015-12-08 15:16:41\",\n      \
+        \  \"dist_tag\": \".el7\",\n        \"koji_name\": \"epel7\",\n        \"\
+        name\": \"Fedora EPEL\",\n        \"status\": \"Active\",\n        \"version\"\
+        : \"7\"\n      },\n      \"critpath\": false,\n      \"package\": {\n    \
+        \    \"acls\": [],\n        \"creation_date\": 1400070978.0,\n        \"description\"\
+        : \"ejabberd is a Free and Open Source distributed fault-tolerant\\nJabber/XMPP\
+        \ server. It is mostly written in Erlang, and runs on many\\nplatforms (tested\
+        \ on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n        \"koschei_monitor\": true,\n        \"monitor\": true,\n      \
+        \  \"name\": \"ejabberd\",\n        \"namespace\": \"rpms\",\n        \"review_url\"\
+        : null,\n        \"status\": \"Approved\",\n        \"summary\": \"A distributed,\
+        \ fault-tolerant Jabber/XMPP server\",\n        \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n      },\n      \"point_of_contact\": \"peter\",\n      \"status\": \"Approved\"\
+        ,\n      \"status_change\": 1450448824.0\n    },\n    {\n      \"acls\": [\n\
+        \        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"rbarlow\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"peter\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"peter\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"peter\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"approveacls\",\n          \"fas_name\": \"peter\",\n\
+        \          \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"watchbugzilla\",\n          \"fas_name\": \"silfreed\",\n          \"\
+        status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"silfreed\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"approveacls\",\n          \"\
+        fas_name\": \"silfreed\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"silfreed\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"jkaluza\",\n        \
+        \  \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"\
+        watchcommits\",\n          \"fas_name\": \"jkaluza\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"jkaluza\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"martinlanghoff\",\n          \"status\": \"Approved\"\n        },\n  \
+        \      {\n          \"acl\": \"watchcommits\",\n          \"fas_name\": \"\
+        martinlanghoff\",\n          \"status\": \"Approved\"\n        },\n      \
+        \  {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"martinlanghoff\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"erlang-sig\",\n     \
+        \     \"status\": \"Approved\"\n        },\n        {\n          \"acl\":\
+        \ \"watchcommits\",\n          \"fas_name\": \"erlang-sig\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"fale\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"jcline\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\"\
+        : \"jcline\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"jcline\",\n   \
+        \       \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"approveacls\",\n          \"fas_name\": \"jcline\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"bowlofeggs\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"bowlofeggs\",\n          \"status\": \"Approved\"\n        },\n      \
+        \  {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"bowlofeggs\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"bowlofeggs\",\n      \
+        \    \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"\
+        watchcommits\",\n          \"fas_name\": \"rbarlow\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"rbarlow\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"group::provenpackager\",\n          \"status\": \"Approved\"\n       \
+        \ }\n      ],\n      \"collection\": {\n        \"allow_retire\": false,\n\
+        \        \"branchname\": \"f24\",\n        \"date_created\": \"2016-02-23\
+        \ 22:57:55\",\n        \"date_updated\": \"2016-06-21 13:54:27\",\n      \
+        \  \"dist_tag\": \".fc24\",\n        \"koji_name\": \"f24\",\n        \"name\"\
+        : \"Fedora\",\n        \"status\": \"Active\",\n        \"version\": \"24\"\
+        \n      },\n      \"critpath\": false,\n      \"package\": {\n        \"acls\"\
+        : [],\n        \"creation_date\": 1400070978.0,\n        \"description\":\
+        \ \"ejabberd is a Free and Open Source distributed fault-tolerant\\nJabber/XMPP\
+        \ server. It is mostly written in Erlang, and runs on many\\nplatforms (tested\
+        \ on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n        \"koschei_monitor\": true,\n        \"monitor\": true,\n      \
+        \  \"name\": \"ejabberd\",\n        \"namespace\": \"rpms\",\n        \"review_url\"\
+        : null,\n        \"status\": \"Approved\",\n        \"summary\": \"A distributed,\
+        \ fault-tolerant Jabber/XMPP server\",\n        \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n      },\n      \"point_of_contact\": \"peter\",\n      \"status\": \"Approved\"\
+        ,\n      \"status_change\": 1456273575.0\n    },\n    {\n      \"acls\": [\n\
+        \        {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"\
+        bowlofeggs\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"bowlofeggs\",\n\
+        \          \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"watchbugzilla\",\n          \"fas_name\": \"bowlofeggs\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"bowlofeggs\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"erlang-sig\",\n          \"status\": \"Approved\"\n    \
+        \    },\n        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\"\
+        : \"erlang-sig\",\n          \"status\": \"Approved\"\n        },\n      \
+        \  {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"fale\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"approveacls\",\n          \"fas_name\": \"jcline\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"commit\"\
+        ,\n          \"fas_name\": \"jcline\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"jcline\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\":\
+        \ \"jcline\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"approveacls\",\n          \"fas_name\": \"jkaluza\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"jkaluza\",\n        \
+        \  \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"\
+        watchcommits\",\n          \"fas_name\": \"jkaluza\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"commit\",\n  \
+        \        \"fas_name\": \"martinlanghoff\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"martinlanghoff\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"martinlanghoff\",\n          \"status\": \"Approved\"\n    \
+        \    },\n        {\n          \"acl\": \"approveacls\",\n          \"fas_name\"\
+        : \"peter\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"peter\",\n    \
+        \      \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"watchbugzilla\",\n          \"fas_name\": \"peter\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"peter\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"rbarlow\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"rbarlow\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"rbarlow\",\n         \
+        \ \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"silfreed\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"silfreed\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"silfreed\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"silfreed\",\n        \
+        \  \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"\
+        commit\",\n          \"fas_name\": \"group::provenpackager\",\n          \"\
+        status\": \"Approved\"\n        }\n      ],\n      \"collection\": {\n   \
+        \     \"allow_retire\": false,\n        \"branchname\": \"f25\",\n       \
+        \ \"date_created\": \"2016-07-26 13:50:32\",\n        \"date_updated\": \"\
+        2016-11-22 14:31:43\",\n        \"dist_tag\": \".fc25\",\n        \"koji_name\"\
+        : \"f25\",\n        \"name\": \"Fedora\",\n        \"status\": \"Active\"\
+        ,\n        \"version\": \"25\"\n      },\n      \"critpath\": false,\n   \
+        \   \"package\": {\n        \"acls\": [],\n        \"creation_date\": 1400070978.0,\n\
+        \        \"description\": \"ejabberd is a Free and Open Source distributed\
+        \ fault-tolerant\\nJabber/XMPP server. It is mostly written in Erlang, and\
+        \ runs on many\\nplatforms (tested on Linux, FreeBSD, NetBSD, Solaris, Mac\
+        \ OS X and\\nWindows NT/2000/XP).\",\n        \"koschei_monitor\": true,\n\
+        \        \"monitor\": true,\n        \"name\": \"ejabberd\",\n        \"namespace\"\
+        : \"rpms\",\n        \"review_url\": null,\n        \"status\": \"Approved\"\
+        ,\n        \"summary\": \"A distributed, fault-tolerant Jabber/XMPP server\"\
+        ,\n        \"upstream_url\": \"http://www.ejabberd.im/\"\n      },\n     \
+        \ \"point_of_contact\": \"peter\",\n      \"status\": \"Approved\",\n    \
+        \  \"status_change\": 1400071215.0\n    },\n    {\n      \"acls\": [\n   \
+        \     {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"bowlofeggs\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"commit\",\n          \"fas_name\": \"bowlofeggs\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"bowlofeggs\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"bowlofeggs\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\"\
+        : \"erlang-sig\",\n          \"status\": \"Approved\"\n        },\n      \
+        \  {\n          \"acl\": \"watchcommits\",\n          \"fas_name\": \"erlang-sig\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"approveacls\",\n          \"fas_name\": \"fale\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"jcline\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"jcline\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"jcline\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"jcline\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"jkaluza\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"jkaluza\",\n          \"status\": \"Obsolete\"\n       \
+        \ },\n        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\"\
+        : \"jkaluza\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"martinlanghoff\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"martinlanghoff\",\n \
+        \         \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"watchcommits\",\n          \"fas_name\": \"martinlanghoff\",\n       \
+        \   \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"\
+        approveacls\",\n          \"fas_name\": \"peter\",\n          \"status\":\
+        \ \"Approved\"\n        },\n        {\n          \"acl\": \"commit\",\n  \
+        \        \"fas_name\": \"peter\",\n          \"status\": \"Approved\"\n  \
+        \      },\n        {\n          \"acl\": \"watchbugzilla\",\n          \"\
+        fas_name\": \"peter\",\n          \"status\": \"Approved\"\n        },\n \
+        \       {\n          \"acl\": \"watchcommits\",\n          \"fas_name\": \"\
+        peter\",\n          \"status\": \"Approved\"\n        },\n        {\n    \
+        \      \"acl\": \"commit\",\n          \"fas_name\": \"rbarlow\",\n      \
+        \    \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"\
+        watchbugzilla\",\n          \"fas_name\": \"rbarlow\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"rbarlow\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"approveacls\",\n          \"\
+        fas_name\": \"silfreed\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"silfreed\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"silfreed\",\n       \
+        \   \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"\
+        watchcommits\",\n          \"fas_name\": \"silfreed\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"commit\",\n  \
+        \        \"fas_name\": \"group::provenpackager\",\n          \"status\": \"\
+        Approved\"\n        }\n      ],\n      \"collection\": {\n        \"allow_retire\"\
+        : false,\n        \"branchname\": \"f26\",\n        \"date_created\": \"2017-02-28\
+        \ 20:24:57\",\n        \"date_updated\": \"2017-07-11 14:04:59\",\n      \
+        \  \"dist_tag\": \".fc26\",\n        \"koji_name\": \"f26\",\n        \"name\"\
+        : \"Fedora\",\n        \"status\": \"Active\",\n        \"version\": \"26\"\
+        \n      },\n      \"critpath\": false,\n      \"package\": {\n        \"acls\"\
+        : [],\n        \"creation_date\": 1400070978.0,\n        \"description\":\
+        \ \"ejabberd is a Free and Open Source distributed fault-tolerant\\nJabber/XMPP\
+        \ server. It is mostly written in Erlang, and runs on many\\nplatforms (tested\
+        \ on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n        \"koschei_monitor\": true,\n        \"monitor\": true,\n      \
+        \  \"name\": \"ejabberd\",\n        \"namespace\": \"rpms\",\n        \"review_url\"\
+        : null,\n        \"status\": \"Approved\",\n        \"summary\": \"A distributed,\
+        \ fault-tolerant Jabber/XMPP server\",\n        \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n      },\n      \"point_of_contact\": \"peter\",\n      \"status\": \"Approved\"\
+        ,\n      \"status_change\": 1400071215.0\n    }\n  ]\n}"}
+    headers:
+      accept-ranges: [bytes]
+      age: ['0']
+      appserver: [proxy14.fedoraproject.org]
+      apptime: [D=2747942]
+      connection: [Keep-Alive]
+      content-length: ['24794']
+      content-type: [application/json]
+      date: ['Mon, 31 Jul 2017 14:33:05 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['77398492']
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagersForTests.test_no_namespace
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPkgdb2PackagersForTests.test_no_namespace
@@ -1,0 +1,401 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.2]
+    method: GET
+    uri: https://admin.fedoraproject.org/pkgdb/api/package/ejabberd
+  response:
+    body: {string: !!python/unicode "{\n  \"output\": \"ok\",\n  \"packages\": [\n\
+        \    {\n      \"acls\": [\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"peter\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"watchbugzilla\",\n          \"\
+        fas_name\": \"peter\",\n          \"status\": \"Approved\"\n        },\n \
+        \       {\n          \"acl\": \"commit\",\n          \"fas_name\": \"peter\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"approveacls\",\n          \"fas_name\": \"peter\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"silfreed\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"silfreed\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"\
+        silfreed\",\n          \"status\": \"Obsolete\"\n        },\n        {\n \
+        \         \"acl\": \"commit\",\n          \"fas_name\": \"rbarlow\",\n   \
+        \       \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\"\
+        : \"commit\",\n          \"fas_name\": \"silfreed\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"jkaluza\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"jkaluza\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"\
+        jkaluza\",\n          \"status\": \"Obsolete\"\n        },\n        {\n  \
+        \        \"acl\": \"commit\",\n          \"fas_name\": \"martinlanghoff\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"martinlanghoff\",\n  \
+        \        \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"watchbugzilla\",\n          \"fas_name\": \"martinlanghoff\",\n      \
+        \    \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"\
+        watchbugzilla\",\n          \"fas_name\": \"erlang-sig\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"erlang-sig\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"approveacls\",\n          \"\
+        fas_name\": \"fale\",\n          \"status\": \"Approved\"\n        },\n  \
+        \      {\n          \"acl\": \"watchcommits\",\n          \"fas_name\": \"\
+        jcline\",\n          \"status\": \"Approved\"\n        },\n        {\n   \
+        \       \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"jcline\",\n\
+        \          \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"commit\",\n          \"fas_name\": \"jcline\",\n          \"status\":\
+        \ \"Approved\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"jcline\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"approveacls\",\n          \"\
+        fas_name\": \"bowlofeggs\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"bowlofeggs\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"bowlofeggs\",\n     \
+        \     \"status\": \"Approved\"\n        },\n        {\n          \"acl\":\
+        \ \"watchcommits\",\n          \"fas_name\": \"bowlofeggs\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"rbarlow\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"rbarlow\",\n          \"status\": \"Obsolete\"\n       \
+        \ },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"\
+        group::provenpackager\",\n          \"status\": \"Approved\"\n        }\n\
+        \      ],\n      \"collection\": {\n        \"allow_retire\": true,\n    \
+        \    \"branchname\": \"master\",\n        \"date_created\": \"2014-05-14 12:36:15\"\
+        ,\n        \"date_updated\": \"2017-02-28 20:24:14\",\n        \"dist_tag\"\
+        : \".fc27\",\n        \"koji_name\": \"rawhide\",\n        \"name\": \"Fedora\"\
+        ,\n        \"status\": \"Under Development\",\n        \"version\": \"devel\"\
+        \n      },\n      \"critpath\": false,\n      \"package\": {\n        \"acls\"\
+        : [],\n        \"creation_date\": 1400070978.0,\n        \"description\":\
+        \ \"ejabberd is a Free and Open Source distributed fault-tolerant\\nJabber/XMPP\
+        \ server. It is mostly written in Erlang, and runs on many\\nplatforms (tested\
+        \ on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n        \"koschei_monitor\": true,\n        \"monitor\": true,\n      \
+        \  \"name\": \"ejabberd\",\n        \"namespace\": \"rpms\",\n        \"review_url\"\
+        : null,\n        \"status\": \"Approved\",\n        \"summary\": \"A distributed,\
+        \ fault-tolerant Jabber/XMPP server\",\n        \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n      },\n      \"point_of_contact\": \"peter\",\n      \"status\": \"Approved\"\
+        ,\n      \"status_change\": 1400071215.0\n    },\n    {\n      \"acls\": [\n\
+        \        {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"\
+        silfreed\",\n          \"status\": \"Obsolete\"\n        },\n        {\n \
+        \         \"acl\": \"watchcommits\",\n          \"fas_name\": \"silfreed\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"silfreed\",\n       \
+        \   \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"\
+        commit\",\n          \"fas_name\": \"silfreed\",\n          \"status\": \"\
+        Obsolete\"\n        },\n        {\n          \"acl\": \"commit\",\n      \
+        \    \"fas_name\": \"mmahut\",\n          \"status\": \"Obsolete\"\n     \
+        \   },\n        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\"\
+        : \"jkaluza\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"jkaluza\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"approveacls\",\n          \"fas_name\": \"jkaluza\",\n          \"\
+        status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"mmahut\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"mmahut\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\"\
+        : \"mmahut\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"martinlanghoff\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"martinlanghoff\",\n  \
+        \        \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\"\
+        : \"commit\",\n          \"fas_name\": \"martinlanghoff\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"erlang-sig\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"erlang-sig\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\":\
+        \ \"rbarlow\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"rbarlow\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"commit\",\n          \"fas_name\": \"group::provenpackager\",\n \
+        \         \"status\": \"Approved\"\n        }\n      ],\n      \"collection\"\
+        : {\n        \"allow_retire\": true,\n        \"branchname\": \"el6\",\n \
+        \       \"date_created\": \"2014-05-14 12:36:15\",\n        \"date_updated\"\
+        : \"2015-12-08 15:17:58\",\n        \"dist_tag\": \".el6\",\n        \"koji_name\"\
+        : \"dist-6E-epel\",\n        \"name\": \"Fedora EPEL\",\n        \"status\"\
+        : \"Active\",\n        \"version\": \"6\"\n      },\n      \"critpath\": false,\n\
+        \      \"package\": {\n        \"acls\": [],\n        \"creation_date\": 1400070978.0,\n\
+        \        \"description\": \"ejabberd is a Free and Open Source distributed\
+        \ fault-tolerant\\nJabber/XMPP server. It is mostly written in Erlang, and\
+        \ runs on many\\nplatforms (tested on Linux, FreeBSD, NetBSD, Solaris, Mac\
+        \ OS X and\\nWindows NT/2000/XP).\",\n        \"koschei_monitor\": true,\n\
+        \        \"monitor\": true,\n        \"name\": \"ejabberd\",\n        \"namespace\"\
+        : \"rpms\",\n        \"review_url\": null,\n        \"status\": \"Approved\"\
+        ,\n        \"summary\": \"A distributed, fault-tolerant Jabber/XMPP server\"\
+        ,\n        \"upstream_url\": \"http://www.ejabberd.im/\"\n      },\n     \
+        \ \"point_of_contact\": \"orphan\",\n      \"status\": \"Retired\",\n    \
+        \  \"status_change\": 1418836492.0\n    },\n    {\n      \"acls\": [\n   \
+        \     {\n          \"acl\": \"commit\",\n          \"fas_name\": \"xavierb\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"commit\",\n          \"fas_name\": \"peter\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"peter\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"peter\",\n          \"status\": \"Approved\"\n        },\n \
+        \       {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"\
+        peter\",\n          \"status\": \"Approved\"\n        },\n        {\n    \
+        \      \"acl\": \"watchcommits\",\n          \"fas_name\": \"jcline\",\n \
+        \         \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"watchbugzilla\",\n          \"fas_name\": \"jcline\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"commit\",\n  \
+        \        \"fas_name\": \"jcline\",\n          \"status\": \"Approved\"\n \
+        \       },\n        {\n          \"acl\": \"approveacls\",\n          \"fas_name\"\
+        : \"fale\",\n          \"status\": \"Approved\"\n        },\n        {\n \
+        \         \"acl\": \"approveacls\",\n          \"fas_name\": \"jcline\",\n\
+        \          \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"commit\",\n          \"fas_name\": \"rbarlow\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"bowlofeggs\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"bowlofeggs\",\n          \"status\": \"Approved\"\n        },\n      \
+        \  {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"bowlofeggs\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"bowlofeggs\",\n      \
+        \    \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"\
+        watchcommits\",\n          \"fas_name\": \"rbarlow\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"rbarlow\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"group::provenpackager\",\n          \"status\": \"Approved\"\n       \
+        \ }\n      ],\n      \"collection\": {\n        \"allow_retire\": true,\n\
+        \        \"branchname\": \"epel7\",\n        \"date_created\": \"2014-05-14\
+        \ 12:36:15\",\n        \"date_updated\": \"2015-12-08 15:16:41\",\n      \
+        \  \"dist_tag\": \".el7\",\n        \"koji_name\": \"epel7\",\n        \"\
+        name\": \"Fedora EPEL\",\n        \"status\": \"Active\",\n        \"version\"\
+        : \"7\"\n      },\n      \"critpath\": false,\n      \"package\": {\n    \
+        \    \"acls\": [],\n        \"creation_date\": 1400070978.0,\n        \"description\"\
+        : \"ejabberd is a Free and Open Source distributed fault-tolerant\\nJabber/XMPP\
+        \ server. It is mostly written in Erlang, and runs on many\\nplatforms (tested\
+        \ on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n        \"koschei_monitor\": true,\n        \"monitor\": true,\n      \
+        \  \"name\": \"ejabberd\",\n        \"namespace\": \"rpms\",\n        \"review_url\"\
+        : null,\n        \"status\": \"Approved\",\n        \"summary\": \"A distributed,\
+        \ fault-tolerant Jabber/XMPP server\",\n        \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n      },\n      \"point_of_contact\": \"peter\",\n      \"status\": \"Approved\"\
+        ,\n      \"status_change\": 1450448824.0\n    },\n    {\n      \"acls\": [\n\
+        \        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"rbarlow\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"peter\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"peter\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"peter\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"approveacls\",\n          \"fas_name\": \"peter\",\n\
+        \          \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"watchbugzilla\",\n          \"fas_name\": \"silfreed\",\n          \"\
+        status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"silfreed\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"approveacls\",\n          \"\
+        fas_name\": \"silfreed\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"silfreed\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"jkaluza\",\n        \
+        \  \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"\
+        watchcommits\",\n          \"fas_name\": \"jkaluza\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"jkaluza\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"martinlanghoff\",\n          \"status\": \"Approved\"\n        },\n  \
+        \      {\n          \"acl\": \"watchcommits\",\n          \"fas_name\": \"\
+        martinlanghoff\",\n          \"status\": \"Approved\"\n        },\n      \
+        \  {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"martinlanghoff\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"erlang-sig\",\n     \
+        \     \"status\": \"Approved\"\n        },\n        {\n          \"acl\":\
+        \ \"watchcommits\",\n          \"fas_name\": \"erlang-sig\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"fale\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"jcline\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\"\
+        : \"jcline\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"jcline\",\n   \
+        \       \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"approveacls\",\n          \"fas_name\": \"jcline\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"bowlofeggs\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"bowlofeggs\",\n          \"status\": \"Approved\"\n        },\n      \
+        \  {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"bowlofeggs\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"bowlofeggs\",\n      \
+        \    \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"\
+        watchcommits\",\n          \"fas_name\": \"rbarlow\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"rbarlow\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"group::provenpackager\",\n          \"status\": \"Approved\"\n       \
+        \ }\n      ],\n      \"collection\": {\n        \"allow_retire\": false,\n\
+        \        \"branchname\": \"f24\",\n        \"date_created\": \"2016-02-23\
+        \ 22:57:55\",\n        \"date_updated\": \"2016-06-21 13:54:27\",\n      \
+        \  \"dist_tag\": \".fc24\",\n        \"koji_name\": \"f24\",\n        \"name\"\
+        : \"Fedora\",\n        \"status\": \"Active\",\n        \"version\": \"24\"\
+        \n      },\n      \"critpath\": false,\n      \"package\": {\n        \"acls\"\
+        : [],\n        \"creation_date\": 1400070978.0,\n        \"description\":\
+        \ \"ejabberd is a Free and Open Source distributed fault-tolerant\\nJabber/XMPP\
+        \ server. It is mostly written in Erlang, and runs on many\\nplatforms (tested\
+        \ on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n        \"koschei_monitor\": true,\n        \"monitor\": true,\n      \
+        \  \"name\": \"ejabberd\",\n        \"namespace\": \"rpms\",\n        \"review_url\"\
+        : null,\n        \"status\": \"Approved\",\n        \"summary\": \"A distributed,\
+        \ fault-tolerant Jabber/XMPP server\",\n        \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n      },\n      \"point_of_contact\": \"peter\",\n      \"status\": \"Approved\"\
+        ,\n      \"status_change\": 1456273575.0\n    },\n    {\n      \"acls\": [\n\
+        \        {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"\
+        bowlofeggs\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"bowlofeggs\",\n\
+        \          \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"watchbugzilla\",\n          \"fas_name\": \"bowlofeggs\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"bowlofeggs\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"erlang-sig\",\n          \"status\": \"Approved\"\n    \
+        \    },\n        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\"\
+        : \"erlang-sig\",\n          \"status\": \"Approved\"\n        },\n      \
+        \  {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"fale\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"approveacls\",\n          \"fas_name\": \"jcline\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"commit\"\
+        ,\n          \"fas_name\": \"jcline\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"jcline\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\":\
+        \ \"jcline\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"approveacls\",\n          \"fas_name\": \"jkaluza\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"jkaluza\",\n        \
+        \  \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"\
+        watchcommits\",\n          \"fas_name\": \"jkaluza\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"commit\",\n  \
+        \        \"fas_name\": \"martinlanghoff\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"martinlanghoff\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"martinlanghoff\",\n          \"status\": \"Approved\"\n    \
+        \    },\n        {\n          \"acl\": \"approveacls\",\n          \"fas_name\"\
+        : \"peter\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"peter\",\n    \
+        \      \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"watchbugzilla\",\n          \"fas_name\": \"peter\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"peter\",\n          \"status\": \"Approved\"\n\
+        \        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"rbarlow\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"rbarlow\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"rbarlow\",\n         \
+        \ \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"silfreed\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"silfreed\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"silfreed\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"silfreed\",\n        \
+        \  \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"\
+        commit\",\n          \"fas_name\": \"group::provenpackager\",\n          \"\
+        status\": \"Approved\"\n        }\n      ],\n      \"collection\": {\n   \
+        \     \"allow_retire\": false,\n        \"branchname\": \"f25\",\n       \
+        \ \"date_created\": \"2016-07-26 13:50:32\",\n        \"date_updated\": \"\
+        2016-11-22 14:31:43\",\n        \"dist_tag\": \".fc25\",\n        \"koji_name\"\
+        : \"f25\",\n        \"name\": \"Fedora\",\n        \"status\": \"Active\"\
+        ,\n        \"version\": \"25\"\n      },\n      \"critpath\": false,\n   \
+        \   \"package\": {\n        \"acls\": [],\n        \"creation_date\": 1400070978.0,\n\
+        \        \"description\": \"ejabberd is a Free and Open Source distributed\
+        \ fault-tolerant\\nJabber/XMPP server. It is mostly written in Erlang, and\
+        \ runs on many\\nplatforms (tested on Linux, FreeBSD, NetBSD, Solaris, Mac\
+        \ OS X and\\nWindows NT/2000/XP).\",\n        \"koschei_monitor\": true,\n\
+        \        \"monitor\": true,\n        \"name\": \"ejabberd\",\n        \"namespace\"\
+        : \"rpms\",\n        \"review_url\": null,\n        \"status\": \"Approved\"\
+        ,\n        \"summary\": \"A distributed, fault-tolerant Jabber/XMPP server\"\
+        ,\n        \"upstream_url\": \"http://www.ejabberd.im/\"\n      },\n     \
+        \ \"point_of_contact\": \"peter\",\n      \"status\": \"Approved\",\n    \
+        \  \"status_change\": 1400071215.0\n    },\n    {\n      \"acls\": [\n   \
+        \     {\n          \"acl\": \"approveacls\",\n          \"fas_name\": \"bowlofeggs\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"commit\",\n          \"fas_name\": \"bowlofeggs\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"watchbugzilla\"\
+        ,\n          \"fas_name\": \"bowlofeggs\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"watchcommits\",\n          \"\
+        fas_name\": \"bowlofeggs\",\n          \"status\": \"Approved\"\n        },\n\
+        \        {\n          \"acl\": \"watchbugzilla\",\n          \"fas_name\"\
+        : \"erlang-sig\",\n          \"status\": \"Approved\"\n        },\n      \
+        \  {\n          \"acl\": \"watchcommits\",\n          \"fas_name\": \"erlang-sig\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"approveacls\",\n          \"fas_name\": \"fale\",\n          \"status\"\
+        : \"Approved\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"jcline\",\n          \"status\": \"Approved\"\
+        \n        },\n        {\n          \"acl\": \"commit\",\n          \"fas_name\"\
+        : \"jcline\",\n          \"status\": \"Approved\"\n        },\n        {\n\
+        \          \"acl\": \"watchbugzilla\",\n          \"fas_name\": \"jcline\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchcommits\",\n          \"fas_name\": \"jcline\",\n          \"\
+        status\": \"Approved\"\n        },\n        {\n          \"acl\": \"approveacls\"\
+        ,\n          \"fas_name\": \"jkaluza\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"watchbugzilla\",\n         \
+        \ \"fas_name\": \"jkaluza\",\n          \"status\": \"Obsolete\"\n       \
+        \ },\n        {\n          \"acl\": \"watchcommits\",\n          \"fas_name\"\
+        : \"jkaluza\",\n          \"status\": \"Obsolete\"\n        },\n        {\n\
+        \          \"acl\": \"commit\",\n          \"fas_name\": \"martinlanghoff\"\
+        ,\n          \"status\": \"Approved\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"martinlanghoff\",\n \
+        \         \"status\": \"Approved\"\n        },\n        {\n          \"acl\"\
+        : \"watchcommits\",\n          \"fas_name\": \"martinlanghoff\",\n       \
+        \   \"status\": \"Approved\"\n        },\n        {\n          \"acl\": \"\
+        approveacls\",\n          \"fas_name\": \"peter\",\n          \"status\":\
+        \ \"Approved\"\n        },\n        {\n          \"acl\": \"commit\",\n  \
+        \        \"fas_name\": \"peter\",\n          \"status\": \"Approved\"\n  \
+        \      },\n        {\n          \"acl\": \"watchbugzilla\",\n          \"\
+        fas_name\": \"peter\",\n          \"status\": \"Approved\"\n        },\n \
+        \       {\n          \"acl\": \"watchcommits\",\n          \"fas_name\": \"\
+        peter\",\n          \"status\": \"Approved\"\n        },\n        {\n    \
+        \      \"acl\": \"commit\",\n          \"fas_name\": \"rbarlow\",\n      \
+        \    \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"\
+        watchbugzilla\",\n          \"fas_name\": \"rbarlow\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"watchcommits\"\
+        ,\n          \"fas_name\": \"rbarlow\",\n          \"status\": \"Obsolete\"\
+        \n        },\n        {\n          \"acl\": \"approveacls\",\n          \"\
+        fas_name\": \"silfreed\",\n          \"status\": \"Obsolete\"\n        },\n\
+        \        {\n          \"acl\": \"commit\",\n          \"fas_name\": \"silfreed\"\
+        ,\n          \"status\": \"Obsolete\"\n        },\n        {\n          \"\
+        acl\": \"watchbugzilla\",\n          \"fas_name\": \"silfreed\",\n       \
+        \   \"status\": \"Obsolete\"\n        },\n        {\n          \"acl\": \"\
+        watchcommits\",\n          \"fas_name\": \"silfreed\",\n          \"status\"\
+        : \"Obsolete\"\n        },\n        {\n          \"acl\": \"commit\",\n  \
+        \        \"fas_name\": \"group::provenpackager\",\n          \"status\": \"\
+        Approved\"\n        }\n      ],\n      \"collection\": {\n        \"allow_retire\"\
+        : false,\n        \"branchname\": \"f26\",\n        \"date_created\": \"2017-02-28\
+        \ 20:24:57\",\n        \"date_updated\": \"2017-07-11 14:04:59\",\n      \
+        \  \"dist_tag\": \".fc26\",\n        \"koji_name\": \"f26\",\n        \"name\"\
+        : \"Fedora\",\n        \"status\": \"Active\",\n        \"version\": \"26\"\
+        \n      },\n      \"critpath\": false,\n      \"package\": {\n        \"acls\"\
+        : [],\n        \"creation_date\": 1400070978.0,\n        \"description\":\
+        \ \"ejabberd is a Free and Open Source distributed fault-tolerant\\nJabber/XMPP\
+        \ server. It is mostly written in Erlang, and runs on many\\nplatforms (tested\
+        \ on Linux, FreeBSD, NetBSD, Solaris, Mac OS X and\\nWindows NT/2000/XP).\"\
+        ,\n        \"koschei_monitor\": true,\n        \"monitor\": true,\n      \
+        \  \"name\": \"ejabberd\",\n        \"namespace\": \"rpms\",\n        \"review_url\"\
+        : null,\n        \"status\": \"Approved\",\n        \"summary\": \"A distributed,\
+        \ fault-tolerant Jabber/XMPP server\",\n        \"upstream_url\": \"http://www.ejabberd.im/\"\
+        \n      },\n      \"point_of_contact\": \"peter\",\n      \"status\": \"Approved\"\
+        ,\n      \"status_change\": 1400071215.0\n    }\n  ]\n}"}
+    headers:
+      accept-ranges: [bytes]
+      age: ['0']
+      appserver: [proxy06.fedoraproject.org]
+      apptime: [D=2441273]
+      connection: [Keep-Alive]
+      content-length: ['24794']
+      content-type: [application/json]
+      date: ['Mon, 31 Jul 2017 14:33:09 GMT']
+      keep-alive: ['timeout=15, max=500']
+      server: [Apache/2.4.6 (Red Hat Enterprise Linux) mod_wsgi/3.4 Python/2.7.5]
+      strict-transport-security: [max-age=15768000; includeSubDomains; preload]
+      via: [1.1 varnish-v4]
+      x-varnish: ['82566231']
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/rules/test_generic.py
+++ b/fmn/tests/rules/test_generic.py
@@ -31,6 +31,7 @@ class UserPackageFilterTests(Base):
 
     def setUp(self):
         super(UserPackageFilterTests, self).setUp()
+        self.config['fmn.rules.utils.use_pagure_for_ownership'] = False
         self.config['fmn.rules.cache'] = {'backend': 'dogpile.cache.memory'}
         self.config['topic_prefix_re'] = r'org.fedoraproject.prod.*'
         make_processors(**self.config)

--- a/fmn/tests/rules/test_utils.py
+++ b/fmn/tests/rules/test_utils.py
@@ -26,10 +26,13 @@ from fmn.tests import Base
 
 
 class GetPkgdb2PackagesForTests(Base):
+    maxDiff = None
 
     def setUp(self):
         super(GetPkgdb2PackagesForTests, self).setUp()
-        self.config['fmn.rules.utils.pkgdb_url'] = 'https://admin.fedoraproject.org/pkgdb/api'
+        self.config['fmn.rules.utils.use_pagure_for_ownership'] = False
+        self.config['fmn.rules.utils.pkgdb_url'] = \
+            'https://admin.fedoraproject.org/pkgdb/api'
         self.expected_point_of_contact = {
             'rpms': set([
                 'erlang-cache_tab',
@@ -119,6 +122,115 @@ class GetPkgdb2PackagesForTests(Base):
 
     def test_all(self):
         packages = utils._get_pkgdb2_packages_for(
+            self.config, 'jcline', ['point of contact', 'watch', 'co-maintained'])
+        self.assertEqual(self.expected_all, packages)
+
+
+class GetPagurePackagesForTests(Base):
+    maxDiff = None
+
+    def setUp(self):
+        super(GetPagurePackagesForTests, self).setUp()
+        self.config['fmn.rules.utils.use_pagure_for_ownership'] = True
+        self.config['fmn.rules.utils.pagure_api_url'] = \
+            'https://src.stg.fedoraproject.org/pagure/api'
+        self.expected_point_of_contact = {
+            'rpms': set([
+                'erlang-cache_tab',
+                'erlang-p1_sip',
+                'erlang-p1_stringprep',
+                'erlang-p1_stun',
+                'erlang-p1_tls',
+                'erlang-p1_xml',
+                'erlang-p1_yaml',
+                'python-args',
+                'python-clint',
+                'python-flower',
+                'python-invocations',
+                'python-pkginfo',
+                'python-releases',
+                'python-sphinxcontrib-fulltoc',
+                'python-twine',
+            ])
+        }
+        self.expected_comaintained = {
+            'rpms': set([
+                'ejabberd',
+                'erlang-cache_tab',
+                'erlang-esip',
+                'erlang-ezlib',
+                'erlang-fast_tls',
+                'erlang-fast_xml',
+                'erlang-fast_yaml',
+                'erlang-goldrush',
+                'erlang-iconv',
+                'erlang-luerl',
+                'erlang-oauth2',
+                'erlang-p1_iconv',
+                'erlang-p1_mysql',
+                'erlang-p1_oauth2',
+                'erlang-p1_pam',
+                'erlang-p1_pgsql',
+                'erlang-p1_sip',
+                'erlang-p1_stringprep',
+                'erlang-p1_stun',
+                'erlang-p1_tls',
+                'erlang-p1_utils',
+                'erlang-p1_xml',
+                'erlang-p1_xmlrpc',
+                'erlang-p1_yaml',
+                'erlang-p1_zlib',
+                'erlang-proper',
+                'erlang-stringprep',
+                'erlang-stun',
+                'pulp',
+                'pulp-docker',
+                'pulp-ostree',
+                'pulp-puppet',
+                'pulp-python',
+                'pulp-rpm',
+                'python-args',
+                'python-clint',
+                'python-crane',
+                'python-flower',
+                'python-invocations',
+                'python-isodate',
+                'python-pkginfo',
+                'python-pymongo',
+                'python-releases',
+                'python-rpdb',
+                'python-sphinxcontrib-fulltoc',
+                'python-twine',
+            ])
+        }
+        self.expected_watch = {}
+        self.expected_all = {
+            'rpms': self.expected_comaintained['rpms'].union(
+                self.expected_point_of_contact['rpms']),
+        }
+
+    def test_bad_response(self):
+        """Assert a bad response results in an empty result."""
+        packages = utils._get_pagure_packages_for(self.config, 'thisisnotausername123', [])
+        self.assertEqual(dict(), packages)
+
+    def test_watch(self):
+        """Assert watch results from pagure works."""
+        packages = utils._get_pagure_packages_for(self.config, 'jcline', ['watch'])
+        self.assertEqual(self.expected_watch, packages)
+
+    def test_comaintained(self):
+        """Assert co-maintained results from pagure works."""
+        packages = utils._get_pagure_packages_for(self.config, 'jcline', ['co-maintained'])
+        self.assertEqual(self.expected_comaintained, packages)
+
+    def test_point_of_contact(self):
+        """Assert point of contact results from pagure works."""
+        packages = utils._get_pagure_packages_for(self.config, 'jcline', ['point of contact'])
+        self.assertEqual(self.expected_point_of_contact, packages)
+
+    def test_all(self):
+        packages = utils._get_pagure_packages_for(
             self.config, 'jcline', ['point of contact', 'watch', 'co-maintained'])
         self.assertEqual(self.expected_all, packages)
 

--- a/fmn/tests/rules/test_utils.py
+++ b/fmn/tests/rules/test_utils.py
@@ -21,6 +21,10 @@ from __future__ import unicode_literals
 
 import unittest
 
+from requests.exceptions import ConnectTimeout, ReadTimeout
+from dogpile import cache
+import mock
+
 from fmn.rules import utils
 from fmn.tests import Base
 
@@ -100,30 +104,120 @@ class GetPkgdb2PackagesForTests(Base):
                 self.expected_point_of_contact['rpms'])),
         }
 
+    @mock.patch('fmn.rules.utils._get_pkgdb2_packages_for')
+    def test_using_pkgdb(self, mock_get_pkgs):
+        utils._get_packages_for(self.config, 'jcline', [])
+        mock_get_pkgs.assert_called_once_with(self.config, 'jcline', [])
+
     def test_bad_response(self):
         """Assert a bad response results in an empty result."""
-        packages = utils._get_pkgdb2_packages_for(self.config, 'thisisnotausername123', [])
+        packages = utils._get_packages_for(self.config, 'thisisnotausername123', [])
         self.assertEqual(dict(), packages)
 
     def test_watch(self):
         """Assert watch results from pkgdb2 works."""
-        packages = utils._get_pkgdb2_packages_for(self.config, 'jcline', ['watch'])
+        packages = utils._get_packages_for(self.config, 'jcline', ['watch'])
         self.assertEqual(self.expected_watch, packages)
 
     def test_comaintained(self):
         """Assert co-maintained results from pkgdb2 works."""
-        packages = utils._get_pkgdb2_packages_for(self.config, 'jcline', ['co-maintained'])
+        packages = utils._get_packages_for(self.config, 'jcline', ['co-maintained'])
         self.assertEqual(self.expected_comaintained, packages)
 
     def test_point_of_contact(self):
         """Assert point of contact results from pkgdb2 works."""
-        packages = utils._get_pkgdb2_packages_for(self.config, 'jcline', ['point of contact'])
+        packages = utils._get_packages_for(self.config, 'jcline', ['point of contact'])
         self.assertEqual(self.expected_point_of_contact, packages)
 
     def test_all(self):
-        packages = utils._get_pkgdb2_packages_for(
+        packages = utils._get_packages_for(
             self.config, 'jcline', ['point of contact', 'watch', 'co-maintained'])
         self.assertEqual(self.expected_all, packages)
+
+    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ConnectTimeout))
+    def test_connect_failure(self):
+        """Assert a bad response results in an empty result."""
+        packages = utils._get_packages_for(self.config, 'jcline', ['co-maintained'])
+        self.assertEqual(set(), packages)
+
+    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ReadTimeout))
+    def test_read_failure(self):
+        """Assert a bad response results in an empty result."""
+        packages = utils._get_packages_for(self.config, 'jcline', ['co-maintained'])
+        self.assertEqual(set(), packages)
+
+
+class GetPkgdb2PackagersForTests(Base):
+
+    def setUp(self):
+        super(GetPkgdb2PackagersForTests, self).setUp()
+
+        self.config = {
+            'fmn.rules.utils.use_pagure_for_ownership': False,
+            'fmn.rules.cache': {'backend': 'dogpile.cache.memory'},
+            'fas_credentials': {'username': 'jcline', 'password': 'supersecret'}
+        }
+
+    @mock.patch('fmn.rules.utils._get_pkgdb2_packagers_for')
+    def test_using_pkgdb(self, mock_get_packagers):
+        utils._get_packagers_for(self.config, 'rpms/urllib3')
+        mock_get_packagers.assert_called_once_with(self.config, 'rpms/urllib3')
+
+    def test_no_groups(self):
+        """Assert packages without groups return the expected set of packagers."""
+        expected_packagers = set(['bowlofeggs', 'jcline', 'martinlanghoff', 'peter'])
+        packagers = utils._get_packagers_for(self.config, 'rpms/ejabberd')
+
+        self.assertTrue(expected_packagers.issubset(packagers))
+
+    def test_groups(self):
+        infra_group = set([
+            'abompard',
+            'bochecha',
+            'bowlofeggs',
+            'codeblock',
+            'jcline',
+            'kevin',
+            'lmacken',
+            'pingou',
+            'puiterwijk',
+            'sayanchowdhury',
+            'toshio',
+        ])
+        committers = set([
+            'abompard',
+            'jcline',
+            'ralph',
+            'sagarun',
+        ])
+        expected_packagers = infra_group.union(committers)
+
+        packagers = utils._get_packagers_for(self.config, 'rpms/python-urllib3')
+
+        self.assertTrue(expected_packagers.issubset(packagers))
+
+    def test_no_namespace(self):
+        """Assert packages without a namespace default to RPM."""
+        expected_packagers = set(['bowlofeggs', 'jcline', 'martinlanghoff', 'peter'])
+        packagers = utils._get_packagers_for(self.config, 'ejabberd')
+        self.assertTrue(expected_packagers.issubset(packagers))
+
+    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ReadTimeout))
+    def test_read_timeout(self):
+        packagers = utils._get_packagers_for(self.config, 'rpms/ejabberd')
+
+        self.assertEqual(set(), packagers)
+
+    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ConnectTimeout))
+    def test_connect_timeout(self):
+        packagers = utils._get_packagers_for(self.config, 'rpms/ejabberd')
+
+        self.assertEqual(set(), packagers)
+
+    def test_error_response(self):
+        packagers = utils._get_packagers_for(self.config, 'notanamespace/orapackage')
+
+        self.assertEqual(set(), packagers)
 
 
 class GetPagurePackagesForTests(Base):
@@ -134,6 +228,7 @@ class GetPagurePackagesForTests(Base):
         self.config['fmn.rules.utils.use_pagure_for_ownership'] = True
         self.config['fmn.rules.utils.pagure_api_url'] = \
             'https://src.stg.fedoraproject.org/pagure/api'
+
         self.expected_point_of_contact = {
             'rpms': set([
                 'erlang-cache_tab',
@@ -145,16 +240,19 @@ class GetPagurePackagesForTests(Base):
                 'erlang-p1_yaml',
                 'python-args',
                 'python-clint',
+                'python-cryptography',
+                'python-cryptography-vectors',
                 'python-flower',
                 'python-invocations',
                 'python-pkginfo',
                 'python-releases',
                 'python-sphinxcontrib-fulltoc',
-                'python-twine',
+                'python-twine'
             ])
         }
         self.expected_comaintained = {
             'rpms': set([
+                'bodhi',
                 'ejabberd',
                 'erlang-cache_tab',
                 'erlang-esip',
@@ -183,56 +281,186 @@ class GetPagurePackagesForTests(Base):
                 'erlang-proper',
                 'erlang-stringprep',
                 'erlang-stun',
-                'pulp',
-                'pulp-docker',
-                'pulp-ostree',
-                'pulp-puppet',
-                'pulp-python',
-                'pulp-rpm',
                 'python-args',
+                'python-chardet',
                 'python-clint',
                 'python-crane',
+                'python-cryptography',
+                'python-cryptography-vectors',
                 'python-flower',
+                'python-idna',
                 'python-invocations',
+                'python-ipdb',
                 'python-isodate',
                 'python-pkginfo',
                 'python-pymongo',
+                'python-pytoml',
                 'python-releases',
+                'python-requests',
                 'python-rpdb',
                 'python-sphinxcontrib-fulltoc',
                 'python-twine',
+                'python-urllib3',
             ])
         }
-        self.expected_watch = {}
         self.expected_all = {
             'rpms': self.expected_comaintained['rpms'].union(
                 self.expected_point_of_contact['rpms']),
         }
 
+    @mock.patch('fmn.rules.utils._get_pagure_packages_for')
+    def test_using_pagure(self, mock_get_packages):
+        utils._get_packages_for(self.config, 'jcline', [])
+        mock_get_packages.assert_called_once_with(self.config, 'jcline', [])
+
     def test_bad_response(self):
         """Assert a bad response results in an empty result."""
-        packages = utils._get_pagure_packages_for(self.config, 'thisisnotausername123', [])
+        packages = utils._get_packages_for(
+            self.config, 'thisisnotausername123', ['co-maintained'])
         self.assertEqual(dict(), packages)
 
-    def test_watch(self):
-        """Assert watch results from pagure works."""
-        packages = utils._get_pagure_packages_for(self.config, 'jcline', ['watch'])
-        self.assertEqual(self.expected_watch, packages)
+    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ConnectTimeout))
+    def test_connect_failure(self):
+        """Assert a bad response results in an empty result."""
+        packages = utils._get_packages_for(self.config, 'jcline', ['co-maintained'])
+        self.assertEqual(dict(), packages)
+
+    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ReadTimeout))
+    def test_read_failure(self):
+        """Assert a bad response results in an empty result."""
+        packages = utils._get_packages_for(self.config, 'jcline', ['co-maintained'])
+        self.assertEqual(dict(), packages)
+
+    def test_no_flags(self):
+        """Assert passing no flags earns the caller a ValueError."""
+        self.assertRaises(ValueError, utils._get_packages_for, self.config, 'jcline', [])
+
+    def test_invalid_flags(self):
+        """Assert passing an invalid flags earns the caller a ValueError."""
+        self.assertRaises(
+            ValueError, utils._get_packages_for, self.config, 'jcline', ['flag'])
 
     def test_comaintained(self):
         """Assert co-maintained results from pagure works."""
-        packages = utils._get_pagure_packages_for(self.config, 'jcline', ['co-maintained'])
+        packages = utils._get_packages_for(self.config, 'jcline', ['co-maintained'])
         self.assertEqual(self.expected_comaintained, packages)
 
     def test_point_of_contact(self):
         """Assert point of contact results from pagure works."""
-        packages = utils._get_pagure_packages_for(self.config, 'jcline', ['point of contact'])
+        packages = utils._get_packages_for(self.config, 'jcline', ['point of contact'])
         self.assertEqual(self.expected_point_of_contact, packages)
 
     def test_all(self):
-        packages = utils._get_pagure_packages_for(
-            self.config, 'jcline', ['point of contact', 'watch', 'co-maintained'])
+        packages = utils._get_packages_for(
+            self.config, 'jcline', ['point of contact', 'co-maintained'])
         self.assertEqual(self.expected_all, packages)
+
+
+class GetPagurePackagersForTests(Base):
+
+    def setUp(self):
+        super(GetPagurePackagersForTests, self).setUp()
+
+        self.config = {
+            'fmn.rules.utils.use_pagure_for_ownership': True,
+            'fmn.rules.utils.pagure_api_url': 'https://src.stg.fedoraproject.org/pagure/api',
+            'fmn.rules.cache': {'backend': 'dogpile.cache.memory'},
+            'fas_credentials': {'username': 'jcline', 'password': 'supersecret'}
+        }
+
+    def test_no_groups(self):
+        """Assert packages without groups return the expected set of packagers."""
+        expected_packagers = set(['bowlofeggs', 'jcline', 'xavierb', 'martinlanghoff', 'peter'])
+        packagers = utils._get_packagers_for(self.config, 'rpms/ejabberd')
+
+        self.assertEqual(expected_packagers, packagers)
+
+    def test_groups(self):
+        infra_group = set([
+            'abompard',
+            'bochecha',
+            'bowlofeggs',
+            'codeblock',
+            'jcline',
+            'kevin',
+            'lmacken',
+            'pingou',
+            'puiterwijk',
+            'sayanchowdhury',
+            'toshio',
+        ])
+        committers = set([
+            'abompard',
+            'jcline',
+            'ralph',
+            'sagarun',
+        ])
+
+        packagers = utils._get_packagers_for(self.config, 'rpms/python-urllib3')
+
+        self.assertEqual(infra_group.union(committers), packagers)
+
+    def test_no_namespace(self):
+        """Assert packages without a namespace default to RPM."""
+        expected_packagers = set(['bowlofeggs', 'jcline', 'xavierb', 'martinlanghoff', 'peter'])
+        packagers = utils._get_packagers_for(self.config, 'ejabberd')
+
+        self.assertEqual(expected_packagers, packagers)
+
+    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ReadTimeout))
+    def test_read_timeout(self):
+        packagers = utils._get_packagers_for(self.config, 'rpms/ejabberd')
+
+        self.assertEqual(set(), packagers)
+
+    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ConnectTimeout))
+    def test_connect_timeout(self):
+        packagers = utils._get_packagers_for(self.config, 'rpms/ejabberd')
+
+        self.assertEqual(set(), packagers)
+
+    def test_error_response(self):
+        packagers = utils._get_packagers_for(self.config, 'notanamespace/orapackage')
+
+        self.assertEqual(set(), packagers)
+
+
+class GetPackagersOfPackageTests(unittest.TestCase):
+    """Tests for the :func:`get_packagers_of_package` function."""
+
+    @mock.patch('fmn.rules.utils._get_packagers_for')
+    def test_cache_miss(self, mock_get_packagers_for):
+        """Assert cache misses result in the value being created."""
+        cache_dict = {}
+        config = {
+            'fmn.rules.cache': {
+                'backend': 'dogpile.cache.memory', 'arguments': {'cache_dict': cache_dict}
+            }
+        }
+
+        with mock.patch('fmn.rules.utils._cache', cache.make_region()):
+            packagers = utils.get_packagers_of_package(config, 'some-package')
+
+        mock_get_packagers_for.assert_called_once_with(config, 'some-package')
+        self.assertTrue(packagers is mock_get_packagers_for.return_value)
+
+    @mock.patch('fmn.rules.utils._get_packagers_for')
+    def test_cache_hit(self, mock_get_packagers_for):
+        """Assert cache hits are used and the value isn't recreated."""
+        cache_dict = {}
+        key = u'fmn.rules.utils|get_packagers_of_package|some-package'.encode('utf-8')
+        cache_dict[key] = cache.api.CachedValue('jcline', {'v': 1, 'ct': 1500000000.0})
+        config = {
+            'fmn.rules.cache': {
+                'backend': 'dogpile.cache.memory', 'arguments': {'cache_dict': cache_dict}
+            }
+        }
+
+        with mock.patch('fmn.rules.utils._cache', cache.make_region()):
+            packagers = utils.get_packagers_of_package(config, 'some-package')
+
+        self.assertEqual(0, mock_get_packagers_for.call_count)
+        self.assertEqual('jcline', packagers)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This introduces a new method to query for package ownership: from
pagure-over-dist-git instead of from pkgdb.

https://fedoraproject.org/wiki/Changes/ArbitraryBranching