### PR TITLE
Change pkgdb_package_new to git_repo_new rule

### DIFF
--- a/alembic/versions/c369fd8ee75c_replace_pkgdb_package_with_git_repo_new.py
+++ b/alembic/versions/c369fd8ee75c_replace_pkgdb_package_with_git_repo_new.py
@@ -1,0 +1,41 @@
+"""
+Since pkgdb was retired, the pkgdb.package.new message was replaced with
+pagure.project.new. Update the rules accordingly.
+
+Revision ID: c369fd8ee75c
+Revises: 9987c7c958c7
+Create Date: 2018-03-28 15:08:24.848222
+"""
+from alembic import op
+
+revision = 'c369fd8ee75c'
+down_revision = '9987c7c958c7'
+
+# Key is the old rule, value is the new rule
+rule_changes = {
+    'fmn.rules:pkgdb_package_new': 'fmn.rules:git_repo_new',
+}
+
+
+def upgrade():
+    """Update rule paths that have changed due to pkgdb retirement."""
+    for old, new in rule_changes.items():
+        sql_statement = """
+            UPDATE rules
+            SET code_path="{new}"
+            WHERE code_path="{old}"
+        """.format(old=old, new=new)
+
+        op.execute(sql_statement)
+
+
+def downgrade():
+    """Undo update to rule paths that have changed due to pkgdb retirement."""
+    for old, new in rule_changes.items():
+        sql_statement = """
+            UPDATE rules
+            SET code_path="{old}"
+            WHERE code_path="{new}"
+        """.format(old=old, new=new)
+
+        op.execute(sql_statement)

--- a/fmn/rules/git.py
+++ b/fmn/rules/git.py
@@ -1,3 +1,4 @@
+"""Notification rules relating to dist-git."""
 from fmn.lib.hinting import hint, prefixed as _
 
 
@@ -99,3 +100,14 @@ def git_receive(config, message):
     ``fedpkg push`` on a package.
     """
     return message['topic'] == _('git.receive')
+
+
+@hint(topics=[_('pagure.project.new', prefix='org.fedoraproject')])
+def git_repo_new(config, message):
+    """
+    New repository in dist-git (https://src.fedoraproject.org).
+
+    This rule triggers when a new dist-git repository is added. This occurs once
+    a package has been reviewed and the SCM request has been approved.
+    """
+    return message['topic'] == _('pagure.project.new', prefix='org.fedoraproject')

--- a/fmn/tests/rules/test_git.py
+++ b/fmn/tests/rules/test_git.py
@@ -1,0 +1,16 @@
+import unittest
+
+from fmn.rules import git
+
+
+class GitRepoNewTests(unittest.TestCase):
+
+    def test_match(self):
+        message = {'topic': 'org.fedoraproject.dev.pagure.project.new'}
+
+        self.assertTrue(git.git_repo_new({}, message))
+
+    def test_not_match(self):
+        message = {'topic': 'org.fedoraproject.dev.pagure.project.old'}
+
+        self.assertFalse(git.git_repo_new({}, message))


### PR DESCRIPTION
When pkgdb got retired, a whole bunch of messages stopped being emitted. Among
them was the message for when a new dist-git repo gets created, so
migrate users of the rule over to the new rule which matches against the
new topic.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>