### PR TITLE
Ensure formatting doesn't result in an unhandled error

### DIFF
--- a/fmn/tasks.py
+++ b/fmn/tasks.py
@@ -211,12 +211,7 @@ class _FindRecipients(task.Task):
                     if context == 'email':
                         formatted_message = formatters.email(message['body'], recipient)
                     elif context == 'irc':
-                        try:
-                            formatted_message = formatters.irc(message['body'], recipient)
-                        except Exception:
-                            _log.exception('An exception occurred formatting the message '
-                                           'for delivery: falling back to sending the raw fedmsg')
-                            formatted_message = message
+                        formatted_message = formatters.irc(message['body'], recipient)
                     elif context == 'sse':
                         try:
                             formatted_message = formatters.sse(message['body'], recipient)
@@ -278,20 +273,17 @@ def batch_messages():
                 for value in pref.detail_values
             ]
             for recipient in recipients:
+                formatted_message = None
                 if pref.context.name == 'email':
                     formatted_message = formatters.email_batch(
                         [m['body'] for m in messages], recipient)
                 elif pref.context.name == 'irc':
-                    try:
-                        formatted_message = formatters.irc_batch(
-                            [m['body'] for m in messages], recipient)
-                    except Exception:
-                        _log.exception('An exception occurred formatting the message '
-                                       'for delivery: falling back to sending the raw fedmsg')
-                        formatted_message = messages
+                    formatted_message = formatters.irc_batch(
+                        [m['body'] for m in messages], recipient)
                 if formatted_message is None:
-                    raise exceptions.FmnError(
-                        'The message was not formatted in any way, aborting!')
+                        _log.error('A batch message for %r was not formatted, skipping!',
+                                   recipient)
+                        continue
 
                 backend_message = {
                     "context": pref.context.name,

--- a/fmn/tasks.py
+++ b/fmn/tasks.py
@@ -36,7 +36,7 @@ import fedmsg
 import fedmsg.meta
 import fedmsg_meta_fedora_infrastructure
 
-from . import config, lib as fmn_lib, formatters
+from . import config, lib as fmn_lib, formatters, exceptions
 from . import fmn_fasshim
 from .lib import models
 from .celery import app
@@ -207,17 +207,27 @@ class _FindRecipients(task.Task):
                         models.QueuedMessage.enqueue(session, user, context, message)
                         continue
 
-                    formatted_message = message
-                    try:
-                        if context == 'email':
-                            formatted_message = formatters.email(message['body'], recipient)
-                        elif context == 'irc':
+                    formatted_message = None
+                    if context == 'email':
+                        formatted_message = formatters.email(message['body'], recipient)
+                    elif context == 'irc':
+                        try:
                             formatted_message = formatters.irc(message['body'], recipient)
-                        elif context == 'sse':
+                        except Exception:
+                            _log.exception('An exception occurred formatting the message '
+                                           'for delivery: falling back to sending the raw fedmsg')
+                            formatted_message = message
+                    elif context == 'sse':
+                        try:
                             formatted_message = formatters.sse(message['body'], recipient)
-                    except Exception:
-                        _log.exception('An unexpected exception occurred formatting the message '
-                                       'for delivery: falling back to sending the raw fedmsg')
+                        except Exception:
+                            _log.exception('An exception occurred formatting the message '
+                                           'for delivery: falling back to sending the raw fedmsg')
+                            formatted_message = message
+
+                    if formatted_message is None:
+                        raise exceptions.FmnError(
+                            'The message was not formatted in any way, aborting!')
 
                     _log.info('Queuing message for delivery to %s on the %s backend', user, context)
                     backend_message = {
@@ -268,15 +278,20 @@ def batch_messages():
                 for value in pref.detail_values
             ]
             for recipient in recipients:
-                try:
-                    if pref.context.name == 'email':
-                        formatted_message = formatters.email_batch(messages, recipient)
-                    elif pref.context.name == 'irc':
-                        formatted_message = formatters.irc_batch(messages, recipient)
-                except Exception:
-                    _log.exception('An unexpected exception occurred formatting the message '
-                                   'for delivery: falling back to sending the raw fedmsg')
-                    formatted_message = messages
+                if pref.context.name == 'email':
+                    formatted_message = formatters.email_batch(
+                        [m['body'] for m in messages], recipient)
+                elif pref.context.name == 'irc':
+                    try:
+                        formatted_message = formatters.irc_batch(
+                            [m['body'] for m in messages], recipient)
+                    except Exception:
+                        _log.exception('An exception occurred formatting the message '
+                                       'for delivery: falling back to sending the raw fedmsg')
+                        formatted_message = messages
+                if formatted_message is None:
+                    raise exceptions.FmnError(
+                        'The message was not formatted in any way, aborting!')
 
                 backend_message = {
                     "context": pref.context.name,

--- a/fmn/tests/fixtures/fmn.tests.test_formatters.IrcTests.test_shorten
+++ b/fmn/tests/fixtures/fmn.tests.test_formatters.IrcTests.test_shorten
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://da.gd/s?url=http%3A%2F%2Fkoji.fedoraproject.org%2Fkoji%2Ftaskinfo%3FtaskID%3D16289846
+  response:
+    body: {string: !!python/unicode 'https://da.gd/TT0da
+
+        '}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      connection: [Keep-Alive]
+      content-length: ['20']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Thu, 30 Nov 2017 19:54:15 GMT']
+      expires: ['-1']
+      keep-alive: ['timeout=5, max=100']
+      server: [Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips PHP/5.4.16]
+      x-content-type-options: [nosniff]
+      x-git-commit: [4359eff]
+      x-powered-by: [PHP/5.4.16]
+      x-short-url: [TT0da]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: http://da.gd/s?url=http%3A%2F%2Flocalhost%3A5000%2Fjcline.id.fedoraproject.org%2Firc%2F7
+  response:
+    body: {string: !!python/unicode 'https://da.gd/B800F
+
+        '}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: [no-cache]
+      connection: [Keep-Alive]
+      content-length: ['20']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Thu, 30 Nov 2017 19:54:17 GMT']
+      expires: ['-1']
+      keep-alive: ['timeout=5, max=100']
+      server: [Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips PHP/5.4.16]
+      x-content-type-options: [nosniff]
+      x-git-commit: [4359eff]
+      x-powered-by: [PHP/5.4.16]
+      x-short-url: [B800F]
+    status: {code: 200, message: OK}
+version: 1

--- a/fmn/tests/test_tasks.py
+++ b/fmn/tests/test_tasks.py
@@ -240,8 +240,8 @@ class ConfirmationsTests(Base):
         self.sess.commit()
         expected_email = """Precedence: Bulk
 Auto-Submitted: auto-generated
-To: jeremy@jcline.org
 From: notifications@fedoraproject.org
+To: jeremy@jcline.org
 Subject: Confirm notification email
 
 jcline.id.fedoraproject.org has requested that notifications be sent to this email address


### PR DESCRIPTION
When we fall back to sending the raw fedmsgs, we still need the email to
have sane headers. Ideally all formatters should ensure no exception is
raised and they always return _something_ sendable. This just converts
the email formatters, however. The rest can be handled in later commits.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>