### PR TITLE
add ability to interact with fasjson

### DIFF
--- a/fmn/config.py
+++ b/fmn/config.py
@@ -444,6 +444,13 @@ class _FmnConfig(dict):
             'default': {'username': None, 'password': None},
             'validator': dict,
         },
+        'fasjson': {
+            'default': {
+                'active': False,
+                'url': None
+            },
+            'validator': dict,
+        },
         'fmn.web.default_login': {
             'default': 'login',
             'validator': None,

--- a/fmn/consumer.py
+++ b/fmn/consumer.py
@@ -25,6 +25,7 @@ from .util import (
     new_packager,
     new_badges_user,
     get_fas_email,
+    get_fasjson_email
 )
 from fmn.tasks import find_recipients, REFRESH_CACHE_TOPIC, heat_fas_cache
 
@@ -163,7 +164,11 @@ class FMNConsumer(fedmsg.consumers.FedmsgConsumer):
                 log.info("Autocreating account for %r" % username)
                 openid = '%s.id.fedoraproject.org' % username
                 openid_url = 'https://%s.id.fedoraproject.org' % username
-                email = get_fas_email(config.app_conf, username)
+                fasjson = config.app_conf['fasjson'].get('active')
+                if fasjson:
+                    email = get_fasjson_email(config.app_conf, username)
+                else:
+                    email = get_fas_email(config.app_conf, username)
                 user = fmn.lib.models.User.get_or_create(
                     session, openid=openid, openid_url=openid_url,
                     create_defaults=True, detail_values=dict(email=email),

--- a/fmn/consumer.py
+++ b/fmn/consumer.py
@@ -164,7 +164,7 @@ class FMNConsumer(fedmsg.consumers.FedmsgConsumer):
                 log.info("Autocreating account for %r" % username)
                 openid = '%s.id.fedoraproject.org' % username
                 openid_url = 'https://%s.id.fedoraproject.org' % username
-                fasjson = config.app_conf['fasjson'].get('active')
+                fasjson = config.app_conf.get("fasjson", {}).get("active")
                 if fasjson:
                     email = get_fasjson_email(config.app_conf, username)
                 else:

--- a/fmn/fasjson_client.py
+++ b/fmn/fasjson_client.py
@@ -1,0 +1,55 @@
+import requests
+import requests.exceptions
+from requests.compat import urlencode, urljoin
+from requests_gssapi import HTTPSPNEGOAuth
+
+
+class Client(object):
+    """
+    A fasjson client to make very specific requests to fasjson.
+    Necessary because the official fasjson-client library does not support
+    python3.
+    """
+    def __init__(self, url, principal=None):
+        self.url = url
+        self.principal = principal
+
+        gssapi_auth = HTTPSPNEGOAuth(
+            opportunistic_auth=True, mutual_authentication="OPTIONAL"
+        )
+        self.session = requests.Session()
+        self.session.auth = gssapi_auth
+
+    def search(self, email):
+        """
+        A very limited search built to only serve fmn's requirement of
+        finding a user based on an email.
+        """
+        # email must be an exact match in fasjson, so we will either have
+        # 1 result or empty result
+        search_string = "search/users" + "?" + urlencode({"email": email})
+        endpoint = urljoin(self.url, search_string)
+
+        return self.session.get(endpoint)
+
+    def get_user(self, username):
+        """
+        Get a specific user based on their username
+        """
+        url_string = "users/" + username + "/"
+        endpoint = urljoin(self.url, url_string)
+
+        return self.session.get(endpoint)
+
+    def list_all_entities(self, ent_name):
+        """
+        Return all entities of a certain type. In fmn's case it is users.
+        """
+        endpoint = urljoin(self.url, ent_name + "/")
+
+        next_page_url = endpoint + "?" + urlencode({"page_number": 1})
+        while next_page_url:
+            res = self.session.get(next_page_url)
+            for item in res["result"]:
+                yield item
+            next_page_url = res.get("page", {}).get("next_page")

--- a/fmn/fmn_fasshim.py
+++ b/fmn/fmn_fasshim.py
@@ -9,10 +9,10 @@ import fedmsg
 import fedmsg.meta
 import fedora.client
 import fedora.client.fas2
-from fasjson_client import Client
 from dogpile.cache import make_region
 
 from fmn import config
+from .fasjson_client import Client
 
 fedmsg.meta.make_processors(**config.app_conf)
 
@@ -108,7 +108,7 @@ def update_nick(username):
         try:
             log.info("Downloading FASJSON cache for %s*" % username)
             response = client.get_user(username=username)
-            _add_to_cache([response.json().result])
+            _add_to_cache([response["result"]])
         except requests.exceptions.RequestException as e:
             log.error("Something went wrong updating the cache with error: %s" % e)
     else:
@@ -145,7 +145,7 @@ def update_email(email):
         try:
             log.info("Downloading FASJSON cache for %s*" % email)
             response = client.search(email=email)
-            _add_to_cache(response.json()['result'])
+            _add_to_cache(response['result'])
         except requests.exceptions.RequestException as e:
             log.error("Something went wrong updating the cache with error: %s" % e)
     else:

--- a/fmn/fmn_fasshim.py
+++ b/fmn/fmn_fasshim.py
@@ -8,6 +8,7 @@ import fedmsg
 import fedmsg.meta
 import fedora.client
 import fedora.client.fas2
+import fasjson_client
 from dogpile.cache import make_region
 
 from fmn import config
@@ -23,27 +24,45 @@ log = logging.getLogger("moksha.hub")
 default_url = 'https://admin.fedoraproject.org/accounts/'
 creds = config.app_conf['fas_credentials']
 
-fasclient = fedora.client.fas2.AccountSystem(
-    base_url=creds.get('base_url', default_url),
-    username=creds['username'],
-    password=creds['password'],
-)
+fasjson = config.app_conf['fasjson']
+if fasjson.get('active'):
+    client = fasjson_client.Client(url=fasjson.get('url', default_url))
+else:
+    client = fedora.client.fas2.AccountSystem(
+        base_url=creds.get('base_url', default_url),
+        username=creds['username'],
+        password=creds['password'],
+    )
+
+
+def make_fasjson_cache(**config):
+    log.warning("Building the FASJSON cache into redis.")
+    if _cache.get('fas_cache_built'):
+        log.warning("FASJSON cache already built into redis.")
+        return
+    global client
+    try:
+        _add_to_cache(list(client.list_all_entities("users")))
+    except fasjson_client.errors.APIError as e:
+        log.error("Something went wrong building cache with error: %s" % e)
+        return
+
+    _cache.set('fas_cache_built', True)
 
 
 def make_fas_cache(**config):
-    log.warn("Building the FAS cache into redis.")
+    log.warning("Building the FAS cache into redis.")
     if _cache.get('fas_cache_built'):
-        log.warn("FAS cache already built into redis.")
+        log.warning("FAS cache already built into redis.")
         return
 
-    global fasclient
+    global client
     timeout = socket.getdefaulttimeout()
     for key in string.ascii_lowercase:
         socket.setdefaulttimeout(600)
         try:
             log.info("Downloading FAS cache for %s*" % key)
-            print(key)
-            request = fasclient.send_request(
+            request = client.send_request(
                 '/user/list',
                 req_params={
                     'search': '%s*' % key,
@@ -71,65 +90,92 @@ def make_fas_cache(**config):
     _cache.set('fas_cache_built', True)
 
 
-def update_nick(username):
-    global fasclient
-    try:
-        log.info("Downloading FAS cache for %s*" % username)
-        request = fasclient.send_request(
-            '/user/list',
-            req_params={'search': '%s' % username},
-            auth=True)
-    except fedora.client.ServerError as e:
-        log.warning(
-            "Failed to download fas cache for %s: %r" % (username, e))
-        return {}
-
-    log.info("Caching necessary data for %s" % username)
-    for user in request['people']:
-        nick = user['ircnick']
-        if nick:
+def _add_to_cache(users):
+    for user in users:
+        nicks = user.get('ircnicks', [])
+        for nick in nicks:
             _cache.set(nick, user['username'])
 
-        email = user['email']
-        if email:
+        emails = user.get('emails', [])
+        for email in emails:
             _cache.set(email, user['username'])
+
+
+def update_nick(username):
+    global client
+    if config.get('fasjson'):
+        try:
+            log.info("Downloading FASJSON cache for %s*" % username)
+            response = client.get_user(username=username)
+            _add_to_cache([response.result])
+        except fasjson_client.errors.APIError as e:
+            log.error("Something went wrong updating the cache with error: %s" % e)
     else:
-        # If we couldn't find the nick in FAS, save it in the _cache as nick
-        # so that we avoid calling FAS for every single filter we have to
-        # run through
-        _cache.set(username, username)
+        try:
+            log.info("Downloading FAS cache for %s*" % username)
+            request = client.send_request(
+                '/user/list',
+                req_params={'search': '%s' % username},
+                auth=True)
+        except fedora.client.ServerError as e:
+            log.warning(
+                "Failed to download fas cache for %s: %r" % (username, e))
+            return {}
+
+        log.info("Caching necessary data for %s" % username)
+        for user in request['people']:
+            nick = user['ircnick']
+            if nick:
+                _cache.set(nick, user['username'])
+
+            email = user['email']
+            if email:
+                _cache.set(email, user['username'])
+        else:
+            # If we couldn't find the nick in FAS, save it in the _cache as nick
+            # so that we avoid calling FAS for every single filter we have to
+            # run through
+            _cache.set(username, username)
 
 
 def update_email(email):
-    global fasclient
-    try:
-        log.info("Downloading FAS cache for %s" % email)
-        request = fasclient.send_request(
-            '/user/list',
-            req_params={
-                'search': '%s' % email,
-                'by_email': 1,
-            },
-            auth=True)
-    except fedora.client.ServerError as e:
-        log.warning(
-            "Failed to download fas cache for %s: %r" % (email, e))
-        return {}
-
-    log.info("Caching necessary data for %s" % email)
-    for user in request['people']:
-        nick = user['ircnick']
-        if nick:
-            _cache.set(nick, user['username'])
-
-        email = user['email']
-        if email:
-            _cache.set(email, user['username'])
+    global client
+    if config.get('fasjson'):
+        try:
+            log.info("Downloading FASJSON cache for %s*" % email)
+            response = client.search(email=email)
+            _add_to_cache(response.result)
+        except fasjson_client.errors.APIError as e:
+            log.error("Something went wrong updating the cache with error: %s" % e)
     else:
-        # If we couldn't find the email in FAS, save it in the _cache as
-        # email so that we avoid calling FAS for every single filter we
-        # have to run through
-        _cache.set(email, email)
+        try:
+            log.info("Downloading FAS cache for %s" % email)
+            request = client.send_request(
+                '/user/list',
+                req_params={
+                    'search': '%s' % email,
+                    'by_email': 1,
+                },
+                auth=True)
+        except fedora.client.ServerError as e:
+            log.warning(
+                "Failed to download fas cache for %s: %r" % (email, e))
+            return {}
+
+        log.info("Caching necessary data for %s" % email)
+        for user in request['people']:
+            nick = user['ircnick']
+            if nick:
+                _cache.set(nick, user['username'])
+
+            email = user['email']
+            if email:
+                _cache.set(email, user['username'])
+        else:
+            # If we couldn't find the email in FAS, save it in the _cache as
+            # email so that we avoid calling FAS for every single filter we
+            # have to run through
+            _cache.set(email, email)
 
 
 def nick2fas(nickname, **config):

--- a/fmn/formatters.py
+++ b/fmn/formatters.py
@@ -99,7 +99,7 @@ def shorten(link):
         response = requests.get('https://da.gd/s', params=dict(url=link), timeout=30)
         return response.text.strip()
     except Exception as e:
-        _log.warn("Link shortening failed: %r" % e)
+        _log.warning("Link shortening failed: %r" % e)
         return link
 
 

--- a/fmn/lib/defaults.py
+++ b/fmn/lib/defaults.py
@@ -225,7 +225,7 @@ def create_defaults_for(session, user, only_for=None, detail_values=None):
     detail_values = detail_values or {}
 
     if not user.openid.endswith('.fedoraproject.org'):
-        log.warn("New user not from fedoraproject.org.  No defaults set.")
+        log.warning("New user not from fedoraproject.org.  No defaults set.")
         return
 
     # the openid is of the form USERNAME.id.fedoraproject.org
@@ -249,7 +249,7 @@ def create_defaults_for(session, user, only_for=None, detail_values=None):
             if context:
                 yield context
             else:
-                log.warn("No such context %r is in the DB." % name)
+                log.warning("No such context %r is in the DB." % name)
 
     # For each context, build one little and two big filters
     for context in contexts():

--- a/fmn/rules/utils.py
+++ b/fmn/rules/utils.py
@@ -54,7 +54,7 @@ def get_fas(config):
     try:
         creds = config['fas_credentials']
     except KeyError:
-        log.warn("No fas_credentials available.  Unable to query FAS.")
+        log.warning("No fas_credentials available.  Unable to query FAS.")
         return None
 
     default_url = 'https://admin.fedoraproject.org/accounts/'
@@ -103,7 +103,7 @@ def _paginate_pagure_data(url, params):
                 next_page_url = None
 
         except requests.exceptions.Timeout as e:
-            log.warn('URL %s timed out %r', next_page_url, e)
+            log.warning('URL %s timed out %r', next_page_url, e)
             next_page_url = None
 
 
@@ -163,11 +163,11 @@ def _get_pagure_packagers_for(config, package):
     try:
         response = requests_session.get(url, params={'fork': False}, timeout=25)
     except requests.exceptions.Timeout as e:
-        log.warn('URL %s timed out %r', url, e)
+        log.warning('URL %s timed out %r', url, e)
         return set()
 
     if response.status_code != 200:
-        log.warn('URL %s returned code %s', response.url, response.status_code)
+        log.warning('URL %s returned code %s', response.url, response.status_code)
         return set()
 
     data = response.json()
@@ -201,7 +201,7 @@ def _get_pkgdb2_packagers_for(config, package):
     try:
         req = requests_session.get(url, timeout=15)
     except requests.exceptions.Timeout as e:
-        log.warn('URL %s timed out %r', url, e)
+        log.warning('URL %s timed out %r', url, e)
         return set()
 
     if not req.status_code == 200:
@@ -320,7 +320,7 @@ def _get_pkgdb2_packages_for(config, username, flags):
     try:
         req = requests_session.get(url, timeout=15)
     except requests.exceptions.Timeout as e:
-        log.warn('URL %s timed out %r', url, e)
+        log.warning('URL %s timed out %r', url, e)
         return set()
 
     if not req.status_code == 200:

--- a/fmn/tasks.py
+++ b/fmn/tasks.py
@@ -416,7 +416,10 @@ def heat_fas_cache():  # pragma: no cover
     This is helpful to do once on startup since we'll need everyone's email or
     IRC nickname eventually.
     """
-    fmn_fasshim.make_fas_cache(**config.app_conf)
+    if config.app_conf['fasjson'].get('active'):
+        fmn_fasshim.make_fasjson_cache(**config.app_conf)
+    else:
+        fmn_fasshim.make_fas_cache(**config.app_conf)
 
 
 @app.task(name='fmn.tasks.confirmations', ignore_results=True)

--- a/fmn/util.py
+++ b/fmn/util.py
@@ -1,4 +1,5 @@
 import fedora.client
+import fasjson_client
 
 import logging
 log = logging.getLogger("fmn")
@@ -35,4 +36,17 @@ def get_fas_email(config, username):
         raise ValueError("No email found: %r" % username)
     except Exception:
         log.exception("Failed to get FAS email for %r" % username)
+        return '%s@fedoraproject.org' % username
+
+
+def get_fasjson_email(config, username):
+    """ Return FASJSON email associated with a username. """
+    try:
+        fasjson = config["fasjson"]
+        client = fasjson_client.Client(url=fasjson.get('url'))
+        person = client.get_user(username=username).result
+
+        return person.get('emails')[0]
+    except Exception:
+        log.exception("Failed to get FASJSON email for %r" % username)
         return '%s@fedoraproject.org' % username

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@ celery>=4.0
 datanommer.models
 docutils
 dogpile.cache
-fasjson-client
 fedmsg[consumers, commands]
 fedmsg_meta_fedora_infrastructure>=0.18.0
 Flask
 flask-openid>=1.2.4
+gssapi
 markupsafe
 moksha.hub
 pika

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ celery>=4.0
 datanommer.models
 docutils
 dogpile.cache
+fasjson-client
 fedmsg[consumers, commands]
 fedmsg_meta_fedora_infrastructure>=0.18.0
 Flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ python-openid
 python-openid-cla
 python-openid-teams
 redis
+requests-gssapi
 urllib3
 requests
 six


### PR DESCRIPTION
This commit adds the ability to interact with the new fasjson API. It builds its cache depending on the `fasjson` config flag from either FAS or the new fasjson.

Signed-off-by: Stephen Coady <scoady@redhat.com>