### PR TITLE
Don’t block API when accessing backend systems

### DIFF
--- a/fmn/api/fasjson.py
+++ b/fmn/api/fasjson.py
@@ -1,12 +1,67 @@
 import logging
+from collections.abc import Awaitable
+from typing import Any
 
-from fasjson_client import Client as FasjsonClient
 from fastapi import Depends
+from httpx import AsyncClient
+from httpx_gssapi import HTTPSPNEGOAuth
 
 from ..core.config import Settings, get_settings
 
 log = logging.getLogger(__name__)
 
+JSON_DICT = dict[str, Any]
+JSON_RESULT = list[Any] | JSON_DICT
 
-def get_fasjson_client(settings: Settings = Depends(get_settings)):
-    return FasjsonClient(settings.services.fasjson_url)
+
+class FASJSONAsyncProxy:
+    """Asynchronous proxy for the FASJSON API endpoints used in FMN"""
+
+    API_VERSION = "v1"
+
+    def __init__(self, fasjson_url: str):
+        self.client = AsyncClient(
+            base_url=f"{fasjson_url.rstrip('/')}/{self.API_VERSION}",
+            auth=HTTPSPNEGOAuth(),
+            timeout=None,
+        )
+
+    async def get(self, url, **kwargs) -> JSON_RESULT:
+        """Query the API and merge paginated results if applicable."""
+        params = kwargs.pop("params", {})
+
+        complete_result = None
+        partial_result = []
+
+        while complete_result is None:
+            response = await self.client.get(url, params=params, **kwargs)
+            response.raise_for_status()
+
+            result = response.json()
+
+            if "page" in result:
+                partial_result.extend(result["result"])
+                page_number = result["page"]["page_number"]
+                if page_number < result["page"]["total_pages"]:
+                    params["page_number"] = page_number + 1
+                else:
+                    complete_result = partial_result
+            else:
+                if partial_result:
+                    raise RuntimeError("Can't merge paginated with unpaginated result.")
+                complete_result = result["result"]
+
+        return complete_result
+
+    def search_users(self, **kwargs) -> Awaitable[JSON_RESULT]:
+        return self.get("/search/users/", **kwargs)
+
+    def get_user(self, *, username: str, **kwargs) -> Awaitable[JSON_RESULT]:
+        return self.get(f"/users/{username}/", **kwargs)
+
+    def list_user_groups(self, *, username: str, **kwargs) -> Awaitable[JSON_RESULT]:
+        return self.get(f"/users/{username}/groups/", **kwargs)
+
+
+def get_fasjson_proxy(settings: Settings = Depends(get_settings)) -> FASJSONAsyncProxy:
+    return FASJSONAsyncProxy(fasjson_url=settings.services.fasjson_url)

