### PR TITLE
Switch to Celery broadcasts for cache invalidation

### DIFF
--- a/ansible/roles/fmn-dev/files/fedmsg.d/fmn.py
+++ b/ansible/roles/fmn-dev/files/fedmsg.d/fmn.py
@@ -82,6 +82,12 @@ config = {
         'include': ['fmn.tasks'],
         'accept_content': ['json'],
         'task_serializer': 'json',
+        'task_routes': {
+            'fmn.tasks.find_recipients': {
+                'queue': 'fmn.tasks.unprocessed_messages',
+                'routing_key': 'fmn.tasks.unprocessed_messages',
+            },
+        }
     },
 
     # Generic stuff

--- a/fedmsg.d/fmn.py
+++ b/fedmsg.d/fmn.py
@@ -93,7 +93,12 @@ config = {
         'include': ['fmn.tasks'],
         'accept_content': ['json'],
         'task_serializer': 'json',
-        'task_default_queue': 'workers',
+        'task_routes': {
+            'fmn.tasks.find_recipients': {
+                'queue': 'fmn.tasks.unprocessed_messages',
+                'routing_key': 'fmn.tasks.unprocessed_messages',
+            },
+        }
     },
 
     # Generic stuff

--- a/fmn/celery.py
+++ b/fmn/celery.py
@@ -20,10 +20,18 @@
 from __future__ import absolute_import
 
 from celery import Celery
+from kombu.common import Broadcast, Queue
 
 from . import config
 
 
+RELOAD_CACHE_EXCHANGE_NAME = 'fmn.tasks.reload_cache'
+
+
 #: The celery application object
 app = Celery('FMN')
+app.conf.task_queues = (
+    Broadcast(RELOAD_CACHE_EXCHANGE_NAME),
+    Queue('fmn.tasks.unprocessed_messages'),
+)
 app.conf.update(**config.app_conf['celery'])


### PR DESCRIPTION
Workers need to refresh their caches when we get messages about user
preference changes. This sets up a broadcast for workers.

There are a few oddities with this patch. Firstly, because of the way
the cache is initialized (inside the Task instance) we have to either dig
around in there to update the cache or dispatch the task itself and do a
special check to see if it's a cache refresh task. In this patch I've
opted for the second approach, although I'm not thrilled about that. In
the future we should have a better caching layer that makes this less
painful. Secondly, workers are being started in --pool=solo mode (one
process per worker). This is because the broadcast gets sent to each
worker, but not to each process in the worker's process pool. Running
in solo mode maps workers to processes 1-to-1, although it is generally
less efficient to run that way.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>