### PR TITLE
Try to speed up getting the user->package mapping

### DIFF
--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_all
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_all
@@ -7,13 +7,13 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&short=True&page=1
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?page=1&owner=jcline&per_page=100&short=True
   response:
     body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
         namespace\": null,\n    \"owner\": \"jcline\",\n    \"page\": 1,\n    \"pattern\"\
         : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
-        \    \"username\": null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=True&page=1\"\
-        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=True&page=1\"\
+        \    \"username\": null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=100&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=100&short=True&page=1\"\
         ,\n    \"next\": null,\n    \"page\": 1,\n    \"pages\": 1,\n    \"per_page\"\
         : 20,\n    \"prev\": null\n  },\n  \"projects\": [\n    {\n      \"description\"\
         : \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\"\
@@ -80,15 +80,15 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=True&page=1&username=jcline
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=True&page=1&username=jcline&per_page=100
   response:
     body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
         namespace\": null,\n    \"owner\": null,\n    \"page\": 1,\n    \"pattern\"\
         : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
         \    \"username\": \"jcline\"\n  },\n  \"pagination\": {\n    \"first\": \"\
-        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
-        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
-        ,\n    \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=2\"\
+        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=3\"\
+        ,\n    \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=2\"\
         ,\n    \"page\": 1,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\"\
         : null\n  },\n  \"projects\": [\n    {\n      \"description\": \"The bodhi\
         \ rpms\",\n      \"fullname\": \"rpms/bodhi\",\n      \"name\": \"bodhi\"\
@@ -161,17 +161,17 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=2
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=2
   response:
     body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
         namespace\": null,\n    \"owner\": null,\n    \"page\": 2,\n    \"pattern\"\
         : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
         \    \"username\": \"jcline\"\n  },\n  \"pagination\": {\n    \"first\": \"\
-        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
-        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
-        ,\n    \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
+        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=3\"\
+        ,\n    \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=3\"\
         ,\n    \"page\": 2,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\"\
-        : \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
+        : \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=1\"\
         \n  },\n  \"projects\": [\n    {\n      \"description\": \"The erlang-p1_tls\
         \ rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n      \"name\": \"\
         erlang-p1_tls\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\"\
@@ -243,16 +243,16 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=3
   response:
     body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
         namespace\": null,\n    \"owner\": null,\n    \"page\": 3,\n    \"pattern\"\
         : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
         \    \"username\": \"jcline\"\n  },\n  \"pagination\": {\n    \"first\": \"\
-        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
-        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
+        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=3\"\
         ,\n    \"next\": null,\n    \"page\": 3,\n    \"pages\": 3,\n    \"per_page\"\
-        : 20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=2\"\
+        : 20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=2\"\
         \n  },\n  \"projects\": [\n    {\n      \"description\": \"The python-pkginfo\
         \ rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n      \"name\": \"\
         python-pkginfo\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"\

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_bad_response
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_bad_response
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=True&page=1&username=thisisnotausername123
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=True&page=1&username=thisisnotausername123&per_page=100
   response:
     body: {string: !!python/unicode "{\n  \"error\": \"No projects found\",\n  \"\
         error_code\": \"ENOPROJECTS\"\n}"}

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_comaintained
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_comaintained
@@ -7,15 +7,15 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=True&page=1&username=jcline
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?short=True&page=1&username=jcline&per_page=100
   response:
     body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
         namespace\": null,\n    \"owner\": null,\n    \"page\": 1,\n    \"pattern\"\
         : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
         \    \"username\": \"jcline\"\n  },\n  \"pagination\": {\n    \"first\": \"\
-        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
-        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
-        ,\n    \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=2\"\
+        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=3\"\
+        ,\n    \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=2\"\
         ,\n    \"page\": 1,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\"\
         : null\n  },\n  \"projects\": [\n    {\n      \"description\": \"The bodhi\
         \ rpms\",\n      \"fullname\": \"rpms/bodhi\",\n      \"name\": \"bodhi\"\
@@ -88,17 +88,17 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=2
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=2
   response:
     body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
         namespace\": null,\n    \"owner\": null,\n    \"page\": 2,\n    \"pattern\"\
         : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
         \    \"username\": \"jcline\"\n  },\n  \"pagination\": {\n    \"first\": \"\
-        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
-        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
-        ,\n    \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
+        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=3\"\
+        ,\n    \"next\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=3\"\
         ,\n    \"page\": 2,\n    \"pages\": 3,\n    \"per_page\": 20,\n    \"prev\"\
-        : \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
+        : \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=1\"\
         \n  },\n  \"projects\": [\n    {\n      \"description\": \"The erlang-p1_tls\
         \ rpms\",\n      \"fullname\": \"rpms/erlang-p1_tls\",\n      \"name\": \"\
         erlang-p1_tls\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"description\"\
@@ -170,16 +170,16 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=3
   response:
     body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
         namespace\": null,\n    \"owner\": null,\n    \"page\": 3,\n    \"pattern\"\
         : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
         \    \"username\": \"jcline\"\n  },\n  \"pagination\": {\n    \"first\": \"\
-        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=1\"\
-        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=3\"\
+        https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=3\"\
         ,\n    \"next\": null,\n    \"page\": 3,\n    \"pages\": 3,\n    \"per_page\"\
-        : 20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=20&short=True&page=2\"\
+        : 20,\n    \"prev\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?username=jcline&per_page=100&short=True&page=2\"\
         \n  },\n  \"projects\": [\n    {\n      \"description\": \"The python-pkginfo\
         \ rpms\",\n      \"fullname\": \"rpms/python-pkginfo\",\n      \"name\": \"\
         python-pkginfo\",\n      \"namespace\": \"rpms\"\n    },\n    {\n      \"\

