### PR TITLE
Skip queries for watch flag rather than crashing

### DIFF
--- a/fmn/rules/utils.py
+++ b/fmn/rules/utils.py
@@ -351,10 +351,7 @@ def _get_pagure_packages_for(config, username, flags):
     """
     log.debug("Requesting pagure packages for user %r" % username)
 
-    # In the future we want to also support the 'watch' state.
-    # See https://github.com/fedora-infra/fmn/issues/209
-    # which depends on https://pagure.io/pagure/issue/2421
-    valid_flags = ['point of contact', 'co-maintained']
+    valid_flags = ['point of contact', 'co-maintained', 'watch']
 
     bogus = set(flags) - set(valid_flags)
     if bogus:
@@ -371,8 +368,14 @@ def _get_pagure_packages_for(config, username, flags):
     for flag in flags:
         if flag == 'point of contact':
             params = dict(owner=username, short=True)
-        else:  # 'co-maintained'
+        elif flag == 'co-maintained':
             params = dict(username=username, short=True)
+        else:  # watch
+            # In the future we want to also support the 'watch' state.
+            # See https://github.com/fedora-infra/fmn/issues/209
+            # which depends on https://pagure.io/pagure/issue/2421
+            log.debug('"watch" flag is currently unsupported, skipping')
+            continue
 
         pages = _paginate_pagure_data(url, params)
         for page in pages:

--- a/fmn/tests/rules/test_utils.py
+++ b/fmn/tests/rules/test_utils.py
@@ -354,9 +354,13 @@ class GetPagurePackagesForTests(Base):
         packages = utils._get_packages_for(self.config, 'jcline', ['point of contact'])
         self.assertEqual(self.expected_point_of_contact, packages)
 
+    def test_watch(self):
+        """Assert "watch" returns an empty set until it's implemented."""
+        self.assertEqual({}, utils._get_packages_for(self.config, 'jcline', ['watch']))
+
     def test_all(self):
         packages = utils._get_packages_for(
-            self.config, 'jcline', ['point of contact', 'co-maintained'])
+            self.config, 'jcline', ['point of contact', 'co-maintained', 'watch'])
         self.assertEqual(self.expected_all, packages)
 
 


### PR DESCRIPTION
Plenty of rules try to query on watch, so just skip them rather than
raising an exception when they query on watch.

CC @ralphbean 

Signed-off-by: Jeremy Cline <jeremy@jcline.org>