### PR TITLE
Update all non-major dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ click = "^8.1.3"
 click-plugins = "^1.1.1"
 python-dotenv = "^0.20.0 || ^0.21.0"
 fastapi = {version = "^0.78.0 || ^0.79.0 || ^0.80.0 || ^0.81.0 || ^0.82.0 || ^0.83.0 || ^0.84.0 || ^0.85.0", optional = true}
-uvicorn = {version = "^0.18.2", optional = true}
+uvicorn = {version = "^0.18.2 || ^0.19.0", optional = true}
 httpx = {version = "^0.23.0", optional = true}
 fasjson-client = {version = "^1.0.7", optional = true}
 fedora-messaging = {version = "^3.1.0", optional = true}
@@ -64,7 +64,7 @@ poetry = "^1.2.0b2"
 black = "^22.6.0"
 isort = "^5.10.1"
 pytest = "^7.1.2"
-pytest-asyncio = "^0.18.3 || ^0.19.0"
+pytest-asyncio = "^0.18.3 || ^0.19.0 || ^0.20.0"
 pytest-black = "^0.3.12"
 pytest-cov = "^3.0.0 || ^4.0.0"
 pytest-flake8 = "^1.1.1"


### PR DESCRIPTION
This contains the updates in #618 which is syntactically wrong (because of an unfixed bug in renovatebot).