### PR TITLE
Update the preference format for example messages

### DIFF
--- a/fmn/web/app.py
+++ b/fmn/web/app.py
@@ -602,9 +602,9 @@ def example_messages(openid, context, filter_id, page, endtime):
     # Mock out a fake 'cached preferences' object like we have in the consumer,
     # but really it just consists of the one preferences and its *one* filter
     # for which we're trying to find example messages.
-    preferences = [pref.__json__()]
-    preferences[0]['detail_values'] = ['mock']
-    preferences[0]['filters'] = [filter.__json__(reify=True)]
+    preferences = {'nobody_mock': pref.__json__()}
+    preferences['nobody_mock']['detail_values'] = ['mock']
+    preferences['nobody_mock']['filters'] = [filter.__json__(reify=True)]
 
     results = []
     for message in messages:


### PR DESCRIPTION
This updates the format of preferences handed to the
``fmn.lib.recipients`` API. Unfortunately there are no tests with this
change. The web application has 0% test coverage and needs to be
refactored. I've filed an issue to track this[0].

[0] https://github.com/fedora-infra/fmn/issues/219

Fixes #210

Signed-off-by: Jeremy Cline <jeremy@jcline.org>