### PR TITLE
Add timestamp to single message emails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Bug fixes
   (`#280 <https://github.com/fedora-infra/fmn/pull/280>`_).
 
 * Add timestamp in single message emails
-  (`#284 <https://github.com/fedora-infra/fmn/pull/284>`_).
+  (`#284 <https://github.com/fedora-infra/fmn/pull/287>`_).
 
 
 v2.0.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Bug fixes
 * Set digest content limits to 1k messages and 500k content length
   (`#280 <https://github.com/fedora-infra/fmn/pull/280>`_).
 
+* Add timestamp in single message emails
+  (`#284 <https://github.com/fedora-infra/fmn/pull/284>`_).
+
 
 v2.0.2
 ======

--- a/fmn/formatters.py
+++ b/fmn/formatters.py
@@ -399,8 +399,9 @@ def email(message, recipient):
             subject_prefix.strip(), subject.strip())
     email_message.add_header('Subject', subject.encode('utf-8'))
 
-    timestamp = datetime.datetime.fromtimestamp(message['timestamp'])
-    content = timestamp.strftime('%c') + u'\n'
+    timestamp = datetime.datetime.fromtimestamp(message['timestamp'], tz=pytz.utc)
+    timestamp = timestamp.strftime('%Y-%m-%d %H:%M:%S %Z')
+    content = u'Notification time stamped {}\n\n'.format(timestamp)
     try:
         content += fedmsg.meta.msg2long_form(message, **config.app_conf) or u''
     except Exception:
@@ -475,10 +476,10 @@ def email_batch(messages, recipient):
                 _log.exception('fedmsg.meta.msg2link failed to handle %r', message)
                 link = u'No link could be found in the message'
 
-            timestamp = datetime.datetime.fromtimestamp(message['timestamp'])
+            timestamp = datetime.datetime.fromtimestamp(message['timestamp'], tz=pytz.utc)
             summary.append(summary_template.format(number=message_number, short_title=shortform))
             formatted_messages.append(message_template.format(
-                ts=timestamp.strftime('%c'), short_title=shortform,
+                ts=timestamp.strftime('%Y-%m-%d %H:%M:%S %Z'), short_title=shortform,
                 link=link,
                 details=longform))
 
@@ -498,9 +499,9 @@ def email_batch(messages, recipient):
                 _log.exception('fedmsg.meta.msg2link failed to handle %r', message)
                 link = u'No link could be found in the message'
 
-            timestamp = datetime.datetime.fromtimestamp(message['timestamp'])
+            timestamp = datetime.datetime.fromtimestamp(message['timestamp'], tz=pytz.utc)
             formatted_messages.append(message_template.format(
-                ts=timestamp.strftime('%c'), short_title=shortform,
+                ts=timestamp.strftime('%Y-%m-%d %H:%M:%S %Z'), short_title=shortform,
                 link=link))
 
         digest_content = separator.join(formatted_messages)

--- a/fmn/formatters.py
+++ b/fmn/formatters.py
@@ -399,11 +399,13 @@ def email(message, recipient):
             subject_prefix.strip(), subject.strip())
     email_message.add_header('Subject', subject.encode('utf-8'))
 
+    timestamp = datetime.datetime.fromtimestamp(message['timestamp'])
+    content = timestamp.strftime('%c') + u'\n'
     try:
-        content = fedmsg.meta.msg2long_form(message, **config.app_conf) or u''
+        content += fedmsg.meta.msg2long_form(message, **config.app_conf) or u''
     except Exception:
         _log.exception('fedmsg.meta.msg2long_form failed to handle %r', message)
-        content = json.dumps(message, sort_keys=True, indent=4)
+        content += json.dumps(message, sort_keys=True, indent=4)
 
     try:
         link = fedmsg.meta.msg2link(message, **config.app_conf)

