### PR TITLE
Remove the archived repositories from documentation

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -58,8 +58,6 @@ Next, clone the repository and configure your Vagrantfile::
 
     $ git clone https://github.com/fedora-infra/fmn.git
     $ cd fmn
-    $ git clone https://github.com/fedora-infra/fmn.web.git
-    $ git clone https://github.com/fedora-infra/fmn.sse.git
     $ cp Vagrantfile.example Vagrantfile
     $ vagrant up
     $ vagrant reload


### PR DESCRIPTION
For setting up the vagrant dev environment documentation tells you to clone two
additional repositories. This is no longer needed, those repositories are
already part of main repository.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>