### PR TITLE
Add readthedocs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,27 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  install:
+    - requirements: dev-requirements.txt
+    - method: pip
+      path: .
+
+# Configure build environment
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"


### PR DESCRIPTION
Currently the documentation builds are failing, let's try to switch to new way
of providing configuration to fix this.

See https://docs.readthedocs.io/en/stable/config-file/v2.html for details

Signed-off-by: Michal Konečný <mkonecny@redhat.com>