--- a/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_point_of_contact
+++ b/fmn/tests/fixtures/fmn.tests.rules.test_utils.GetPagurePackagesForTests.test_point_of_contact
@@ -7,13 +7,13 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.18.2]
     method: GET
-    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&short=True&page=1
+    uri: https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&short=True&page=1&per_page=100
   response:
     body: {string: !!python/unicode "{\n  \"args\": {\n    \"fork\": null,\n    \"\
         namespace\": null,\n    \"owner\": \"jcline\",\n    \"page\": 1,\n    \"pattern\"\
         : null,\n    \"per_page\": 20,\n    \"short\": true,\n    \"tags\": [],\n\
-        \    \"username\": null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=True&page=1\"\
-        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=20&short=True&page=1\"\
+        \    \"username\": null\n  },\n  \"pagination\": {\n    \"first\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=100&short=True&page=1\"\
+        ,\n    \"last\": \"https://src.stg.fedoraproject.org/pagure/api/0/projects?owner=jcline&per_page=100&short=True&page=1\"\
         ,\n    \"next\": null,\n    \"page\": 1,\n    \"pages\": 1,\n    \"per_page\"\
         : 20,\n    \"prev\": null\n  },\n  \"projects\": [\n    {\n      \"description\"\
         : \"The erlang-cache_tab rpms\",\n      \"fullname\": \"rpms/erlang-cache_tab\"\

--- a/fmn/tests/rules/test_utils.py
+++ b/fmn/tests/rules/test_utils.py
@@ -135,15 +135,17 @@ class GetPkgdb2PackagesForTests(Base):
             self.config, 'jcline', ['point of contact', 'watch', 'co-maintained'])
         self.assertEqual(self.expected_all, packages)
 
-    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ConnectTimeout))
-    def test_connect_failure(self):
+    @mock.patch('fmn.rules.utils.requests_session')
+    def test_connect_failure(self, mock_session):
+        mock_session.get.side_effect = ConnectTimeout
         """Assert a bad response results in an empty result."""
         packages = utils._get_packages_for(self.config, 'jcline', ['co-maintained'])
         self.assertEqual(set(), packages)
 
