### PR TITLE
remove datanommer from vagrant and use postgres

### DIFF
--- a/ansible/roles/fmn-dev/files/fedmsg.d/fmn.py
+++ b/ansible/roles/fmn-dev/files/fedmsg.d/fmn.py
@@ -5,9 +5,6 @@ hostname = socket.gethostname().split('.')[0]
 config = {
     # Consumer stuff
     "fmn.consumer.enabled": True,
-
-    # Our web frontend also needs to be able to talk to datanommer to get
-    # example messages that match rules (optional)
-    "datanommer.sqlalchemy.url": "postgresql+psycopg2://datanommer@localhost:5432/datanommer",
-    'datanommer.enabled': True,
+    "datanommer.enabled": False,
+    "fmn.sqlalchemy.uri":  "postgresql://postgres:anypasswordworkslocally@localhost/notifications",
 }

--- a/ansible/roles/fmn-dev/tasks/db.yml
+++ b/ansible/roles/fmn-dev/tasks/db.yml
@@ -9,15 +9,6 @@
       - postgresql
       - python-psycopg2
 
-- name: Install datanommer
-  dnf:
-      name: "{{ item }}"
-      state: present
-  with_items:
-      - datanommer-commands
-      - python-datanommer-models
-      - python-datanommer-consumer
-
 - name: Set up postgresql database
   command: postgresql-setup --initdb
   args:
@@ -37,15 +28,10 @@
 - name: Start and enable postgresql
   service: name=postgresql state=restarted enabled=yes
 
-- name: Set up the DB user
-  postgresql_user:
-      name: datanommer
-  become_user: postgres
-
 - name: Create the database
   postgresql_db:
-      name: datanommer
-      owner: datanommer
+      name: notifications
+      owner: postgres
   register: db_creation
   become_user: postgres
 
@@ -63,10 +49,8 @@
   replace:
     dest: /home/vagrant/alembic.ini
     regexp: "^sqlalchemy.url = sqlite.*$"
-    replace: "sqlalchemy.url = postgresql://postgres:anypasswordworkslocally@localhost/datanommer"
+    replace: "sqlalchemy.url = postgresql://postgres:anypasswordworkslocally@localhost/notifications"
 
-- name: Create the database schema
+- name: Create fmn database schema
   become_user: "{{ ansible_env.SUDO_USER }}"
-  command: /usr/bin/datanommer-create-db
-  args:
-      chdir: /home/vagrant/
+  shell: "source ~/.bashrc && workon fmn && fmn-createdb -c --with-dev-data"

--- a/ansible/roles/fmn-dev/tasks/main.yml
+++ b/ansible/roles/fmn-dev/tasks/main.yml
@@ -118,11 +118,4 @@
     src: fedmsg.d/
     dest: /home/{{ ansible_env.SUDO_USER }}/.fedmsg.d
 
-- name: Create fmn database
-  become_user: "{{ ansible_env.SUDO_USER }}"
-  shell: "source ~/.bashrc && workon fmn && fmn-createdb -c --with-dev-data"
-  args:
-    creates: /var/tmp/fmn-dev-db.sqlite
-
-
 - include: db.yml


### PR DESCRIPTION
remove setting up datanommer in the vagrant setup (we disable it by
default now) and switch the postgres groundwork we were using for
datanommer to use it for the main fmn database (rather than using sqlite)

Signed-off-by: Ryan Lerch <rlerch@redhat.com>