--- a/fmn/api/handlers/misc.py
+++ b/fmn/api/handlers/misc.py
@@ -89,7 +89,7 @@ async def get_artifacts(
 
 
 @router.post("/rule-preview", response_model=list[Notification], tags=["users/rules"])
-def preview_rule(
+async def preview_rule(
     rule: api_models.RulePreview,
     identity: Identity = Depends(get_identity),
     requester: Requester = Depends(gen_requester),
@@ -108,7 +108,7 @@ def preview_rule(
     rule_db.id = 0
     notifs = []
     # TODO make the delta a setting
-    for message in get_last_messages(24):
+    async for message in get_last_messages(24):
         log.debug(f"Processing message: {message.body}")
         for notif in rule_db.handle(message, requester):
             notifs.append(notif)

--- a/poetry.lock
+++ b/poetry.lock
@@ -82,7 +82,7 @@ name = "anyio"
 version = "3.6.2"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6.2"
 
 [package.dependencies]
@@ -677,7 +677,7 @@ name = "h11"
 version = "0.12.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [[package]]
@@ -703,7 +703,7 @@ name = "httpcore"
 version = "0.15.0"
 description = "A minimal low-level HTTP client."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -721,7 +721,7 @@ name = "httpx"
 version = "0.23.0"
 description = "The next generation HTTP client."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -735,6 +735,22 @@ brotli = ["brotli", "brotlicffi"]
 cli = ["click (>=8.0.0,<9.0.0)", "pygments (>=2.0.0,<3.0.0)", "rich (>=10,<13)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (>=1.0.0,<2.0.0)"]
+
+[[package]]
+name = "httpx-gssapi"
+version = "0.1.7"
+description = "A Python GSSAPI authentication handler for HTTPX"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+gssapi = "*"
+httpx = ">=0.16,<0.24"
+
+[package.extras]
+all = ["k5test", "pytest"]
+test = ["k5test", "pytest"]
 
 [[package]]
 name = "hyperlink"
@@ -1630,6 +1646,17 @@ urllib3 = ">=1.25.10"
 tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "types-requests"]
 
 [[package]]
+name = "respx"
+version = "0.20.0"
+description = "A utility for mocking out the Python HTTPX and HTTP Core libraries."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+httpx = ">=0.21.0"
+
+[[package]]
 name = "rfc3339-validator"
 version = "0.1.4"
 description = "A pure python RFC3339 validator"
@@ -1645,7 +1672,7 @@ name = "rfc3986"
 version = "1.5.0"
 description = "Validating URI References per RFC 3986"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 
 [package.dependencies]
@@ -1737,7 +1764,7 @@ name = "sniffio"
 version = "1.3.0"
 description = "Sniff out which async library your code is running under"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [[package]]
@@ -2063,7 +2090,7 @@ test = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
 [extras]
-api = ["fastapi", "uvicorn", "httpx", "SQLAlchemy"]
+api = ["fastapi", "uvicorn", "httpx", "httpx-gssapi", "SQLAlchemy"]
 consumer = ["fedora-messaging", "pika", "fasjson-client", "dogpile.cache", "SQLAlchemy"]
 database = ["SQLAlchemy", "alembic"]
 postgresql = ["psycopg2", "asyncpg"]
@@ -2075,7 +2102,7 @@ sqlite = ["aiosqlite"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "46a9ce855b974b35b26ea75c8b770d01e3f95f7ed46c0593d17edfc88da33a5e"
+content-hash = "0c22df931bdef014b398499f4a80cd0e12d0c010150b71ca64fbafbcbd064ba2"
 
 [metadata.files]
 aio-pika = [
@@ -2623,6 +2650,10 @@ httpcore = [
 httpx = [
     {file = "httpx-0.23.0-py3-none-any.whl", hash = "sha256:42974f577483e1e932c3cdc3cd2303e883cbfba17fe228b0f63589764d7b9c4b"},
     {file = "httpx-0.23.0.tar.gz", hash = "sha256:f28eac771ec9eb4866d3fb4ab65abd42d38c424739e80c08d8d20570de60b0ef"},
+]
+httpx-gssapi = [
+    {file = "httpx-gssapi-0.1.7.tar.gz", hash = "sha256:7bdcbab8725bc15702dd756eec638e36d700e5f534af6f7584ec283c34c8dc69"},
+    {file = "httpx_gssapi-0.1.7-py3-none-any.whl", hash = "sha256:e2d4c595b39702d557bc6f0150186b3d040e04788875a759c92f959f2d0d09a3"},
 ]
 hyperlink = [
     {file = "hyperlink-21.0.0-py2.py3-none-any.whl", hash = "sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4"},
@@ -3180,6 +3211,10 @@ requests-toolbelt = [
 responses = [
     {file = "responses-0.22.0-py3-none-any.whl", hash = "sha256:dcf294d204d14c436fddcc74caefdbc5764795a40ff4e6a7740ed8ddbf3294be"},
     {file = "responses-0.22.0.tar.gz", hash = "sha256:396acb2a13d25297789a5866b4881cf4e46ffd49cc26c43ab1117f40b973102e"},
+]
+respx = [
+    {file = "respx-0.20.0-py2.py3-none-any.whl", hash = "sha256:61e26ddf66b2b0d1bcd78c4e18a06533e50493f8c0179e5542ebfffd3ed3d0c5"},
+    {file = "respx-0.20.0.tar.gz", hash = "sha256:27ef411ca9622ae1e032c3f355506f62de5efe08c4296f64ae2c0621888e710a"},
 ]
 rfc3339-validator = [
     {file = "rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ psycopg2 = {version = "^2.9.3", optional = true}
 asyncpg = {version = "^0.26.0 || ^0.27.0", optional = true}
 alembic = {version = "^1.8.1", optional = true}
 SQLAlchemy = {version = "^1.4.41", optional = true}
+
 # Schema packages
 anitya-schema = {version = "*", optional = true}
 bodhi-messages = {version = "*", optional = true}
@@ -74,7 +75,9 @@ noggin-messages = {version = "*", optional = true}
 nuancier-messages = {version = "*", optional = true}
 pagure-messages = {version = "*", optional = true}
 
-[tool.poetry.dev-dependencies]
+httpx-gssapi = {version = "^0.1.7", optional = true}
+
+[tool.poetry.group.dev.dependencies]
 poetry = "^1.2.0b2"
 black = "^22.6.0"
 isort = "^5.10.1"
@@ -90,12 +93,14 @@ toml = "^0.10.2"
 responses = "^0.21.0 || ^0.22.0"
 pytest-mock = "^3.8.2"
 flake8 = ">=4,<6"
+respx = "^0.20.0"
 
 [tool.poetry.extras]
 api = [
     "fastapi",
     "uvicorn",
     "httpx",
+    "httpx-gssapi",
     "SQLAlchemy",
 ]
 consumer = [

--- a/tests/api/test_fasjson.py
+++ b/tests/api/test_fasjson.py
@@ -1,8 +1,99 @@
+from contextlib import nullcontext
+from unittest import mock
+
+import pytest
+
 from fmn.api import fasjson
 
 
-def test_get_fasjson_client(mocker):
-    settings = fasjson.Settings(services={"fasjson_url": "http://fasjson.test/"})
-    mocker.patch.object(fasjson.FasjsonClient, "_make_bravado_client")
-    client = fasjson.get_fasjson_client(settings)
-    assert client._base_url == settings.services.fasjson_url
+class TestFASJSONAsyncProxy:
+    PAGINATE_TOTAL_PAGES = 5
+    PAGINATE_PER_PAGE = 5
+
+    def test___init__(self):
+        fasjson_url = "http://fasjson.test"
+        proxy = fasjson.FASJSONAsyncProxy(fasjson_url)
+        API_VERSION = fasjson.FASJSONAsyncProxy.API_VERSION
+        assert proxy.client.base_url == f"{fasjson_url}/{API_VERSION.strip('/')}/"
+
+    @classmethod
+    def get_paginated_results(cls, broken=False):
+        per_page = cls.PAGINATE_PER_PAGE
+        total_pages = cls.PAGINATE_TOTAL_PAGES
+        pages = [
+            {
+                "result": [{"boop": i + pageidx * per_page} for i in range(per_page)],
+                "page": {"page_number": pageidx + 1, "total_pages": total_pages},
+            }
+            for pageidx in range(total_pages)
+        ]
+        if broken:
+            pages[-1] = {"result": {"this is": "broken"}}
+        return pages
+
+    @classmethod
+    def get_paginated_responses(cls, broken=False):
+        responses = []
+
+        for result in cls.get_paginated_results(broken=broken):
+            response = mock.Mock()
+            response.json.return_value = result
+            responses.append(response)
+
+        return responses
+
+    @pytest.mark.parametrize("testcase", ("single", "paginated", "broken"))
+    async def test_get(self, testcase):
+        fasjson_url = "http://fasjson.test"
+        proxy = fasjson.FASJSONAsyncProxy(fasjson_url)
+        proxy.client = client = mock.AsyncMock()
+
+        expectation = nullcontext()
+
+        if "single" in testcase:
+            response = mock.Mock()
+            response.json.return_value = {"result": {"boop": "yes"}}
+            client.get.return_value = response
+        elif "paginated" in testcase:
+            client.get.side_effect = self.get_paginated_responses()
+        elif "broken" in testcase:
+            client.get.side_effect = self.get_paginated_responses(broken=True)
+            expectation = pytest.raises(RuntimeError)
+
+        with expectation:
+            result = await proxy.get("/foo")
+
+        if "single" in testcase:
+            assert result == {"boop": "yes"}
+        elif "paginated" in testcase:
+            assert isinstance(result, list)
+            assert len(result) == self.PAGINATE_TOTAL_PAGES * self.PAGINATE_PER_PAGE
+            assert all(i == item["boop"] for i, item in enumerate(result))
+
+    @pytest.mark.parametrize(
+        "method, processed_kwargs, passed_through_kwargs, expected_path",
+        (
+            ("search_users", {}, {"username": "foo"}, "/search/users/"),
+            ("get_user", {"username": "boop"}, {}, "/users/boop/"),
+            ("list_user_groups", {"username": "boop"}, {}, "/users/boop/groups/"),
+        ),
+    )
+    def test_wrapper_method(self, method, processed_kwargs, passed_through_kwargs, expected_path):
+        fasjson_url = "http://fasjson.test"
+        proxy = fasjson.FASJSONAsyncProxy(fasjson_url)
+        proxy.get = mock.Mock()
+        proxy.get.return_value = sentinel = object()
+
+        retval = getattr(proxy, method)(**(processed_kwargs | passed_through_kwargs))
+
+        assert retval is sentinel
+        proxy.get.assert_called_once_with(expected_path, **passed_through_kwargs)
+
+
+def test_get_fasjson_proxy():
+    settings = mock.Mock()
+    settings.services.fasjson_url = "http://foo"
+
+    proxy = fasjson.get_fasjson_proxy(settings)
+
+    assert str(proxy.client.base_url).rstrip("/") == "http://foo/v1"

--- a/tests/api/test_handlers.py
+++ b/tests/api/test_handlers.py
@@ -2,6 +2,7 @@ import re
 
 import pytest
 from fastapi import status
+from httpx import Response
 from sqlalchemy.exc import NoResultFound
 
 from fmn.api import api_models
@@ -280,25 +281,29 @@ class TestPreviewRule(BaseTestAPIV1Handler):
     }
 
     def test_preview_basic(
-        self, mocker, responses_mocker, client, api_identity, make_mocked_message
+        self, mocker, async_respx_mocker, client, api_identity, make_mocked_message
     ):
         mocker.patch("fmn.rules.services.fasjson.Client")
-        responses_mocker.get(
-            "https://apps.fedoraproject.org/datagrepper/v2/search?page=1&delta=86400",
-            json={
-                "raw_messages": [
-                    {
-                        "id": "id-foobar",
-                        "topic": "topic.foobar",
-                        "headers": {
-                            "fedora_messaging_schema": "testmessage",
-                            "sent-at": "2022-01-01T00:00:00+00:00",
-                        },
-                        "body": {"app": "koji", "packages": ["foobar"]},
-                    }
-                ],
-                "pages": 1,
-            },
+        async_respx_mocker.get(
+            "https://apps.fedoraproject.org/datagrepper/v2/search?page=1&delta=86400"
+        ).mock(
+            return_value=Response(
+                status.HTTP_200_OK,
+                json={
+                    "raw_messages": [
+                        {
+                            "id": "id-foobar",
+                            "topic": "topic.foobar",
+                            "headers": {
+                                "fedora_messaging_schema": "testmessage",
+                                "sent-at": "2022-01-01T00:00:00+00:00",
+                            },
+                            "body": {"app": "koji", "packages": ["foobar"]},
+                        }
+                    ],
+                    "pages": 1,
+                },
+            )
         )
         response = client.post(f"{self.path}/rule-preview", json=self._dummy_rule_dict)
 
@@ -324,58 +329,62 @@ class TestPreviewRule(BaseTestAPIV1Handler):
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_dg_url_fix(self, mocker, responses_mocker):
+    async def test_dg_url_fix(self, mocker, async_respx_mocker):
         settings = get_settings()
         settings.services.datagrepper_url = "http://datagrepper.test"
         mocker.patch("fmn.api.handlers.utils.get_settings", return_value=settings)
-        resp = responses_mocker.get(
-            re.compile(r"http://datagrepper\.test/v2/search.*"),
-            json={
-                "raw_messages": [],
-                "pages": 0,
-            },
+        resp = async_respx_mocker.get(re.compile(r"http://datagrepper\.test/v2/search.*")).mock(
+            return_value=Response(status.HTTP_200_OK, json={"raw_messages": [], "pages": 0})
         )
-        messages = list(get_last_messages(1))
+        messages = [msg async for msg in get_last_messages(1)]
         assert messages == []
         assert resp.call_count == 1
 
-    def test_get_last_messages_pages(self, mocker, responses_mocker, make_mocked_message):
-        rsp1 = responses_mocker.get(
-            "https://apps.fedoraproject.org/datagrepper/v2/search?page=1&delta=3600",
-            json={
-                "raw_messages": [
-                    {
-                        "id": "id-foobar-1",
-                        "topic": "topic.foobar",
-                        "headers": {
-                            "fedora_messaging_schema": "testmessage",
-                            "sent-at": "2022-01-01T00:00:00+00:00",
-                        },
-                        "body": {"app": "koji", "packages": ["foobar"]},
-                    }
-                ],
-                "pages": 2,
-            },
+    async def test_get_last_messages_pages(self, mocker, async_respx_mocker, make_mocked_message):
+        rsp1 = async_respx_mocker.get(
+            "https://apps.fedoraproject.org/datagrepper/v2/search?page=1&delta=3600"
+        ).mock(
+            return_value=Response(
+                status.HTTP_200_OK,
+                json={
+                    "raw_messages": [
+                        {
+                            "id": "id-foobar-1",
+                            "topic": "topic.foobar",
+                            "headers": {
+                                "fedora_messaging_schema": "testmessage",
+                                "sent-at": "2022-01-01T00:00:00+00:00",
+                            },
+                            "body": {"app": "koji", "packages": ["foobar"]},
+                        }
+                    ],
+                    "pages": 2,
+                },
+            )
         )
-        rsp2 = responses_mocker.get(
-            "https://apps.fedoraproject.org/datagrepper/v2/search?page=2&delta=3600",
-            json={
-                "raw_messages": [
-                    {
-                        "id": "id-foobar-2",
-                        "topic": "topic.foobar",
-                        "headers": {
-                            "fedora_messaging_schema": "testmessage",
-                            "sent-at": "2022-01-01T00:00:00+00:00",
-                        },
-                        "body": {"app": "koji", "packages": ["foobar"]},
-                    }
-                ],
-                "pages": 2,
-            },
+        rsp2 = async_respx_mocker.get(
+            "https://apps.fedoraproject.org/datagrepper/v2/search?page=2&delta=3600"
+        ).mock(
+            return_value=Response(
+                status.HTTP_200_OK,
+                json={
+                    "raw_messages": [
+                        {
+                            "id": "id-foobar-2",
+                            "topic": "topic.foobar",
+                            "headers": {
+                                "fedora_messaging_schema": "testmessage",
+                                "sent-at": "2022-01-01T00:00:00+00:00",
+                            },
+                            "body": {"app": "koji", "packages": ["foobar"]},
+                        }
+                    ],
+                    "pages": 2,
+                },
+            )
         )
 
-        messages = list(get_last_messages(1))
+        messages = [msg async for msg in get_last_messages(1)]
 
         assert len(messages) == 2
         assert rsp1.call_count == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ JSONSCHEMA_HYPERSCHEMA_JSON = TESTDATA / "jsonschema_hyperschema.json"
 
 
 @pytest.fixture
-def mocked_responses():
+def responses_mocker():
     with responses.mock as rm:
         yield rm
 
@@ -46,7 +46,7 @@ def fasjson_url() -> str:
 
 
 @pytest.fixture
-def mocked_fasjson(mocked_responses, fasjson_url):
+def mocked_fasjson(responses_mocker, fasjson_url):
     spec_v1_url = fasjson_url + "/specs/v1.json"
 
     with (
@@ -69,12 +69,6 @@ def mocked_fasjson_client(mocker, mocked_fasjson):
         real_init(self, url, **kwargs)
 
     mocker.patch.object(Client, "__init__", unauth_init)
-
-
-@pytest.fixture
-def responses_mocker():
-    with responses.mock as rm:
-        yield rm
 
 
 @pytest.fixture
@@ -227,8 +221,8 @@ def fasjson_group_data():
 
 
 @pytest.fixture
-def fasjson_user(mocked_responses, fasjson_user_data, fasjson_url):
-    mocked_responses.get(
+def fasjson_user(responses_mocker, fasjson_user_data, fasjson_url):
+    responses_mocker.get(
         f"{fasjson_url}/v1/users/{fasjson_user_data['username']}/",
         json={"result": fasjson_user_data},
     )
@@ -237,8 +231,8 @@ def fasjson_user(mocked_responses, fasjson_user_data, fasjson_url):
 
 
 @pytest.fixture
-def fasjson_groups(mocked_responses, fasjson_user_data, fasjson_group_data, fasjson_url):
-    mocked_responses.get(
+def fasjson_groups(responses_mocker, fasjson_user_data, fasjson_group_data, fasjson_url):
+    responses_mocker.get(
         f"{fasjson_url}/v1/users/{fasjson_user_data['username']}/groups/",
         json={"result": fasjson_group_data},
     )


### PR DESCRIPTION
```
commit cdbf914302f969b5a4419c44d370e1d06c8675cb
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Nov 14 16:04:06 2022 +0100

    Consolidate mocked_responses and responses_mocker
    
    Both fixtures do the same thing.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 8966649b7c6699ad5e7c154fefa1e2d399f16fac
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Nov 3 09:20:28 2022 +0100

    API: Implement and use async FASJSON proxy
    
    This replaces fasjson_client in the API which is synchronous and would
    block API requests.
    
    Related: #621
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 62c084b51a715f285a53ffbdb5be200e3bca7432
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Nov 14 17:35:23 2022 +0100

    Access datagrepper asynchronously from the API
    
    Related: #621
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```