### PR TITLE
FastAPI: Establish identity from OIDC token + changes around configuration

### DIFF
--- a/devel/ansible/roles/api/files/fmn-api.service
+++ b/devel/ansible/roles/api/files/fmn-api.service
@@ -7,7 +7,11 @@ Wants=network-online.target
 User=vagrant
 Environment=GSS_USE_PROXY=yes
 WorkingDirectory=/home/vagrant/fmn
-ExecStart=poetry run uvicorn fmn.api.main:app --host 0.0.0.0 --ssl-keyfile /etc/pki/tls/private/server.key --ssl-certfile /etc/pki/tls/certs/server.pem
+ExecStart=poetry run uvicorn fmn.api.main:app \
+    --env-file /home/vagrant/fmn/fmn.cfg \
+    --host 0.0.0.0 \
+    --ssl-keyfile /etc/pki/tls/private/server.key \
+    --ssl-certfile /etc/pki/tls/certs/server.pem
 
 [Install]
 WantedBy=multi-user.target

--- a/devel/ansible/roles/api/files/fmn.cfg
+++ b/devel/ansible/roles/api/files/fmn.cfg
@@ -1,2 +1,0 @@
-CORS_ORIGINS="http://localhost:5173 https://localhost:5173 http://fmn.tinystage.test:5173 https://fmn.tinystage.test:5173"
-FASJSON_URL=http://fasjson.tinystage.test/fasjson

--- a/devel/ansible/roles/api/tasks/main.yml
+++ b/devel/ansible/roles/api/tasks/main.yml
@@ -35,9 +35,29 @@
 #   set_fact:
 #     poetryvenvpath: "{{ _poetry_venv_path.stdout | trim }}"
 
+- name: Register the API as an OIDC client with Ipsilon
+  command:
+    cmd: >
+      oidc-register --debug --output-file /home/vagrant/api-oidc-secrets.json
+      https://ipsilon.tinystage.test/idp/openidc/ https://fmn.tinystage.test/
+    creates: /home/vagrant/api-oidc-secrets.json
+  become: yes
+  become_user: vagrant
+
+- name: Read the OIDC credentials file
+  slurp:
+    src: /home/vagrant/api-oidc-secrets.json
+  register: api_oidc_secrets_out
+
+- name: Set OIDC client credentials
+  set_fact:
+    oidc_client_id: "{{ (api_oidc_secrets_out.content | b64decode | from_json).web.client_id }}"
+    oidc_client_secret: >-
+      {{ (api_oidc_secrets_out.content | b64decode | from_json).web.client_secret }}
+
 - name: Install the configuration file
-  copy:
-    src: fmn.cfg
+  template:
+    src: fmn.cfg.j2
     dest: /home/vagrant/fmn/fmn.cfg
     mode: 0644
 

--- a/devel/ansible/roles/api/templates/fmn.cfg.j2
+++ b/devel/ansible/roles/api/templates/fmn.cfg.j2
@@ -1,0 +1,7 @@
+CORS_ORIGINS="http://localhost:5173 https://localhost:5173 http://fmn.tinystage.test:5173 https://fmn.tinystage.test:5173"
+OIDC_PROVIDER_URL="https://ipsilon.tinystage.test/idp/openidc"
+OIDC_CONF_ENDPOINT="/.well-known/openid-configuration"
+OIDC_TOKEN_INFO_ENDPOINT="/TokenInfo"
+OIDC_CLIENT_ID="{{ oidc_client_id }}"
+OIDC_CLIENT_SECRET="{{ oidc_client_secret }}"
+FASJSON_URL=http://fasjson.tinystage.test/fasjson

--- a/fmn/api/__init__.py
+++ b/fmn/api/__init__.py
@@ -1,0 +1,2 @@
+from . import auth  # noqa: F401
+from . import main  # noqa: F401