--- a/fmn/tests/test_formatters.py
+++ b/fmn/tests/test_formatters.py
@@ -372,9 +372,9 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
-            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
-            'b25zLw==\n'
+            'Tm90aWZpY2F0aW9uIHRpbWUgc3RhbXBlZCAyMDE3LTEwLTA2IDE3OjI1OjMwIFVUQwoKamNsaW5l\n'
+            'IHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9hcHBzLmZl\n'
+            'ZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -396,9 +396,9 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
-            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
-            'b25zLw==\n'
+            'Tm90aWZpY2F0aW9uIHRpbWUgc3RhbXBlZCAyMDE3LTEwLTA2IDE3OjI1OjMwIFVUQwoKamNsaW5l\n'
+            'IHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9hcHBzLmZl\n'
+            'ZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -417,7 +417,7 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3Cg==\n'
+            'Tm90aWZpY2F0aW9uIHRpbWUgc3RhbXBlZCAyMDE3LTEwLTA2IDE3OjI1OjMwIFVUQwoK\n'
         )
         self.message['topic'] = 'so.short'
 
@@ -440,9 +440,9 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
-            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
-            'b25zLw==\n'
+            'Tm90aWZpY2F0aW9uIHRpbWUgc3RhbXBlZCAyMDE3LTEwLTA2IDE3OjI1OjMwIFVUQwoKamNsaW5l\n'
+            'IHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9hcHBzLmZl\n'
+            'ZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -463,9 +463,9 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
-            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
-            'b25zLw==\n'
+            'Tm90aWZpY2F0aW9uIHRpbWUgc3RhbXBlZCAyMDE3LTEwLTA2IDE3OjI1OjMwIFVUQwoKamNsaW5l\n'
+            'IHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9hcHBzLmZl\n'
+            'ZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -488,9 +488,9 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
-            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
-            'b25zLw==\n'
+            'Tm90aWZpY2F0aW9uIHRpbWUgc3RhbXBlZCAyMDE3LTEwLTA2IDE3OjI1OjMwIFVUQwoKamNsaW5l\n'
+            'IHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9hcHBzLmZl\n'
+            'ZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -512,9 +512,9 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
-            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
-            'b25zLw==\n'
+            'Tm90aWZpY2F0aW9uIHRpbWUgc3RhbXBlZCAyMDE3LTEwLTA2IDE3OjI1OjMwIFVUQwoKamNsaW5l\n'
+            'IHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9hcHBzLmZl\n'
+            'ZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -536,13 +536,14 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CnsKICAgICJtc2ciOiB7CiAgICAgICAgImNoYW5nZWQi\n'
-            'OiAicnVsZXMiLCAKICAgICAgICAiY29udGV4dCI6ICJlbWFpbCIsIAogICAgICAgICJvcGVuaWQi\n'
-            'OiAiamNsaW5lLmlkLmZlZG9yYXByb2plY3Qub3JnIgogICAgfSwgCiAgICAibXNnX2lkIjogIjIw\n'
-            'MTctNmFhNzFkNWItZmJlNC00OWU3LWFmZGQtYWZjZjBkMjI4MDJiIiwgCiAgICAidGltZXN0YW1w\n'
-            'IjogMTUwNzMxMDczMCwgCiAgICAidG9waWMiOiAib3JnLmZlZG9yYXByb2plY3QuZGV2LmZtbi5m\n'
-            'aWx0ZXIudXBkYXRlIiwgCiAgICAidXNlcm5hbWUiOiAidmFncmFudCIKfQoJaHR0cHM6Ly9hcHBz\n'
-            'LmZlZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n'
+            'Tm90aWZpY2F0aW9uIHRpbWUgc3RhbXBlZCAyMDE3LTEwLTA2IDE3OjI1OjMwIFVUQwoKewogICAg\n'
+            'Im1zZyI6IHsKICAgICAgICAiY2hhbmdlZCI6ICJydWxlcyIsIAogICAgICAgICJjb250ZXh0Ijog\n'
+            'ImVtYWlsIiwgCiAgICAgICAgIm9wZW5pZCI6ICJqY2xpbmUuaWQuZmVkb3JhcHJvamVjdC5vcmci\n'
+            'CiAgICB9LCAKICAgICJtc2dfaWQiOiAiMjAxNy02YWE3MWQ1Yi1mYmU0LTQ5ZTctYWZkZC1hZmNm\n'
+            'MGQyMjgwMmIiLCAKICAgICJ0aW1lc3RhbXAiOiAxNTA3MzEwNzMwLCAKICAgICJ0b3BpYyI6ICJv\n'
+            'cmcuZmVkb3JhcHJvamVjdC5kZXYuZm1uLmZpbHRlci51cGRhdGUiLCAKICAgICJ1c2VybmFtZSI6\n'
+            'ICJ2YWdyYW50Igp9CglodHRwczovL2FwcHMuZmVkb3JhcHJvamVjdC5vcmcvbm90aWZpY2F0aW9u\n'
+            'cy8=\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -564,8 +565,8 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
-            'biBlbWFpbCBmaWx0ZXI=\n'
+            'Tm90aWZpY2F0aW9uIHRpbWUgc3RhbXBlZCAyMDE3LTEwLTA2IDE3OjI1OjMwIFVUQwoKamNsaW5l\n'
+            'IHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcg==\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -586,11 +587,11 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
-            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
-            'b25zLwoKLS0KWW91IHJlY2VpdmVkIHRoaXMgbWVzc2FnZSBkdWUgdG8geW91ciBwcmVmZXJlbmNl\n'
-            'IHNldHRpbmdzIGF0IApodHRwOi8vbG9jYWxob3N0OjUwMDAvamNsaW5lLmlkLmZlZG9yYXByb2pl\n'
-            'Y3Qub3JnL2VtYWlsLzEx\n'
+            'Tm90aWZpY2F0aW9uIHRpbWUgc3RhbXBlZCAyMDE3LTEwLTA2IDE3OjI1OjMwIFVUQwoKamNsaW5l\n'
+            'IHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9hcHBzLmZl\n'
+            'ZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMvCgotLQpZb3UgcmVjZWl2ZWQgdGhpcyBtZXNz\n'
+            'YWdlIGR1ZSB0byB5b3VyIHByZWZlcmVuY2Ugc2V0dGluZ3MgYXQgCmh0dHA6Ly9sb2NhbGhvc3Q6\n'
+            'NTAwMC9qY2xpbmUuaWQuZmVkb3JhcHJvamVjdC5vcmcvZW1haWwvMTE=\n'
         )
         self.recipient['triggered_by_links'] = True
 
