### PR TITLE
Fix the ReadTheDocs build

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,5 +9,6 @@ vcrpy
 # Docs requirements
 sphinx
 sqlalchemy_schemadisplay
+jinja2<3.1.0
 # Nice to have
 flower


### PR DESCRIPTION
Froze the jinja2 requirement.
Jinja2 is probably needed by some other library, but it will replace the
existing one in ReadTheDocs, which causes errors during build.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>