### PR TITLE
taskotron: remove upgradepath from critical tasks

### DIFF
--- a/fmn/rules/taskotron.py
+++ b/fmn/rules/taskotron.py
@@ -7,7 +7,6 @@ RELEASE_CRITICAL_TASKS = [
     # taskotron_release_critical_task()
     'dist.abicheck',
     'dist.rpmdeplint',
-    'dist.upgradepath',
 ]
 
 
@@ -142,7 +141,6 @@ def taskotron_release_critical_task(config, message):
 
     * ``dist.abicheck``
     * ``dist.rpmdeplint``
-    * ``dist.upgradepath``
     """
 
     # We only operate on taskotron messages, first off.


### PR DESCRIPTION
Upgradepath check has been deprecated. See
https://pagure.io/taskotron/issue/244