@@ -697,15 +698,15 @@ class EmailBatchTests(Base):
             'RGlnZXN0IFN1bW1hcnk6CjEuCWpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZtbiBlbWFp\n'
             'bCBmaWx0ZXIKMi4JYm93bG9mZWdncyB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZtbiBlbWFpbCBm\n'
             'aWx0ZXIKCi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0t\n'
-            'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0KCihGcmkgT2N0ICA2IDE3OjI1OjMwIDIwMTcp\n'
-            'IGpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZtbiBlbWFpbCBmaWx0ZXIKLSBodHRwczov\n'
-            'L2FwcHMuZmVkb3JhcHJvamVjdC5vcmcvbm90aWZpY2F0aW9ucy8KCmpjbGluZSB1cGRhdGVkIHRo\n'
-            'ZSBydWxlcyBvbiBhIGZtbiBlbWFpbCBmaWx0ZXIKCi0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0t\n'
-            'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0KCihG\n'
-            'cmkgT2N0ICA2IDE3OjI1OjMwIDIwMTcpIGJvd2xvZmVnZ3MgdXBkYXRlZCB0aGUgcnVsZXMgb24g\n'
-            'YSBmbW4gZW1haWwgZmlsdGVyCi0gaHR0cHM6Ly9hcHBzLmZlZG9yYXByb2plY3Qub3JnL25vdGlm\n'
-            'aWNhdGlvbnMvCgpib3dsb2ZlZ2dzIHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZp\n'
-            'bHRlcg==\n'
+            'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0KCigyMDE3LTEwLTA2IDE3OjI1OjMwIFVUQykg\n'
+            'amNsaW5lIHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgotIGh0dHBzOi8v\n'
+            'YXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRpb25zLwoKamNsaW5lIHVwZGF0ZWQgdGhl\n'
+            'IHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoKLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0t\n'
+            'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQoKKDIw\n'
+            'MTctMTAtMDYgMTc6MjU6MzAgVVRDKSBib3dsb2ZlZ2dzIHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEg\n'
+            'Zm1uIGVtYWlsIGZpbHRlcgotIGh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmlj\n'
+            'YXRpb25zLwoKYm93bG9mZWdncyB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZtbiBlbWFpbCBmaWx0\n'
+            'ZXI=\n'
         )
 
         actual = formatters.email_batch(self.messages, self.verbose_recipient)
