### PR TITLE
Make the topic the FMN consumer subscribes to configurable

### DIFF
--- a/fedmsg.d/fmn.py
+++ b/fedmsg.d/fmn.py
@@ -5,6 +5,9 @@ hostname = socket.gethostname().split('.')[0]
 config = {
     # Consumer stuff
     "fmn.consumer.enabled": True,
+    # The topics to subscribe to as a consumer, defaults to everything. Must be a list
+    # of bytestrings.
+    "fmn.topics": [b'*'],
     "fmn.sqlalchemy.uri": "sqlite:////var/tmp/fmn-dev-db.sqlite",
     "fmn.autocreate": True,  # Should new packagers auto-get accounts?
     "fmn.junk_suffixes": [

--- a/fmn/consumer/consumer.py
+++ b/fmn/consumer/consumer.py
@@ -100,12 +100,13 @@ class FMNConsumer(fedmsg.consumers.FedmsgConsumer):
         config_key (str): The key to set to ``True`` in the fedmsg config to
             enable this consumer. The key is ``fmn.consumer.enabled``.
     """
-    topic = '*'
     config_key = 'fmn.consumer.enabled'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, hub, *args, **kwargs):
+        self.topic = hub.config.get('fmn.topics', b'*')
+
         log.debug("FMNConsumer initializing")
-        super(FMNConsumer, self).__init__(*args, **kwargs)
+        super(FMNConsumer, self).__init__(hub, *args, **kwargs)
 
         self.uri = self.hub.config.get('fmn.sqlalchemy.uri', None)
         self.autocreate = self.hub.config.get('fmn.autocreate', False)

--- a/fmn/tests/consumer/test_consumer.py
+++ b/fmn/tests/consumer/test_consumer.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of FMN.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+"""Tests for the :mod:`fmn.consumer.consumer` module"""
+from __future__ import absolute_import
+
+import unittest
+
+import mock
+
+from fmn.consumer import consumer
+
+
+class FMNConsumerTests(unittest.TestCase):
+
+    def setUp(self):
+        self.config = {
+            'fmn.consumer.enabled': True,
+            'validate_signatures': False,
+            'fmn.sqlalchemy.uri': 'sqlite://',
+        }
+        self.hub = mock.Mock(config=self.config)
+
+    def test_default_topic(self):
+        """Assert the default topic for the FMN consumer is everything."""
+        fmn_consumer = consumer.FMNConsumer(self.hub)
+
+        self.assertEqual(b'*', fmn_consumer.topic)
+        self.hub.subscribe.assert_called_once_with(b'*', fmn_consumer._consume_json)
+
+    def test_custom_topics(self):
+        """Assert the default topic for the FMN consumer is everything."""
+        self.config['fmn.topics'] = [b'my.custom.topic']
+        fmn_consumer = consumer.FMNConsumer(self.hub)
+
+        self.assertEqual([b'my.custom.topic'], fmn_consumer.topic)
+        self.hub.subscribe.assert_called_once_with(b'my.custom.topic', fmn_consumer._consume_json)


### PR DESCRIPTION
Allow the user to configure what topic(s) the FMN consumer subscribes
to. The default remains "everything".

Fixes #216

Signed-off-by: Jeremy Cline <jeremy@jcline.org>