--- a/fmn/api/auth.py
+++ b/fmn/api/auth.py
@@ -1,0 +1,104 @@
+import logging
+import time
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from httpx import AsyncClient
+from pydantic import BaseModel
+
+from .config import get_settings
+
+log = logging.getLogger(__name__)
+
+
+class TokenExpired(ValueError):
+    pass
+
+
+class Identity(BaseModel):
+
+    _client = None
+    _token_to_identities_cache = {}
+    _cache_next_gc_after = None
+
+    name: str
+    expires_at: float
+
+    class Config:
+        extra = "ignore"
+
+    @classmethod
+    def client(cls) -> AsyncClient:
+        settings = get_settings()
+        if not cls._client:
+            cls._client = AsyncClient(
+                base_url=settings.oidc_provider_url,
+                auth=(settings.oidc_client_id, settings.oidc_client_secret),
+                timeout=None,
+            )
+        return cls._client
+
+    @classmethod
+    def _cache_collect_garbage(cls, force: bool = False) -> None:
+        id_cache_gc_interval = get_settings().id_cache_gc_interval
+        now = time.time()
+        then = now + id_cache_gc_interval
+
+        if not force:
+            if not cls._cache_next_gc_after:
+                cls._cache_next_gc_after = then
+                return
+
+            if now < cls._cache_next_gc_after:
+                return
+
+        cls._token_to_identities_cache = {
+            k: v for k, v in cls._token_to_identities_cache.items() if v.expires_at > now
+        }
+        cls._cache_next_gc_after = then
+
+    @classmethod
+    async def from_oidc_token(cls, token: str) -> "Identity":
+        identity = cls._token_to_identities_cache.get(token)
+        if not identity:
+            response = await cls.client().post(
+                get_settings().oidc_token_info_url, data={"token": token}
+            )
+            await response.raise_for_status()
+            result = response.json()
+
+            identity = cls(name=result["username"], expires_at=float(result["exp"]))
+
+        if identity.expires_at < time.time():
+            cls._cache_collect_garbage(force=True)
+            raise TokenExpired(token)
+        else:
+            cls._cache_collect_garbage()
+
+        cls._token_to_identities_cache[token] = identity
+
+        return identity
+
+
+class IdentityFactory:
+    def __init__(self, optional=False):
+        self.optional = optional
+
+    async def process_oidc_auth(
+        self, creds: HTTPAuthorizationCredentials | None
+    ) -> Identity | None:
+        return await Identity.from_oidc_token(creds.credentials)
+
+    async def __call__(
+        self, bearer: HTTPAuthorizationCredentials | None = Depends(HTTPBearer(auto_error=False))
+    ) -> Identity | None:
+        try:
+            return await self.process_oidc_auth(bearer)
+        except TokenExpired as exc:
+            if self.optional:
+                return None
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Token expired") from exc
+
+
+get_identity = IdentityFactory(optional=False)
+get_identity_optional = IdentityFactory(optional=True)

--- a/fmn/api/cli.py
+++ b/fmn/api/cli.py
@@ -1,12 +1,28 @@
 import click
 import uvicorn
 
-from . import main
+from . import config, main
+
+DEFAULT_CONFIG_FILE = "/etc/fmn/api.cfg"
 
 
 @click.group()
-def api():
+@click.option(
+    "settings_file",
+    "--config",
+    "-c",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help="The configuration file for the API service.",
+)
+def api(settings_file: str | None):
     """The FMN API service"""
+    config.settings_file = settings_file or DEFAULT_CONFIG_FILE
+    config.get_settings.cache_clear()
+
+
+@api.command(hidden=True)
+def test_helper():
+    pass
 
 
 @api.command()

--- a/fmn/api/config.py
+++ b/fmn/api/config.py
@@ -1,16 +1,35 @@
 from functools import cache
 
-from pydantic import BaseSettings
+from pydantic import BaseSettings, root_validator
 
 settings_file = None  # will be set from CLI
 
 
 class Settings(BaseSettings):
     cors_origins: str = "https://notifications.fedoraproject.org"