@@ -727,12 +728,12 @@ class EmailBatchTests(Base):
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'KEZyaSBPY3QgIDYgMTc6MjU6MzAgMjAxNykgamNsaW5lIHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEg\n'
-            'Zm1uIGVtYWlsIGZpbHRlcgotIGh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmlj\n'
-            'YXRpb25zLwoKLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0t\n'
-            'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQoKKEZyaSBPY3QgIDYgMTc6MjU6MzAgMjAx\n'
-            'NykgYm93bG9mZWdncyB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZtbiBlbWFpbCBmaWx0ZXIKLSBo\n'
-            'dHRwczovL2FwcHMuZmVkb3JhcHJvamVjdC5vcmcvbm90aWZpY2F0aW9ucy8=\n'
+            'KDIwMTctMTAtMDYgMTc6MjU6MzAgVVRDKSBqY2xpbmUgdXBkYXRlZCB0aGUgcnVsZXMgb24gYSBm\n'
+            'bW4gZW1haWwgZmlsdGVyCi0gaHR0cHM6Ly9hcHBzLmZlZG9yYXByb2plY3Qub3JnL25vdGlmaWNh\n'
+            'dGlvbnMvCgotLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0t\n'
+            'LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tCgooMjAxNy0xMC0wNiAxNzoyNTozMCBVVEMp\n'
+            'IGJvd2xvZmVnZ3MgdXBkYXRlZCB0aGUgcnVsZXMgb24gYSBmbW4gZW1haWwgZmlsdGVyCi0gaHR0\n'
+            'cHM6Ly9hcHBzLmZlZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n'
         )
 
         actual = formatters.email_batch(self.messages, self.not_verbose_recipient)

--- a/fmn/tests/test_formatters.py
+++ b/fmn/tests/test_formatters.py
@@ -372,8 +372,9 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            "amNsaW5lIHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9h\n"
-            "cHBzLmZlZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n"
+            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
+            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
+            'b25zLw==\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -395,8 +396,9 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            "amNsaW5lIHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9h\n"
-            "cHBzLmZlZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n"
+            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
+            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
+            'b25zLw==\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -415,6 +417,7 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
+            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3Cg==\n'
         )
         self.message['topic'] = 'so.short'
 
