### PR TITLE
Bring up backend coverage to 100% again

### DIFF
--- a/fmn/api/api_models.py
+++ b/fmn/api/api_models.py
@@ -1,26 +1,25 @@
 import logging
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel as PydanticBaseModel
 from pydantic.utils import GetterDict
 
 log = logging.getLogger(__name__)
+
+
+class BaseModel(PydanticBaseModel):
+    class Config:
+        orm_mode = True
 
 
 class TrackingRule(BaseModel):
     name: str
     params: list[str] | dict[str, str] | None
 
-    class Config:
-        orm_mode = True
-
 
 class Destination(BaseModel):
     protocol: str
     address: str
-
-    class Config:
-        orm_mode = True
 
 
 class Filters(BaseModel):
@@ -42,7 +41,6 @@ class GenerationRule(BaseModel):
     filters: Filters
 
     class Config:
-        orm_mode = True
         getter_dict = GRGetterDict
 
 
@@ -51,6 +49,3 @@ class Rule(BaseModel):
     name: str
     tracking_rule: TrackingRule
     generation_rules: list[GenerationRule]
-
-    class Config:
-        orm_mode = True

--- a/fmn/api/database.py
+++ b/fmn/api/database.py
@@ -1,10 +1,8 @@
 from typing import Iterator
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
-from ..database import async_session_maker, model
+from ..database import async_session_maker
 
 
 async def gen_db_session() -> Iterator[AsyncSession]:
@@ -31,18 +29,3 @@ async def gen_db_session() -> Iterator[AsyncSession]:
         raise
     finally:
         await db_session.close()
-
-
-async def query_rule(session, *filters):
-    query = (
-        select(model.Rule)
-        .join(model.User)
-        .options(
-            selectinload(model.Rule.tracking_rule),
-            selectinload(model.Rule.generation_rules),
-            selectinload(model.Rule.generation_rules, model.GenerationRule.destinations),
-            selectinload(model.Rule.generation_rules, model.GenerationRule.filters),
-        )
-        .where(*filters)
-    )
-    return await session.execute(query)

--- a/fmn/api/database.py
+++ b/fmn/api/database.py
@@ -7,16 +7,30 @@ from sqlalchemy.orm import selectinload
 from ..database import async_session_maker, model
 
 
-async def req_db_async_session() -> Iterator[AsyncSession]:  # pragma: no cover todo
-    db_async_session = async_session_maker()
+async def gen_db_session() -> Iterator[AsyncSession]:
+    """Generate database sessions for FastAPI request handlers.
+
+    This lets users declare the session as a dependency in request handler
+    functions, e.g.:
+
+        @app.get("/path")
+        def process_path(db_session: AsyncSession = Depends(gen_db_session)):
+            query = select(Model).filter_by(...)
+            result = await db_session.execute(query)
+            ...
+
+    :return: A :class:`sqlalchemy.ext.asyncio.AsyncSession` object for the
+        current request
+    """
+    db_session = async_session_maker()
     try:
-        yield db_async_session
-        await db_async_session.commit()
+        yield db_session
+        await db_session.commit()
     except Exception:
-        await db_async_session.rollback()
+        await db_session.rollback()
         raise
     finally:
-        await db_async_session.close()
+        await db_session.close()
 
 
 async def query_rule(session, *filters):

--- a/fmn/api/main.py
+++ b/fmn/api/main.py
@@ -264,7 +264,7 @@ def get_applications():  # pragma: no cover todo
 @app.get("/artifacts/owned")
 def get_owned_artifacts(
     users: list[str] = Query(default=[]), groups: list[str] = Query(default=[])
-):
+):  # pragma: no cover todo
     # TODO: Get artifacts owned by a user or a group
 
     artifacts = []

--- a/fmn/api/main.py
+++ b/fmn/api/main.py
@@ -7,8 +7,6 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from fmn.database.main import get, get_or_create
-
 from ..core.config import Settings, get_settings
 from ..database import init_async_model
 from ..database.model import Destination, Filter, GenerationRule, Rule, TrackingRule, User