+    oidc_provider_url: str = "https://id.fedoraproject.org/openidc"
+    oidc_conf_endpoint: str = "/.well-known/openid-configuration"
+    oidc_token_info_endpoint: str = "/TokenInfo"
+    oidc_client_id: str = "0123456789abcdef0123456789abcdef"
+    oidc_client_secret: str = "0123456789abcdef0123456789abcdef"
     fasjson_url: str = "https://fasjson.fedoraproject.org"
+
+    id_cache_gc_interval: int = 300
 
     class Config:
         env_file = "fmn.cfg"
+
+    @root_validator
+    def compute_compound_fields(cls, values) -> dict:
+        values["oidc_conf_url"] = (
+            values["oidc_provider_url"].rstrip("/") + "/" + values["oidc_conf_endpoint"].lstrip("/")
+        )
+        values["oidc_token_info_url"] = (
+            values["oidc_provider_url"].rstrip("/")
+            + "/"
+            + values["oidc_token_info_endpoint"].lstrip("/")
+        )
+        return values
 
 
 @cache

--- a/fmn/api/config.py
+++ b/fmn/api/config.py
@@ -1,4 +1,8 @@
+from functools import cache
+
 from pydantic import BaseSettings
+
+settings_file = None  # will be set from CLI
 
 
 class Settings(BaseSettings):
@@ -7,3 +11,8 @@ class Settings(BaseSettings):
 
     class Config:
         env_file = "fmn.cfg"
+
+
+@cache
+def get_settings() -> Settings:
+    return Settings(_env_file=settings_file)

--- a/fmn/api/main.py
+++ b/fmn/api/main.py
@@ -1,27 +1,22 @@
-from functools import lru_cache
-
 from fasjson_client import Client as FasjsonClient
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from .config import Settings
+from .config import Settings, get_settings
 
 app = FastAPI()
 
 
-@lru_cache
-def get_settings():
-    return Settings()
-
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=get_settings().cors_origins.split(" "),
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+@app.on_event("startup")
+def add_middlewares():
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=get_settings().cors_origins.split(" "),
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
 
 class Rule(BaseModel):

