### PR TITLE
Use libkrb5-dev instead of krb5-config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -26,4 +26,4 @@ build:
   tools:
     python: "3.10"
   apt_packages:
-    - krb5-config
+    - libkrb5-dev


### PR DESCRIPTION
krb5-config doesn't contain `krb5-config` command, let's use package that
actually contains it.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>