### PR TITLE
Use one queue per messaging backend

### DIFF
--- a/fmn/constants.py
+++ b/fmn/constants.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of the FMN project.
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+"""FMN constants."""
+
+#: The prefix to use for AMQP routing keys when publishing messages to the delivery backends.
+BACKEND_QUEUE_PREFIX = 'fmn.backends.'

--- a/fmn/tests/test_tasks.py
+++ b/fmn/tests/test_tasks.py
@@ -24,7 +24,7 @@ from dogpile import cache
 from kombu import Queue
 import mock
 
-from fmn import tasks, lib as fmn_lib
+from fmn import tasks, lib as fmn_lib, constants
 from fmn.lib import models
 from fmn.tests import Base
 
@@ -158,8 +158,8 @@ class FindRecipientsTestCase(Base):
         conn = mock_conns.__getitem__.return_value.acquire.return_value.__enter__.return_value
         conn.Producer.return_value.publish.assert_called_with(
             expected_published_message,
-            routing_key='backends',
-            declare=[Queue('backends', durable=True)],
+            routing_key=constants.BACKEND_QUEUE_PREFIX + 'sse',
+            declare=[Queue(constants.BACKEND_QUEUE_PREFIX + 'sse', durable=True)],
         )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,4 +37,4 @@ commands =
 [flake8]
 show-source = True
 max-line-length = 100
-exclude = .git,.tox,dist,*egg,docs,alembic,ansible,setup.py,fmn/lib/,fmn/rules,fmn/web/,fedmsg.d/fmn.py
+exclude = .git,.tox,dist,*egg,docs,alembic,ansible,setup.py,fmn/lib/,fmn/rules,fmn/web/,fedmsg.d/fmn.py,fmn/consumer.py


### PR DESCRIPTION
Publish messages to the backend using a routing key based off the
backend (``fmn.backend.`` + ``<backend-name>``). This solves the issue
introduced in #238 where the irc network being down causes emails to
back up. The delivery service round-robins the various queues.

cc @puiterwijk  @pypingou

Signed-off-by: Jeremy Cline <jeremy@jcline.org>