@@ -68,7 +66,7 @@ async def get_users(
 async def get_user(
     username, db_session: AsyncSession = Depends(gen_db_session)
 ):  # pragma: no cover todo
-    user, _created = await get_or_create(db_session, User, name=username)
+    user = await User.async_get_or_create(db_session, name=username)
     return {"user": user}
 
 
@@ -202,7 +200,7 @@ async def delete_user_rule(
     if username != identity.name:
         raise HTTPException(status_code=403, detail="Not allowed to delete someone else's rules")
 
-    rule = await get(db_session, Rule, id=id)
+    rule = await Rule.async_get(db_session, id=id)
     await db_session.delete(rule)
     await db_session.flush()
 
@@ -219,7 +217,7 @@ async def create_user_rule(
     if username != identity.name:
         raise HTTPException(status_code=403, detail="Not allowed to edit someone else's rules")
     log.info("Creating rule:", rule)
-    user, _created = await get_or_create(db_session, User, name=username)
+    user = await User.async_get_or_create(db_session, name=username)
     rule_db = Rule(user=user, name=rule.name)
     db_session.add(rule_db)
     await db_session.flush()

--- a/fmn/database/model/generation_rule.py
+++ b/fmn/database/model/generation_rule.py
@@ -2,7 +2,6 @@ from sqlalchemy import Column, ForeignKey, Integer
 from sqlalchemy.orm import relationship
 
 from ..main import Base
-from .rule import Rule
 
 
 class GenerationRule(Base):
@@ -10,8 +9,8 @@ class GenerationRule(Base):
 
     id = Column(Integer, primary_key=True, nullable=False)
 
-    rule_id = Column(Integer, ForeignKey(Rule.id, ondelete="CASCADE"), nullable=False)
-    rule = relationship(Rule, back_populates="generation_rules")
+    rule_id = Column(Integer, ForeignKey("rules.id", ondelete="CASCADE"), nullable=False)
+    rule = relationship("Rule", back_populates="generation_rules")
 
     destinations = relationship(
         "Destination", back_populates="generation_rule", cascade="all, delete-orphan"

--- a/fmn/database/model/rule.py
+++ b/fmn/database/model/rule.py
@@ -1,7 +1,12 @@
-from sqlalchemy import Column, ForeignKey, Integer, UnicodeText
-from sqlalchemy.orm import relationship
+from functools import cache
+
+from sqlalchemy import Column, ForeignKey, Integer, UnicodeText, select
+from sqlalchemy.orm import relationship, selectinload
+from sqlalchemy.sql import Select
 
 from ..main import Base
+from .generation_rule import GenerationRule
+from .tracking_rule import TrackingRule
 from .user import User
 
 
@@ -15,8 +20,25 @@ class Rule(Base):
     user = relationship(User, back_populates="rules")
 
     tracking_rule = relationship(
-        "TrackingRule", back_populates="rule", uselist=False, cascade="all, delete-orphan"
+        TrackingRule, back_populates="rule", uselist=False, cascade="all, delete-orphan"
     )
     generation_rules = relationship(
-        "GenerationRule", back_populates="rule", cascade="all, delete-orphan"
+        GenerationRule, back_populates="rule", cascade="all, delete-orphan"
     )
+
+    @classmethod
+    @cache
+    def select_related(cls) -> Select:
+        """Convenience method to query rules and related property objects.
+
+        This tells SQLAlchemy to query ORM objects related to a Rule right in
+        the query which is necessary when accessing their respective properties
+        in an async context.
+        """
+        return select(cls).options(
+            selectinload(cls.user),
+            selectinload(cls.tracking_rule),
+            selectinload(cls.generation_rules),
+            selectinload(cls.generation_rules, GenerationRule.destinations),
+            selectinload(cls.generation_rules, GenerationRule.filters),
+        )

--- a/fmn/database/model/tracking_rule.py
+++ b/fmn/database/model/tracking_rule.py
@@ -2,7 +2,6 @@ from sqlalchemy import JSON, Column, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
 from ..main import Base
-from .rule import Rule
 
 
 class TrackingRule(Base):
@@ -11,8 +10,8 @@ class TrackingRule(Base):
     id = Column(Integer, primary_key=True, nullable=False)
 
     # Unique: there can be only one TrackingRule per Rule
-    rule_id = Column(Integer, ForeignKey(Rule.id), nullable=False, unique=True)
-    rule = relationship(Rule, back_populates="tracking_rule", uselist=False)
+    rule_id = Column(Integer, ForeignKey("rules.id"), nullable=False, unique=True)
+    rule = relationship("Rule", back_populates="tracking_rule", uselist=False)
 
     name = Column(String(length=255), nullable=False)
     params = Column(JSON)

--- a/tests/api/test_api_models.py
+++ b/tests/api/test_api_models.py
@@ -1,0 +1,21 @@
+from unittest import mock
+
+from fmn.api.api_models import GRGetterDict
+
+
+class TestGRGetterDict:
+    def test_get(self):
+        filter_obj = mock.Mock()
+        filter_obj.name = "filter"
+        filter_obj.params = {"this is": "params"}
+
+        processed_obj = mock.Mock(foo="bar", filters=[filter_obj])
+        del processed_obj.boop
+
+        getter_dict = GRGetterDict(processed_obj)
+
+        default_sentinel = object()
+
+        assert getter_dict.get("boop", default_sentinel) is default_sentinel
+        assert getter_dict.get("foo", default_sentinel) == "bar"
+        assert getter_dict.get("filters", default_sentinel) == {"filter": {"this is": "params"}}

--- a/tests/api/test_database.py
+++ b/tests/api/test_database.py
@@ -1,0 +1,39 @@
+from unittest import mock
+
+import pytest
+
+from fmn.api.database import gen_db_session
+
+
+@pytest.mark.parametrize("testcase", ("happy-path", "exception-thrown", "commit-raises-exception"))
+@mock.patch("fmn.api.database.async_session_maker")
+async def test_gen_db_session(async_session_maker, testcase):
+    mock_session = mock.AsyncMock()
+    async_session_maker.return_value = mock_session
+
+    if testcase == "happy-path":
+        expectation = pytest.raises(StopAsyncIteration)
+    else:
+        expectation = pytest.raises(Exception)
+
+    if "commit-raises-exception" in testcase:
+        mock_session.commit.side_effect = Exception("BOO")
+
+    agen = gen_db_session()
+
+    db_session = await agen.asend(None)
+
+    assert db_session is mock_session
+
+    with expectation:
+        if "thrown" not in testcase:
+            await agen.asend(None)
+        else:
+            await agen.athrow(Exception("FOO"))
+
+    if "exception" in testcase:
+        mock_session.rollback.assert_awaited_with()
+    else:
+        mock_session.rollback.assert_not_awaited()
+
+    mock_session.close.assert_awaited_with()

--- a/tests/database/test_model.py
+++ b/tests/database/test_model.py
@@ -78,4 +78,16 @@ class TestRule(ModelTestBase):
     }
 
     def _db_obj_get_dependencies(self):
-        return {"user": model.User(name="allkneelbeforezod")}
+        return {
+            "user": model.User(name="allkneelbeforezod"),
+            "tracking_rule": model.TrackingRule(name="datrackingrule"),
+            "generation_rules": [model.GenerationRule()],
+        }
+
+    async def test_select_related(self, db_async_session, db_async_obj):
+        rule = (await db_async_session.execute(model.Rule.select_related())).scalar_one()
+
+        assert rule.user.name == "allkneelbeforezod"
+        assert rule.tracking_rule.name == "datrackingrule"
+        assert len(rule.generation_rules) == 1
+        assert all(isinstance(gr, model.GenerationRule) for gr in rule.generation_rules)


### PR DESCRIPTION
In the course, some refactoring:

- Name the DB session FastAPI dep less awkward
- Scope getter and rules selection convenience code better
- As Pydantic model class are used less than ORM classes, access them by explicit namespace and import the latter directly