### PR TITLE
Add s2i integration

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+# The assemble script builds the application artifacts from a source and
+# places them into appropriate directories inside the image.
+
+# Execute the default S2I script
+. /usr/libexec/s2i/assemble
+
+set -e
+
+install_tool "micropipenv" "[toml]"
+
+micropipenv install --deploy
+
+# Now install the root project too, micropipenv does not do that
+pip install . --no-deps
+
+# set permissions for any installed artifacts
+fix-permissions /opt/app-root -P

--- a/.s2i/environment
+++ b/.s2i/environment
@@ -1,0 +1,4 @@
+UPGRADE_PIP_TO_LATEST=true
+# APP_SCRIPT=.s2i/run-api.sh
+# APP_SCRIPT=.s2i/run-consumer.sh
+# APP_SCRIPT=.s2i/run-sender.sh

--- a/.s2i/run-api.sh
+++ b/.s2i/run-api.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# We install the app in a specific virtualenv:
+export PATH=/opt/app-root/src/.local/venvs/fmn/bin:$PATH
+
+# Run the application
+uvicorn fmn.api.main:app --env-file /etc/fmn/fmn.cfg --host 0.0.0.0

--- a/.s2i/run-consumer.sh
+++ b/.s2i/run-consumer.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# We install the app in a specific virtualenv:
+export PATH=/opt/app-root/src/.local/venvs/fmn/bin:$PATH
+
+# Run the application
+fedora-messaging --conf /etc/fmn/consumer.toml consume --callback fmn.consumer:Consumer

--- a/.s2i/run-sender.sh
+++ b/.s2i/run-sender.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# We install the app in a specific virtualenv:
+export PATH=/opt/app-root/src/.local/venvs/fmn/bin:$PATH
+
+# Run the application
+fmn-sender --config /etc/fmn/sender.toml

--- a/.s2iignore
+++ b/.s2iignore
@@ -1,0 +1,4 @@
+.tox
+.pytest_cache
+.vagrant
+tests


### PR DESCRIPTION
This adds the files necessary for Source 2 Image integration, that OpenShift will use to build the image to run in pods.

For testing, build the image with:
```
s2i build . quay.io/fedora/python-310 fmn-test --copy --rm
```

There will be 3 possible ways to run the image:

- with `APP_SCRIPT=.s2i/run-api.sh` to run the API
- with `APP_SCRIPT=.s2i/run-consumer.sh` to run the consumer
- with `APP_SCRIPT=.s2i/run-sender.sh` to run the sender