### PR TITLE
Remove links to old website

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ FedMSG Notifications
         :target: https://fmn.readthedocs.io/en/latest/
 
 ``fmn`` is a family of systems to manage end-user notifications triggered by
-`fedmsg, the FEDerated MESsage bus <http://fedmsg.com>`_. ``fmn`` provides a
+`fedmsg, the FEDerated MESsage bus <https://fedmsg.readthedocs.io/>`_. ``fmn`` provides a
 single place for all applications using ``fedmsg`` to notify users of events.
 Notifications can be delivered by email, irc, and server-sent events. Users
 can configure their notifications for all the applications they use in one

--- a/fmn/consumer.py
+++ b/fmn/consumer.py
@@ -7,7 +7,7 @@ FMN makes heavy use of caches since it needs to know who owns what packages and
 what user notification preferences are, both of which require expensive API
 queries to `FAS`_, `pkgdb`_, or the database.
 
-.. _fedmsg consumer: http://www.fedmsg.com/en/latest/consuming/#the-hub-consumer-approach
+.. _fedmsg consumer: https://fedmsg.readthedocs.io/en/stable/subscribing/#consumer-approach
 .. _FAS: https://admin.fedoraproject.org/accounts/
 .. _pkgdb: https://admin.fedoraproject.org/pkgdb/
 """

--- a/fmn/web/docs/about.rst
+++ b/fmn/web/docs/about.rst
@@ -2,8 +2,8 @@ Fedora Notifications
 ====================
 
 Fedora Notifications is a family of systems built to manage end-user
-notifications triggered by `fedmsg <http://fedmsg.com>`_, the fedora FEDerated
-MeSsaGe bus.
+notifications triggered by `the Fedora Project deployment of fedmsg
+<https://fedora-fedmsg.readthedocs.io/en/latest/>`_.
 
 The wins here are:
 
@@ -32,7 +32,7 @@ In a nutshell, here's the way this application works:
 We maintain a `lot of applications <https://apps.fedoraproject.org>`_. Over
 time, there has been an initiative to get them all speaking a similar language
 on the backend with fedmsg. Take a look at the `list of fedmsg topics
-<http://fedmsg.com/en/latest/topics/>`_ to see what all is covered.
+<https://fedora-fedmsg.readthedocs.io/en/latest/topics.html>`_ to see what all is covered.
 
 Some Terminology
 ================

--- a/fmn/web/templates/context.html
+++ b/fmn/web/templates/context.html
@@ -63,7 +63,7 @@
     <p>You have {{preference.filters|length}} rule filters
     defined for the {{current}} messaging context.  You can add new ones and
     delete existing ones here.</p>
-    <p>If a message on the <a href="http://fedmsg.com">fedmsg bus</a> matches
+    <p>If a message on the <a href="https://fedmsg.readthedocs.io">fedmsg bus</a> matches
     any one of these filters, then a notification will be sent your
     way{% if preference.enabled %}.{% else %} (except that you currently have
     the {{current}} delivery mechanism disabled.  Enable it and

--- a/fmn/web/templates/master.html
+++ b/fmn/web/templates/master.html
@@ -125,7 +125,7 @@
       <div class="container">
         <p class="text-muted credit">
         Fedora Notifications is powered by
-        <a href="http://fedmsg.com">fedmsg</a>.  The
+        <a href="https://fedmsg.readthedocs.io">fedmsg</a>.  The
         <a href="https://github.com/fedora-infra/fmn">source</a>
         and
         <a href="https://github.com/fedora-infra/fmn/issues">issue tracker</a>


### PR DESCRIPTION
Happy user of https://apps.fedoraproject.org/notifications/about I noticed that some links seemed wrong. A [quick search](https://github.com/fedora-infra/anitya/pull/914) shows that the `fedmsg.com` domain isn't used anymore.