### PR TITLE
Use single quotes in SQL for the git.repo.new migration

### DIFF
--- a/alembic/versions/c369fd8ee75c_replace_pkgdb_package_with_git_repo_new.py
+++ b/alembic/versions/c369fd8ee75c_replace_pkgdb_package_with_git_repo_new.py
@@ -22,8 +22,8 @@ def upgrade():
     for old, new in rule_changes.items():
         sql_statement = """
             UPDATE rules
-            SET code_path="{new}"
-            WHERE code_path="{old}"
+            SET code_path='{new}'
+            WHERE code_path='{old}'
         """.format(old=old, new=new)
 
         op.execute(sql_statement)
@@ -34,8 +34,8 @@ def downgrade():
     for old, new in rule_changes.items():
         sql_statement = """
             UPDATE rules
-            SET code_path="{old}"
-            WHERE code_path="{new}"
+            SET code_path='{old}'
+            WHERE code_path='{new}'
         """.format(old=old, new=new)
 
         op.execute(sql_statement)


### PR DESCRIPTION
Single quotes and double quotes are not interchangeable, it seems. It
also seems that SQLite is fine with double quotes, but Postgres is
*not*.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>  