@@ -437,8 +440,9 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            "amNsaW5lIHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9h\n"
-            "cHBzLmZlZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n"
+            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
+            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
+            'b25zLw==\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -459,8 +463,9 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            "amNsaW5lIHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9h\n"
-            "cHBzLmZlZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n"
+            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
+            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
+            'b25zLw==\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -483,8 +488,9 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            "amNsaW5lIHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9h\n"
-            "cHBzLmZlZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n"
+            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
+            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
+            'b25zLw==\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -506,8 +512,9 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            "amNsaW5lIHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9h\n"
-            "cHBzLmZlZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n"
+            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
+            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
+            'b25zLw==\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -529,13 +536,13 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'ewogICAgIm1zZyI6IHsKICAgICAgICAiY2hhbmdlZCI6ICJydWxlcyIsIAogICAgICAgICJjb250\n'
-            'ZXh0IjogImVtYWlsIiwgCiAgICAgICAgIm9wZW5pZCI6ICJqY2xpbmUuaWQuZmVkb3JhcHJvamVj\n'
-            'dC5vcmciCiAgICB9LCAKICAgICJtc2dfaWQiOiAiMjAxNy02YWE3MWQ1Yi1mYmU0LTQ5ZTctYWZk\n'
-            'ZC1hZmNmMGQyMjgwMmIiLCAKICAgICJ0aW1lc3RhbXAiOiAxNTA3MzEwNzMwLCAKICAgICJ0b3Bp\n'
-            'YyI6ICJvcmcuZmVkb3JhcHJvamVjdC5kZXYuZm1uLmZpbHRlci51cGRhdGUiLCAKICAgICJ1c2Vy\n'
-            'bmFtZSI6ICJ2YWdyYW50Igp9CglodHRwczovL2FwcHMuZmVkb3JhcHJvamVjdC5vcmcvbm90aWZp\n'
-            'Y2F0aW9ucy8=\n'
+            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CnsKICAgICJtc2ciOiB7CiAgICAgICAgImNoYW5nZWQi\n'
+            'OiAicnVsZXMiLCAKICAgICAgICAiY29udGV4dCI6ICJlbWFpbCIsIAogICAgICAgICJvcGVuaWQi\n'
+            'OiAiamNsaW5lLmlkLmZlZG9yYXByb2plY3Qub3JnIgogICAgfSwgCiAgICAibXNnX2lkIjogIjIw\n'
+            'MTctNmFhNzFkNWItZmJlNC00OWU3LWFmZGQtYWZjZjBkMjI4MDJiIiwgCiAgICAidGltZXN0YW1w\n'
+            'IjogMTUwNzMxMDczMCwgCiAgICAidG9waWMiOiAib3JnLmZlZG9yYXByb2plY3QuZGV2LmZtbi5m\n'
+            'aWx0ZXIudXBkYXRlIiwgCiAgICAidXNlcm5hbWUiOiAidmFncmFudCIKfQoJaHR0cHM6Ly9hcHBz\n'
+            'LmZlZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMv\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -557,7 +564,8 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'amNsaW5lIHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcg==\n'
+            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
+            'biBlbWFpbCBmaWx0ZXI=\n'
         )
 
         actual = formatters.email(self.message, self.recipient)
@@ -578,10 +586,11 @@ email notifications@fedoraproject.org if you have any concerns/issues/abuse."""
             'MIME-Version: 1.0\n'
             'Content-Type: text/plain; charset="utf-8"\n'
             'Content-Transfer-Encoding: base64\n\n'
-            'amNsaW5lIHVwZGF0ZWQgdGhlIHJ1bGVzIG9uIGEgZm1uIGVtYWlsIGZpbHRlcgoJaHR0cHM6Ly9h\n'
-            'cHBzLmZlZG9yYXByb2plY3Qub3JnL25vdGlmaWNhdGlvbnMvCgotLQpZb3UgcmVjZWl2ZWQgdGhp\n'
-            'cyBtZXNzYWdlIGR1ZSB0byB5b3VyIHByZWZlcmVuY2Ugc2V0dGluZ3MgYXQgCmh0dHA6Ly9sb2Nh\n'
-            'bGhvc3Q6NTAwMC9qY2xpbmUuaWQuZmVkb3JhcHJvamVjdC5vcmcvZW1haWwvMTE=\n'
+            'RnJpIE9jdCAgNiAxNzoyNTozMCAyMDE3CmpjbGluZSB1cGRhdGVkIHRoZSBydWxlcyBvbiBhIGZt\n'
+            'biBlbWFpbCBmaWx0ZXIKCWh0dHBzOi8vYXBwcy5mZWRvcmFwcm9qZWN0Lm9yZy9ub3RpZmljYXRp\n'
+            'b25zLwoKLS0KWW91IHJlY2VpdmVkIHRoaXMgbWVzc2FnZSBkdWUgdG8geW91ciBwcmVmZXJlbmNl\n'
+            'IHNldHRpbmdzIGF0IApodHRwOi8vbG9jYWxob3N0OjUwMDAvamNsaW5lLmlkLmZlZG9yYXByb2pl\n'
+            'Y3Qub3JnL2VtYWlsLzEx\n'
         )
         self.recipient['triggered_by_links'] = True
 


### PR DESCRIPTION
Fixes #285 
This will add a timestamp as starting line for every single message email.
The other content (message or dump) remains unchanged.