### PR TITLE
Announce message notifications via fedmsg

### DIFF
--- a/fmn/consumer.py
+++ b/fmn/consumer.py
@@ -104,6 +104,11 @@ class FMNConsumer(fedmsg.consumers.FedmsgConsumer):
         """
         topic, msg = raw_msg['topic'], raw_msg['body']
 
+        if 'fmn.notification' in topic:
+            # This is a notification of a notification we've sent. Processing it
+            # would lead to a positive feedback loop.
+            return
+
         for suffix in self.junk_suffixes:
             if topic.endswith(suffix):
                 log.debug("Dropping %r", topic)


### PR DESCRIPTION
Send a notification of the notification we're about to send via fedmsg.
Make sure the consumer does not try to process that notification.

@abompard I thought I'd just put this up and we could talk about the details of what you need on the PR. I was thinking about implementing a simple formatter for the message so it would arrive on your end as human-readable, but I thought you might want to control that so maybe it makes sense to just resend the original fedmsg. Also, I don't know whether the message topic should be "notification.{user}.{context}" or "notification.{context}.{user}" - the first lets you subscribe to all contexts for a user, or all contexts for all users, while the second lets you subscribe to all users for a context, or all contexts for all users.