### PR TITLE
Comment out setting the poetry venv path

### DIFF
--- a/devel/ansible/roles/api/tasks/main.yml
+++ b/devel/ansible/roles/api/tasks/main.yml
@@ -27,14 +27,14 @@
   args:
     chdir: /home/vagrant/fmn/
 
-- name: Determine poetry venv path
-  command: poetry env info --path
-  register: _poetry_venv_path
-  changed_when: False
+# - name: Determine poetry venv path
+#   command: poetry env info --path
+#   register: _poetry_venv_path
+#   changed_when: False
 
-- name: Set poetry venv path fact
-  set_fact:
-    poetryvenvpath: "{{ _poetry_venv_path.stdout | trim }}"
+# - name: Set poetry venv path fact
+#   set_fact:
+#     poetryvenvpath: "{{ _poetry_venv_path.stdout | trim }}"
 
 - name: Start the service using systemd
   systemd:


### PR DESCRIPTION
We don't need this fact for now -- might need it later however, so
leaving it in the file for now, but commented out.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>