### PR TITLE
Remove old FAS calls from FMN

### DIFF
--- a/fmn/util.py
+++ b/fmn/util.py
@@ -1,4 +1,3 @@
-import fedora.client
 import fasjson_client
 
 import logging
@@ -29,10 +28,12 @@ def get_fas_email(config, username):
     have that alias available yet.
     """
     try:
-        fas = fedora.client.AccountSystem(**config['fas_credentials'])
-        person = fas.person_by_username(username)
-        if person.get('email'):
-            return person['email']
+        fasjson = config["fasjson"]
+        client = fasjson_client.Client(url=fasjson.get('url'))
+        person = client.get_user(username=username).result
+
+        if person.get('emails'):
+            return person.get('emails')[0]
         raise ValueError("No email found: %r" % username)
     except Exception:
         log.exception("Failed to get FAS email for %r" % username)

--- a/python-fmn.spec
+++ b/python-fmn.spec
@@ -37,7 +37,6 @@ BuildRequires:      python3-docutils
 BuildRequires:      python3-dogpile-cache
 BuildRequires:      python3-fedmsg
 BuildRequires:      python3-fedmsg-meta-fedora-infrastructure
-BuildRequires:      python3-fedora
 BuildRequires:      python3-flake8
 BuildRequires:      python3-flask
 BuildRequires:      python3-flask-openid

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ psycopg2
 py3dns
 pylibravatar
 pyOpenSSL
-python-fedora
 python3-openid
 python-openid-cla
 python-openid-teams

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ basepython=python3
 deps =
     flake8 > 3.0
 commands =
-    python -m flake8 {posargs}
+    python -m flake8 fmn/ {posargs}
 
 [flake8]
 show-source = True


### PR DESCRIPTION
FAS2 is no longer used by anything except FMN. Let's remove these calls from FMN
and use fasjson_client instead.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>