--- a/poetry.lock
+++ b/poetry.lock
@@ -487,7 +487,7 @@ lxml = ["lxml"]
 name = "httpcore"
 version = "0.15.0"
 description = "A minimal low-level HTTP client."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -505,7 +505,7 @@ socks = ["socksio (>=1.0.0,<2.0.0)"]
 name = "httpx"
 version = "0.23.0"
 description = "The next generation HTTP client."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -1164,7 +1164,7 @@ six = "*"
 name = "rfc3986"
 version = "1.5.0"
 description = "Validating URI References per RFC 3986"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1491,7 +1491,7 @@ consumer = ["fedora-messaging", "pika", "fasjson-client", "dogpile.cache"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "d9fc6446d9548211b8231c89d057f5622d873394bd2dc837a5369b15c6ad4a27"
+content-hash = "af2823b6861a51beb7418ae37feac923839a172f674baa7f2e3de7f5e7ac5983"
 
 [metadata.files]
 anyio = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,11 @@ fasjson-client = {version = "^1.0.7", optional = true}
 fedora-messaging = {version = "^3.0.2", optional = true}
 pika = {version = "^1.3.0", optional = true}
 "dogpile.cache" = {version = "^1.1.8", optional = true}
+httpx = "^0.23.0"
 
 [tool.poetry.dev-dependencies]
 poetry = "^1.2.0b2"
 black = "^22.6.0"
-httpx = "^0.23.0"
 isort = "^5.10.1"
 pytest = "^7.1.2"
 pytest-asyncio = "^0.18.3"

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,14 @@
+from unittest import mock
+
+import pytest
+
+from fmn.api.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def clear_api_settings(tmp_path):
+    with mock.patch(
+        "fmn.api.cli.DEFAULT_CONFIG_FILE", new=str(tmp_path / "non-existing-file")
+    ), mock.patch("fmn.api.config.settings_file", new=None):
+        get_settings.cache_clear()
+        yield

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,0 +1,121 @@
+import time
+from contextlib import nullcontext
+from unittest import mock
+
+import pytest
+from fastapi import HTTPException, status
+from httpx import AsyncClient
+
+from fmn.api.auth import Identity, IdentityFactory, TokenExpired
+
+
+class TestIdentity:
+    def test_client(self):
+        client = Identity.client()
+        assert isinstance(client, AsyncClient)
+
+        new_client = Identity.client()
+        assert new_client is client
+
+    @pytest.mark.parametrize("expired", (False, True))
+    @pytest.mark.parametrize("perform_gc", (False, True))
+    @mock.patch.object(Identity, "_cache_next_gc_after", new=None)
+    @mock.patch.object(Identity, "_token_to_identities_cache", new_callable=dict)
+    @mock.patch.object(Identity, "client")
+    async def test_from_oidc_token(self, client, _token_to_identities_cache, expired, perform_gc):
+        now = time.time()
+        if expired:
+            expectation = pytest.raises(TokenExpired)
+            then = now - 1
+        else:
+            expectation = nullcontext()
+            then = now + 3600
+
+        client.return_value = mock_client = mock.AsyncMock()
+        mock_client.post.return_value.json = mock.Mock()
+        mock_client.post.return_value.json.return_value = token_info_result = {
+            "username": "karlheinzschinkenwurst",
+            "exp": str(then),
+        }
+
+        # cold cache
+
+        with expectation:
+            identity = await Identity.from_oidc_token("abcd-1234")
+
+        mock_client.post.assert_awaited_once()
+
+        if expired:
+            return
+
+        assert identity.name == token_info_result["username"]
+        assert str(identity.expires_at) == token_info_result["exp"]
+
+        # hot cache
+
+        mock_client.post.reset_mock()
+
+        Identity._token_to_identities_cache["efgh-5678"] = gc_sentinel = mock.Mock(
+            expires_at=now - 1
+        )
+
+        if perform_gc:
+            Identity._cache_next_gc_after = now - 1
+
+        identity2 = await Identity.from_oidc_token("abcd-1234")
+
+        mock_client.post.assert_not_awaited()
+        assert identity2 is identity
+
+        if perform_gc:
+            assert gc_sentinel not in Identity._token_to_identities_cache.values()
+        else:
+            assert gc_sentinel in Identity._token_to_identities_cache.values()
+
+
+class TestIdentityFactory:
+    @mock.patch.object(Identity, "from_oidc_token")
+    async def test_process_oidc_auth(self, from_oidc_token):
+        from_oidc_token.return_value = sentinel = object()
+        creds = mock.Mock(credentials="dead-beef")
+        identity = await IdentityFactory().process_oidc_auth(creds=creds)
+
+        assert identity is sentinel
+        from_oidc_token.assert_awaited_once_with("dead-beef")
+
+    @pytest.mark.parametrize("testcase", ("success", "failure-mandatory", "failure-optional"))
+    async def test___call__(self, testcase):
+        optional = "optional" in testcase
+        success = "success" in testcase
+
+        factory = IdentityFactory(optional=optional)
+
+        with mock.patch.object(factory, "process_oidc_auth") as process_oidc_auth:
+            expectation = nullcontext()
+            if success:
+                process_oidc_auth.return_value = result_sentinel = object()
+            else:
+                process_oidc_auth.side_effect = TokenExpired("abcd-1234")
+                if not optional:
+                    expectation = pytest.raises(HTTPException)
+
+            if success:
+                bearer_sentinel = object()
+                args = (bearer_sentinel,)
+            else:
+                args = (None,)
+
+            with expectation as excinfo:
+                result = await factory(*args)
+
+            if success:
+                process_oidc_auth.assert_awaited_once_with(bearer_sentinel)
+            else:
+                process_oidc_auth.assert_awaited_once_with(None)
+                if not optional:
+                    assert excinfo.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+            if success:
+                assert result is result_sentinel
+            elif optional:
+                assert result is None

--- a/tests/api/test_cli.py
+++ b/tests/api/test_cli.py
@@ -1,6 +1,8 @@
 from unittest import mock
 
-from fmn.api import main
+import pytest
+
+from fmn.api import cli, config, main
 from fmn.api.cli import api
 
 
@@ -8,6 +10,25 @@ def test_api_help(cli_runner):
     result = cli_runner.invoke(api, ["--help"])
     assert result.exit_code == 0
     assert "Usage: api" in result.output
+
+
+@pytest.mark.parametrize("default_config", (True, False))
+@mock.patch.object(config, "settings_file")
+def test_api_settings(settings_file, default_config, cli_runner):
+    if default_config:
+        args = []
+    else:
+        args = [f"--config={__file__}"]
+
+    with mock.patch("fmn.api.config.get_settings") as get_settings:
+        result = cli_runner.invoke(api, args + ["test-helper"])
+        get_settings.cache_clear.assert_called_once_with()
+
+    assert result.exit_code == 0
+    if default_config:
+        assert config.settings_file == cli.DEFAULT_CONFIG_FILE
+    else:
+        assert config.settings_file == __file__
 
 
 @mock.patch("fmn.api.cli.uvicorn")

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -1,0 +1,12 @@
+from unittest import mock
+
+from fmn.api import config
+
+
+@mock.patch("fmn.api.config.Settings")
+def test_get_settings(Settings):
+    Settings.return_value = sentinel = object()
+
+    assert config.get_settings() is sentinel
+
+    Settings.assert_called_once_with(_env_file=None)

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -1,6 +1,23 @@
+from unittest import mock
+
 import responses
 
 from fmn.api import main
+
+
+@mock.patch("fmn.api.main.get_settings")
+@mock.patch("fmn.api.main.app")
+def test_add_middlewares(app, get_settings):
+    get_settings.return_value = mock.Mock(cors_origins="https://foo")
+    main.add_middlewares()
+
+    app.add_middleware.assert_called_once_with(
+        main.CORSMiddleware,
+        allow_origins=["https://foo"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
 
 def test_read_root():

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from unittest import mock
 
 import responses
@@ -20,8 +21,19 @@ def test_add_middlewares(app, get_settings):
     )
 
 
-def test_read_root():
-    assert main.read_root()["Hello"] == "World"
+async def test_read_root():
+    request = mock.Mock()
+    creds = mock.Mock(scheme="bearer", credentials="abcd-1234")
+    identity = mock.Mock(expires_at=dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc))
+    identity.name = "foo"  # name can't be set in the constructor of Mock()
+
+    result = await main.read_root(request=request, creds=creds, identity=identity)
+
+    assert result["Hello"] == "World"
+    assert result["creds"].scheme == "bearer"
+    assert result["creds"].credentials == "abcd-1234"
+    assert result["identity"].name == "foo"
+    assert isinstance(result["identity"].expires_at, dt.datetime)
 
 
 def test_get_settings():


### PR DESCRIPTION
```
commit bd0e83f3c927837682271f95297e5221d51d169d
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Aug 29 13:23:06 2022 +0200

    Implement system-wide or custom settings file
    
    Previously, this was hard-coded to `fmn.cfg` in the current directory
    and loaded with the `fmn.api.main` module. Now this defaults to
    `/etc/fmn/api.cfg` and users can set this on the `fmn api` command line.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 27d859316858c50974b26a74bb2bea99f1a0c194
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Aug 29 14:10:29 2022 +0200

    Establish identity from provided OIDC token
    
    This caches identities obtained from the identity provider (i.e.
    ipsilon) by their token value.
    
    Fixes: #499
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```