### PR TITLE
Pin urllib3 and requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,9 @@ python-openid
 python-openid-cla
 python-openid-teams
 redis
-requests
+urllib3>=1.21.1,<1.22
+requests>=2.18.1
 six
 SQLAlchemy>=0.8
 twisted
-urllib3
 wtforms

--- a/tox.ini
+++ b/tox.ini
@@ -39,11 +39,11 @@ deps =
     python-openid-cla==1.2
     python-openid-teams==1.1
     redis==2.10.3
-    requests
+    urllib3==1.21.1
+    requests==2.18.1
     six==1.9.0
     SQLAlchemy==0.9.8
     twisted
-    urllib3
     wtforms==2.0
     mock
     pytest


### PR DESCRIPTION
The two test failures were due to fedmsg_meta quietly failing to load
processors. This failed because at some point at some point during the
processor loading phase it was importing requests which was upset about
the urllib3 version.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>