### PR TITLE
Dispatch a task on consumer startup to cache all of FAS

### DIFF
--- a/ansible/roles/fmn-dev/files/fedmsg.d/fmn.py
+++ b/ansible/roles/fmn-dev/files/fedmsg.d/fmn.py
@@ -91,6 +91,10 @@ config = {
                 'queue': 'fmn.tasks.unprocessed_messages',
                 'routing_key': 'fmn.tasks.unprocessed_messages',
             },
+            'fmn.tasks.heat_fas_cache': {
+                'queue': 'fmn.tasks.unprocessed_messages',
+                'routing_key': 'fmn.tasks.unprocessed_messages',
+            },
         },
         'beat_schedule': {
             'process-digests': {

--- a/fmn/consumer.py
+++ b/fmn/consumer.py
@@ -25,7 +25,7 @@ from .util import (
     new_badges_user,
     get_fas_email,
 )
-from fmn.tasks import find_recipients, REFRESH_CACHE_TOPIC
+from fmn.tasks import find_recipients, REFRESH_CACHE_TOPIC, heat_fas_cache
 
 
 log = logging.getLogger("fmn")
@@ -59,6 +59,8 @@ class FMNConsumer(fedmsg.consumers.FedmsgConsumer):
 
         if not self.uri:
             raise ValueError('fmn.sqlalchemy.uri must be present')
+
+        heat_fas_cache.apply_async()
 
         _log.info("Loading rules from fmn.rules")
         self.valid_paths = fmn.lib.load_rules(root="fmn.rules")

--- a/fmn/tasks.py
+++ b/fmn/tasks.py
@@ -322,5 +322,16 @@ def _batch_ready(preference):
     return False
 
 
+@app.task(name='fmn.tasks.heat_fas_cache', ignore_results=True)
+def heat_fas_cache():  # pragma: no cover
+    """
+    Fetch all users from FAS and populate the local Redis cache.
+
+    This is helpful to do once on startup since we'll need everyone's email or
+    IRC nickname eventually.
+    """
+    fmn_fasshim.make_fas_cache(**config.app_conf)
+
+
 #: A Celery task that accepts a message as input and determines the recipients.
 find_recipients = app.tasks[_FindRecipients.name]

--- a/fmn/tests/test_consumer.py
+++ b/fmn/tests/test_consumer.py
@@ -36,6 +36,7 @@ class FMNConsumerTests(Base):
         }
         self.hub = mock.Mock(config=self.config)
 
+    @mock.patch('fmn.consumer.heat_fas_cache', mock.Mock())
     def test_default_topic(self):
         """Assert the default topic for the FMN consumer is everything."""
         fmn_consumer = consumer.FMNConsumer(self.hub)
@@ -43,6 +44,7 @@ class FMNConsumerTests(Base):
         self.assertEqual(b'*', fmn_consumer.topic)
         self.hub.subscribe.assert_called_once_with(b'*', fmn_consumer._consume_json)
 
+    @mock.patch('fmn.consumer.heat_fas_cache', mock.Mock())
     def test_custom_topics(self):
         """Assert the default topic for the FMN consumer is everything."""
         self.config['fmn.topics'] = [b'my.custom.topic']
@@ -51,6 +53,14 @@ class FMNConsumerTests(Base):
         self.assertEqual([b'my.custom.topic'], fmn_consumer.topic)
         self.hub.subscribe.assert_called_once_with(b'my.custom.topic', fmn_consumer._consume_json)
 
+    @mock.patch('fmn.consumer.heat_fas_cache')
+    def test_heat_cache(self, mock_heat):
+        """Assert a task is dispatched to heat the cache on startup."""
+        consumer.FMNConsumer(self.hub)
+
+        mock_heat.apply_async.assert_called_once_with()
+
+    @mock.patch('fmn.consumer.heat_fas_cache', mock.Mock())
     @mock.patch('fmn.consumer.find_recipients')
     def test_refresh_cache_fmn_message(self, mock_find_recipients):
         """Assert messages with an '.fmn.' topic result in a message to workers."""
@@ -75,6 +85,7 @@ class FMNConsumerTests(Base):
             dict(exchange='fmn.tasks.reload_cache'),
         )
 
+    @mock.patch('fmn.consumer.heat_fas_cache', mock.Mock())
     @mock.patch('fmn.consumer.new_packager', mock.Mock(return_value='jcline'))
     @mock.patch('fmn.consumer.get_fas_email', mock.Mock(return_value='jcline'))
     @mock.patch('fmn.consumer.find_recipients')


### PR DESCRIPTION
We need everyone's email/irc/groups to do message classification. This
is fetched lazily as necessary, but we know we're going to need nearly
everyone's account information anyway, so dispatches a task right at
startup to populate the cache in the background.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>