### PR TITLE
Don’t suggest to clone fmn.web and fmn.sse repositories

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -5,16 +5,6 @@ FedMSG Notifications Development Guide
 FedMSG Notifications welcomes contributions! Our issue tracker is located on
 `GitHub <https://github.com/fedora-infra/fmn/issues>`_.
 
-This repository contains the FMN library. The follow repositories contain
-packages that interact with FMN:
-
-- `fmn.web <https://github.com/fedora-infra/fmn.web>`_
-- `fmn.sse <https://github.com/fedora-infra/fmn.sse>`_
-
-It is recommended that you check out all these repositories inside the
-`fmn <https://github.com/fedora-infra/fmn/>`_ repository that contains the
-Vagrantfile.
-
 
 Contribution Guidelines
 -----------------------


### PR DESCRIPTION
The READMEs for each of these repositories says:

> This repository is kept for historical purposes only. It was merged into the fmn repository and you should look there if you would like to contribute or report an issue!