### PR TITLE
Enable the IRC client to authenticate with NickServ

### DIFF
--- a/ansible/roles/fmn-dev/files/fedmsg.d/fmn.py
+++ b/ansible/roles/fmn-dev/files/fedmsg.d/fmn.py
@@ -60,8 +60,10 @@ config = {
 
     # IRC
     "fmn.irc.network": "irc.freenode.net",
+    "fmn.irc.port": 6697,
     "fmn.irc.nickname": "fmn-devbot",
-    "fmn.irc.port": 6667,
+    "fmn.irc.nickserv_pass": None,
+    "fmn.irc.use_ssl": True,
     "fmn.irc.timeout": 120,
 
     # GCM - Android notifs

--- a/fedmsg.d/fmn.py
+++ b/fedmsg.d/fmn.py
@@ -70,7 +70,9 @@ config = {
     # IRC
     "fmn.irc.network": "irc.freenode.net",
     "fmn.irc.nickname": "threebot",
-    "fmn.irc.port": 6667,
+    "fmn.irc.nickserv_pass": None,
+    "fmn.irc.port": 6697,
+    "fmn.irc.use_ssl": True,
     "fmn.irc.timeout": 120,
 
     # SSE

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ moksha.hub
 pika
 pydns
 pylibravatar
+pyOpenSSL
 python-fedora
 python-openid
 python-openid-cla


### PR DESCRIPTION
This also adds the ability to turn TLS on for the IRC connection.

As is always there case with FMN, there aren't any tests for this. Pretty much all of the backend needs to be re-written anyway. This particular issue is more urgent since Freenode enabled +R for everyone by default.

fixes #217 

Signed-off-by: Jeremy Cline <jeremy@jcline.org>