### PR TITLE
Add diff-cover

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -6,3 +6,4 @@
         - tox-python38
         - tox-python39
         - simple-tox-docs
+        - tox-diff-cover

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 # Unit test requirements
+diff-cover
 flake8
 html5lib
 mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = lint,py3{7,8,9},docs
+envlist = lint,py3{7,8,9},diff-cover,docs
 skip_missing_interpreters = True
 
 [testenv]
-passenv = TRAVIS TRAVIS_*
 deps =
     -rrequirements.txt
     -rdev-requirements.txt
@@ -13,6 +12,10 @@ commands =
     rm -rf htmlcov coverage.xml
     py.test --cov-config .coveragerc --cov=fmn --cov-report term \
         --cov-report xml --cov-report html
+
+[testenv:diff-cover]
+commands =
+    diff-cover coverage.xml --compare-branch=origin/develop --fail-under=100
 
 [testenv:docs]
 basepython=python3


### PR DESCRIPTION
Because we are no longer using travis and the integration with codecov
doesn't work anymore, let's use diff-cover instead.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>