### PR TITLE
Fine tune the multiselect settings

### DIFF
--- a/frontend/src/components/rule-edit/tracking-rule/ArtifactsFollowedParams.vue
+++ b/frontend/src/components/rule-edit/tracking-rule/ArtifactsFollowedParams.vue
@@ -47,6 +47,8 @@ const getArtifacts = async (query: string) => {
       :delay="0"
       :min-chars="1"
       :disabled="artifactType === ''"
+      placeholder="Search by artifact name"
+      noOptionsText="No matches on that artifact found"
     />
   </FormKit>
 </template>

--- a/frontend/src/components/rule-edit/tracking-rule/ArtifactsOwnedParams.vue
+++ b/frontend/src/components/rule-edit/tracking-rule/ArtifactsOwnedParams.vue
@@ -10,6 +10,8 @@ const username = userStore.username;
   <UserMultiSelect
     :initialvalue="username ? [username] : []"
     label="Artifacts owned by:"
+    placeholder="Search by FAS Username"
+    nooptionstext="No matches on that username found"
     showArtifactsOwnedSummary
   />
 </template>

--- a/frontend/src/components/rule-edit/tracking-rule/UserMultiSelect.vue
+++ b/frontend/src/components/rule-edit/tracking-rule/UserMultiSelect.vue
@@ -10,6 +10,7 @@ const props = defineProps<{
   label: string;
   showArtifactsOwnedSummary?: boolean;
   placeholder?: string;
+  nooptionstext?: string;
 }>();
 
 const value = ref<string[]>(props.initialvalue);
@@ -33,6 +34,7 @@ const getUsers = async (query: string) => {
     label-class="fw-bold"
     mode="tags"
     :placeholder="props.placeholder"
+    :noOptionsText="props.nooptionstext"
     v-model="value"
     :msOptions="getUsers"
     :close-on-select="false"
@@ -42,6 +44,7 @@ const getUsers = async (query: string) => {
     validation="required"
     :min-chars="3"
     :delay="0"
+    :clearOnSearch="true"
   />
 
   <ArtifactsOwnedSummary

--- a/frontend/src/forms/MultiSelectInputConstants.ts
+++ b/frontend/src/forms/MultiSelectInputConstants.ts
@@ -14,4 +14,6 @@ export const msProps = [
   "object",
   "class",
   "classes",
+  "noOptionsText",
+  "clearOnSearch",
 ];


### PR DESCRIPTION
This really changes 3 things:

1. Previously the text when there was no options (i.e. the user hasnt typed anything or the async search hasnt returned anything) was an unhelpful "the list is empty" this passes the "noOptionsText" param through to the multiselect, so we can set this tring to something a little more helpful, which we also do for tyhe user search and the artifact search.

2. We hadd some more helpful placeholders for the user search and artifact search.

3. finally we add the "clearOnSearch" to the multiselect. This clears all the options when we do a new search. This is primarily to stop the multiselect from showing the list of all options previously loaded when removing text.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>