### PR TITLE
query distgit for artifacts

### DIFF
--- a/devel/ansible/roles/backend/templates/fmn.cfg.j2
+++ b/devel/ansible/roles/backend/templates/fmn.cfg.j2
@@ -6,3 +6,4 @@ OIDC_TOKEN_INFO_ENDPOINT="/TokenInfo"
 OIDC_CLIENT_ID="{{ oidc_client_id }}"
 OIDC_CLIENT_SECRET="{{ oidc_client_secret }}"
 SERVICES__FASJSON_URL=http://fasjson.tinystage.test/fasjson
+SERVICES__DISTGIT_URL=http://src.tinystage.test

--- a/fmn/api/distgit.py
+++ b/fmn/api/distgit.py
@@ -1,0 +1,31 @@
+import logging
+
+from fastapi import Depends
+from httpx import AsyncClient
+
+from ..core.config import Settings, get_settings
+
+log = logging.getLogger(__name__)
+
+
+class DistGitClient:
+    def __init__(self, settings):
+        self.client = AsyncClient(base_url=settings.services.distgit_url, timeout=None)
+
+    async def get_artifacts(self, pattern):
+        response = await self.client.get(
+            "/api/0/projects",
+            params={
+                "pattern": f"*{pattern}*",
+                "short": "true",
+                "fork": "false",
+            },
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        return [project["name"] for project in result["projects"]]
+
+
+def get_distgit_client(settings: Settings = Depends(get_settings)):
+    return DistGitClient(settings)

--- a/fmn/api/handlers/misc.py
+++ b/fmn/api/handlers/misc.py
@@ -1,6 +1,8 @@
 import logging
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
+
+from ..distgit import DistGitClient, get_distgit_client
 
 log = logging.getLogger(__name__)
 
@@ -43,13 +45,7 @@ def get_owned_artifacts(
 
 
 @router.get("/artifacts", response_model=list[str], tags=["misc"])
-def get_artifacts(type: str, name: str):  # pragma: no cover todo
-    # TODO: Get artifacts
-
-    artifacts = []
-
-    artifacts.append(f"foobar-{name}")
-    artifacts.append(f"foo-{name}")
-    artifacts.append(f"bar-{name}")
-
-    return artifacts
+async def get_artifacts(
+    type: str, name: str, distgit_client: DistGitClient = Depends(get_distgit_client)
+):  # pragma: no cover todo
+    return await distgit_client.get_artifacts(pattern=name)

--- a/tests/api/test_distgit.py
+++ b/tests/api/test_distgit.py
@@ -1,0 +1,45 @@
+from unittest import mock
+
+import httpx
+
+from fmn.api import distgit
+
+
+def test_get_distgit_client():
+    settings = distgit.Settings(services={"distgit_url": "http://src.distgit.test"})
+    distgit_client = distgit.get_distgit_client(settings)
+    assert isinstance(distgit_client.client, httpx.AsyncClient)
+    assert distgit_client.client.base_url == settings.services.distgit_url
+
+
+@mock.patch.object(distgit, "AsyncClient")
+async def test_get_artifacts(mock_httpx):
+    mock_httpx.return_value = mock_client = mock.AsyncMock()
+    mock_client.get.return_value.json = mock.Mock()
+    mock_client.get.return_value.json.return_value = {
+        "projects": [
+            {
+                "description": "0ad-data containers",
+                "fullname": "containers/0ad-data",
+                "name": "0ad-data",
+                "namespace": "containers",
+            },
+            {
+                "description": "0install rpms",
+                "fullname": "rpms/0install",
+                "name": "0install",
+                "namespace": "rpms",
+            },
+        ]
+    }
+
+    settings = distgit.Settings(services={"distgit_url": "http://src.distgit.test"})
+    distgit_client = distgit.get_distgit_client(settings)
+
+    artifacts = await distgit_client.get_artifacts("0")
+
+    mock_client.get.assert_awaited_once_with(
+        "/api/0/projects", params={"fork": "false", "pattern": "*0*", "short": "true"}
+    )
+
+    assert artifacts == ["0ad-data", "0install"]


### PR DESCRIPTION
Filed early for feedback on this approach.

still need to tweak how we search for artifacts type (rpm/module/flatpak etc), and need to tweak the frontend too.

it queries the new src.tinystage.test so youll need to provision that in tinystage.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>