### PR TITLE
Run using prefork with concurrency 1

### DIFF
--- a/ansible/roles/fmn-dev/files/fmn-worker@.service
+++ b/ansible/roles/fmn-dev/files/fmn-worker@.service
@@ -5,7 +5,7 @@ Documentation=https://github.com/fedora-infra/fmn/
 
 [Service]
 Type=simple
-ExecStart=/home/vagrant/.virtualenvs/fmn/bin/celery worker --pool=solo -E -A fmn -l info -n fmn-worker%i@%H
+ExecStart=/home/vagrant/.virtualenvs/fmn/bin/celery worker --pool=prefork --concurrency=1 -E -A fmn -l info -n fmn-worker%i@%H
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/fmn-worker@.service
+++ b/systemd/fmn-worker@.service
@@ -5,7 +5,7 @@ Documentation=https://github.com/fedora-infra/fmn/
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/celery worker --pool=solo -E -A fmn -l info -n fmn-worker%i@%H
+ExecStart=/usr/bin/celery worker --pool=prefork --concurrency=1 -E -A fmn -l info -n fmn-worker%i@%H
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Rather than running in solo mode, run in prefork mode with concurrency
of 1. The difference is long-running tasks (of which FMN unfortunately
has many) block the heartbeat celery uses to see if the workers are
alive. The reason we want concurrency=1 is that we use broadcasts to
tell workers to refresh their caches and if we don't do this, only one
process in the worker's pool will handle the message.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>