### PR TITLE
Set up basic CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,37 @@
+name: CI
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: setup venv
+        run: |
+             python -m pip install --upgrade virtualenv
+             virtualenv venv
+             source venv/bin/activate
+             which python
+
+      - name: Install base dependencies
+        run: |
+             source venv/bin/activate
+             python -m pip install --upgrade poetry
+             python -m pip install --upgrade pytest
+             python -m pip install --upgrade tox
+
+
+      - name: execute tox
+        run: |
+             source venv/bin/activate
+             tox

--- a/fmn/api/cli.py
+++ b/fmn/api/cli.py
@@ -10,7 +10,7 @@ def api():
 
 
 @api.command()
-@click.option('--host', default='127.0.0.1', help='host to serve the api on')
+@click.option("--host", default="127.0.0.1", help="host to serve the api on")
 def serve(host):
     """Serve the FMN API via HTTP"""
     uvicorn.run(main.app, host=host)

--- a/fmn/api/main.py
+++ b/fmn/api/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 
 app = FastAPI()
 
+
 @app.get("/")
 def read_root():
     return {"Hello": "World"}

--- a/fmn/core/cli.py
+++ b/fmn/core/cli.py
@@ -1,4 +1,9 @@
-from importlib.metadata import entry_points
+import sys
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points  # pragma: no cover
+else:
+    from importlib.metadata import entry_points  # pragma: no cover
 
 import click
 import click_plugins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ fastapi = "^0.78.0"
 uvicorn = "^0.18.2"
 click = "^8.1.3"
 click-plugins = "^1.1.1"
+importlib-metadata = {version = "^4.12.0", python = "<3.10"}
 
 [tool.poetry.dev-dependencies]
 poetry = "^1.1.14"

--- a/tests/api/test_cli.py
+++ b/tests/api/test_cli.py
@@ -14,4 +14,4 @@ def test_api_help(cli_runner):
 def test_api_serve(uvicorn, cli_runner):
     result = cli_runner.invoke(api, ["serve"])
     assert result.exit_code == 0
-    uvicorn.run.assert_called_once_with(main.api)
+    uvicorn.run.assert_called_once_with(main.app, host="127.0.0.1")

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -1,0 +1,5 @@
+from fmn.api import main
+
+
+def test_read_root():
+    assert main.read_root()["Hello"] == "World"

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
 
 [testenv:isort]
 commands =
-  fmn -q install isort
+  pip -q install isort
   isort --diff fmn/ tests/
 
 [flake8]


### PR DESCRIPTION
commit a54aca8dbd8da056a6db2768f7481161f7677551
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Jul 27 16:52:48 2022 +0200

    Make black and flake8 happy
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 1dd791ce822efdc312f32e5dd3167d594273b1b1
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Jul 27 16:54:35 2022 +0200

    Update expected uvicorn.run() invocation.
    
    The FastAPI object was renamed from `api` to `app` and the function call
    got a new parameter but the test didn’t follow suit.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit aa8135ac3890b937f25e8dc50fe240dfb637c8f1
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Jul 27 17:18:17 2022 +0200

    Test newly introduced path operation function
    
    This function doesn’t serve a real purpose, but test it anyway so future
    CI will be happy.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit cf527ebe208de857145cad98b5c4c324b05c8b8c
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Jul 27 18:45:38 2022 +0200

    Fix installing isort into tox environment
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 54b70b6f59177390cdce86619222e2fc346f0907
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Jul 27 18:45:02 2022 +0200

    Fix discovering CLI entry points in Python < 3.10
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 9f7e64625ba03caf91919b9574f3740569bd136a
Author:     Nils Philippsen <nils@redhat.com>
Date: Wed Jul 27 18:51:11 2022 +0200

    Set up GitHub actions
    
    Essentially, run unit tests through tox for now.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>