### PR TITLE
Encode the email with UTF-8

### DIFF
--- a/fmn/delivery/backends/mail.py
+++ b/fmn/delivery/backends/mail.py
@@ -66,7 +66,7 @@ class EmailBackend(BaseBackend):
                 self.host,
                 to_bytes(self.from_address),
                 [to_bytes(recipient['email address'])],
-                formatted_message,
+                formatted_message.encode('utf-8'),
                 port=self.port,
             )
             _log.info('Email successfully delivered to %s', recipient['email address'])


### PR DESCRIPTION
When formatting the email, we mark it as UTF-8. However, when it arrives
in the delivery service it is decoded to unicode until it's being sent.
This encodes it just before handing it to Twisted for delivery.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>