### PR TITLE
Lowering digest content limits

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Bug fixes
 * X-Fedmsg-Username headers should not be duplicated
   (`#281 <https://github.com/fedora-infra/fmn/pull/281>`_).
 
+* Set digest content limits to 1k messages and 500k content length
+  (`#280 <https://github.com/fedora-infra/fmn/pull/280>`_).
+
 
 v2.0.2
 ======

--- a/fmn/tests/test_formatters.py
+++ b/fmn/tests/test_formatters.py
@@ -706,3 +706,27 @@ class EmailBatchTests(Base):
 
         actual = formatters.email_batch(self.messages, self.not_verbose_recipient)
         self.assertEqual(expected, actual)
+
+    def test_too_many_messages(self):
+        """Test batch content when too many messages were queued."""
+        big_batch = self.messages * 500
+        expected = (
+            'Precedence: Bulk\n'
+            'Auto-Submitted: auto-generated\n'
+            'From: notifications@fedoraproject.org\n'
+            'To: jeremy@jcline.org\n'
+            'X-Fedmsg-Topic: org.fedoraproject.dev.fmn.filter.update\n'
+            'X-Fedmsg-Category: fmn\n'
+            'X-Fedmsg-Username: jcline\n'
+            'X-Fedmsg-Username: bowlofeggs\n'
+            'X-Fedmsg-Num-Packages: 0\n'
+            'Subject: Fedora Notifications Digest error\n'
+            'MIME-Version: 1.0\n'
+            'Content-Type: text/plain; charset="utf-8"\n'
+            'Content-Transfer-Encoding: base64\n\n'
+            'VG9vIG1hbnkgbWVzc2FnZXMgd2VyZSBxdWV1ZWQgdG8gYmUgc2VudCBpbiB0aGlzIGRpZ2VzdCAo\n'
+            'MTAwMCkhCkNvbnNpZGVyIGFkanVzdGluZyB5b3VyIEZNTiBzZXR0aW5ncy4K\n'
+        )
+
+        actual = formatters.email_batch(big_batch, self.verbose_recipient)
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
This PR lowers the maximum number of characters admitted in the digest content from 2M to 500k and fixes a missing unicode declaration to the line where msg_ids are added to the content.

The PR also add a limit to the number of messages that can be included in a digest (1000). Now the user can set in backend a maximum number of 250 before get the digest, but it can also set that to 'disabled' and only put a temporal limit. If something goes wrong, a digest can include thousands of messages, so this limit will ensure a protection against that.
I've added a test unit to check this limit is working as expected.

p.s. I removed the second check on the digest content length because in the worst case we now have a content made by 999 msg_ids, so it's not possible that it overcomes the 500k chars limit.