### PR TITLE
Fix the ReadTheDocs build - 2nd attempt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,5 @@ vcrpy
 # Docs requirements
 sphinx
 sqlalchemy_schemadisplay
-jinja2<3.1.0
 # Nice to have
 flower

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ fedmsg_meta_fedora_infrastructure>=0.18.0
 Flask
 flask-openid>=1.2.4
 gssapi
+Jinja2<3.1.0
 markupsafe
 moksha.hub
 munch


### PR DESCRIPTION
Adding the Jinja2 to dev-requirements didn't helped, those are not handled
during the last pip update of documentation build on RTD.
Let's move it to requirements.txt instead, which should be used.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>