### PR TITLE
Add krb5-config to readthedocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,3 +25,5 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.10"
+  apt_packages:
+    - krb5-config


### PR DESCRIPTION
Build is currently failing on missing krb5-config command, let's add it.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>