-    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ReadTimeout))
-    def test_read_failure(self):
+    @mock.patch('fmn.rules.utils.requests_session')
+    def test_read_failure(self, mock_session):
         """Assert a bad response results in an empty result."""
+        mock_session.get.side_effect = ReadTimeout
         packages = utils._get_packages_for(self.config, 'jcline', ['co-maintained'])
         self.assertEqual(set(), packages)
 
@@ -206,14 +208,16 @@ class GetPkgdb2PackagersForTests(Base):
         packagers = utils._get_packagers_for(self.config, 'ejabberd')
         self.assertTrue(expected_packagers.issubset(packagers))
 
-    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ReadTimeout))
-    def test_read_timeout(self):
+    @mock.patch('fmn.rules.utils.requests_session')
+    def test_read_timeout(self, mock_session):
+        mock_session.get.side_effect = ReadTimeout
         packagers = utils._get_packagers_for(self.config, 'rpms/ejabberd')
 
         self.assertEqual(set(), packagers)
 
-    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ConnectTimeout))
-    def test_connect_timeout(self):
+    @mock.patch('fmn.rules.utils.requests_session')
+    def test_connect_timeout(self, mock_session):
+        mock_session.get.side_effect = ConnectTimeout
         packagers = utils._get_packagers_for(self.config, 'rpms/ejabberd')
 
         self.assertEqual(set(), packagers)
@@ -323,15 +327,17 @@ class GetPagurePackagesForTests(Base):
             self.config, 'thisisnotausername123', ['co-maintained'])
         self.assertEqual(dict(), packages)
 
-    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ConnectTimeout))
-    def test_connect_failure(self):
+    @mock.patch('fmn.rules.utils.requests_session')
+    def test_connect_failure(self, mock_session):
         """Assert a bad response results in an empty result."""
+        mock_session.get.side_effect = ConnectTimeout
         packages = utils._get_packages_for(self.config, 'jcline', ['co-maintained'])
         self.assertEqual(dict(), packages)
 
-    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ReadTimeout))
-    def test_read_failure(self):
+    @mock.patch('fmn.rules.utils.requests_session')
+    def test_read_failure(self, mock_session):
         """Assert a bad response results in an empty result."""
+        mock_session.get.side_effect = ReadTimeout
         packages = utils._get_packages_for(self.config, 'jcline', ['co-maintained'])
         self.assertEqual(dict(), packages)
 
@@ -415,14 +421,16 @@ class GetPagurePackagersForTests(Base):
 
         self.assertEqual(expected_packagers, packagers)
 
-    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ReadTimeout))
-    def test_read_timeout(self):
+    @mock.patch('fmn.rules.utils.requests_session')
+    def test_read_timeout(self, mock_session):
+        mock_session.get.side_effect = ReadTimeout
         packagers = utils._get_packagers_for(self.config, 'rpms/ejabberd')
 
         self.assertEqual(set(), packagers)
 
-    @mock.patch('fmn.rules.utils.requests.get', mock.Mock(side_effect=ConnectTimeout))
-    def test_connect_timeout(self):
+    @mock.patch('fmn.rules.utils.requests_session')
+    def test_connect_timeout(self, mock_session):
+        mock_session.get.side_effect = ConnectTimeout
         packagers = utils._get_packagers_for(self.config, 'rpms/ejabberd')
 
         self.assertEqual(set(), packagers)


### PR DESCRIPTION
On the first message, we (unfortunately) have to get the packages a user owns/co-maintains/watches for every single user in FMN. This is because there are rules like "Notify me when X happens to a package I own/co-maintain/watch" and those rules are in the default rule set (so my guess is nearly everyone has them on. This means that when processing the first message, we block for a _really_ long time while those queries happen and get cached.

This ups the items per page to 100 (the max) and uses a session so we at least reuse the connection for each page. A more global session should be used, but care needs to be taken with that.