### PR TITLE
Make `rangeStrategy="widen"` effective and label opened PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,16 @@
   "automergeStrategy": "rebase",
   "rangeStrategy": "widen",
   "stabilityDays": 3,
+  "labels": ["dependencies"],
   "packageRules": [
+    {
+      "matchLanguages": ["python"],
+      "addLabels": ["python"]
+    },
+    {
+      "matchLanguages": ["js"],
+      "addLabels": ["javascript"]
+    },
     {
       "matchDepTypes": ["devDependencies"],
       "automerge": true,

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    ":preserveSemverRanges",
     "group:allNonMajor",
     "schedule:weekdays",
     ":maintainLockFilesWeekly",


### PR DESCRIPTION
```
commit ed4ce196e5bf2558ec79bad587575cd15dada47a
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Aug 31 12:42:38 2022 +0200

    Make rangeStrategy default value effective
    
    The preserveSemverRanges default preset applies its setting as a
    packageRule, which overrides the default value of rangeStrategy.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 4f512bd668f475e4b435c96508ab9d0907c63371
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Aug 31 12:44:03 2022 +0200

    Add labels to renovatebot PRs
    
    Dependabot labelled PRs with `dependencies` and either `python` or
    `javascript`, depending on what gets updated. This looks like a good
    thing to retain to me.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```