### PR TITLE
Stop converting database models to dicts

### DIFF
--- a/fmn/tasks.py
+++ b/fmn/tasks.py
@@ -201,7 +201,7 @@ class _FindRecipients(task.Task):
                         fltr = models.Filter.query.get(idx)
                         fltr.fired(session)
 
-                    if preference.get('batch_delta') or preference.get('batch_count'):
+                    if preference.batch_delta or preference.batch_count:
                         _log.info('User "%s" has batch delivery set; placing message in database',
                                   user)
                         models.QueuedMessage.enqueue(session, user, context, message)

--- a/fmn/tests/lib/test_lib.py
+++ b/fmn/tests/lib/test_lib.py
@@ -57,7 +57,7 @@ class LoadPreferenceTests(BaseTestCase):
             pref = models.Preference.query.filter(
                 models.Preference.openid == openid,
                 models.Preference.context_name == context).first()
-            self.assertEqual(pref.__json__(reify=True), preferences[key])
+            self.assertEqual(pref, preferences[key])
 
     def test_load_preferences_cull_backends(self):
         """Assert all preferences are loaded, excepting specified backends"""
@@ -70,7 +70,7 @@ class LoadPreferenceTests(BaseTestCase):
             pref = models.Preference.query.filter(
                 models.Preference.openid == openid,
                 models.Preference.context_name == context).first()
-            self.assertEqual(pref.__json__(reify=True), preferences[key])
+            self.assertEqual(pref, preferences[key])
 
     def test_load_preferences_skip_disabled(self):
         """Assert all preferences are loaded, excepting disabled preferences"""
@@ -80,7 +80,7 @@ class LoadPreferenceTests(BaseTestCase):
         pref = models.Preference.query.filter(
             models.Preference.openid == 'jcline',
             models.Preference.context_name == 'pidgeon').first()
-        self.assertEqual(pref.__json__(reify=True), preferences['jcline_pidgeon'])
+        self.assertEqual(pref, preferences['jcline_pidgeon'])
 
 
 class TestRecipients(BaseTestCase):

--- a/fmn/tests/test_defaults.py
+++ b/fmn/tests/test_defaults.py
@@ -26,14 +26,14 @@ class TestDefaults(fmn.tests.Base):
         self.create_data()
         preferences = fmn.lib.load_preferences()
         pref = preferences['ralph.id.fedoraproject.org_email']
-        self.assertEqual(pref['user']['openid'], 'ralph.id.fedoraproject.org')
-        self.assertEqual(pref['detail_values'], ['shmalf@fedoraproject.org'])
-        self.assertEqual(pref['enabled'], True)
+        self.assertEqual(pref.user.openid, 'ralph.id.fedoraproject.org')
+        self.assertEqual([v.value for v in pref.detail_values], ['shmalf@fedoraproject.org'])
+        self.assertEqual(pref.enabled, True)
 
     def test_defaults_without_detail_value(self):
         self.create_data()
         preferences = fmn.lib.load_preferences()
         pref = preferences['toshio.id.fedoraproject.org_email']
-        self.assertEqual(pref['user']['openid'], 'toshio.id.fedoraproject.org')
-        self.assertEqual(pref['detail_values'], [])
-        self.assertEqual(pref['enabled'], False)
+        self.assertEqual(pref.user.openid, 'toshio.id.fedoraproject.org')
+        self.assertEqual(pref.detail_values, [])
+        self.assertEqual(pref.enabled, False)

--- a/fmn/web/app.py
+++ b/fmn/web/app.py
@@ -598,18 +598,11 @@ def example_messages(openid, context, filter_id, page, endtime):
             'time': arrow.get(msg.timestamp).humanize(),
         }
 
-    # Mock out a fake 'cached preferences' object like we have in the consumer,
-    # but really it just consists of the one preferences and its *one* filter
-    # for which we're trying to find example messages.
-    preferences = {'nobody_mock': pref.__json__()}
-    preferences['nobody_mock']['detail_values'] = ['mock']
-    preferences['nobody_mock']['filters'] = [filter.__json__(reify=True)]
-
     results = []
     for message in messages:
         original = message.__json__()
         recips = fmn.lib.recipients(
-            preferences, message.__json__(), valid_paths, config.app_conf)
+            {'nobody_mock': pref}, message.__json__(), valid_paths, config.app_conf)
         if recips:
             results.append(_make_result(message, original))
 


### PR DESCRIPTION
This should _vastly_ improve the performance of load_preferences. It
does this by 1) eagerly loading the filter and rule relationships (which
we need in all cases) and 2) keeping the preferences as the SQLAlchemy
database classes rather than turning them all to JSON.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>