### PR TITLE
Move confirmation generation to a celery beat task

### DIFF
--- a/ansible/roles/fmn-dev/files/fedmsg.d/endpoints.py
+++ b/ansible/roles/fmn-dev/files/fedmsg.d/endpoints.py
@@ -31,6 +31,11 @@ config = dict(
             "tcp://hub.fedoraproject.org:9940",
             #"tcp://stg.fedoraproject.org:9940",
         ],
+        'fmn.fmn-dev': [
+            'tcp://*:3333',
+            'tcp://*:3334',
+            'tcp://*:3335',
+        ]
 
         # For other, more 'normal' services, fedmsg will try to guess the
         # name of it's calling module to determine which endpoint definition

--- a/ansible/roles/fmn-dev/files/fedmsg.d/fmn.py
+++ b/ansible/roles/fmn-dev/files/fedmsg.d/fmn.py
@@ -95,12 +95,20 @@ config = {
                 'queue': 'fmn.tasks.unprocessed_messages',
                 'routing_key': 'fmn.tasks.unprocessed_messages',
             },
+            'fmn.tasks.confirmations': {
+                'queue': 'fmn.tasks.unprocessed_messages',
+                'routing_key': 'fmn.tasks.unprocessed_messages',
+            },
         },
         'beat_schedule': {
             'process-digests': {
                 'task': 'fmn.tasks.batch_messages',
                 'schedule': 60.0,
-            }
+            },
+            'process-confirmations': {
+                'task': 'fmn.tasks.confirmations',
+                'schedule': 15.0,
+            },
         },
     },
 

--- a/fmn/delivery/backends/base.py
+++ b/fmn/delivery/backends/base.py
@@ -58,13 +58,6 @@ class BaseBackend(object):
         """
         pass
 
-    @abc.abstractmethod
-    def handle_confirmation(self, session, confirmation):
-        """
-        Handle a confirmation message.
-        """
-        pass
-
     # Some helper methods for our child classes.
     def context_object(self, session):
         return fmn.lib.models.Context.get(self.__context_name__)


### PR DESCRIPTION
Move the database querying and message formatting to a celery task
dispatched by celery beat rather than a looping call in Twisted.

The advantage is two-fold. It makes confirmations not be a special case
(except for IRC at the moment, but that will take a substantial
refactor) and it removes the regular blocking IO from the Twisted
thread, improving throughput on the delivery service.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>