### PR TITLE
Fix fasjson wrapper and related

### DIFF
--- a/fmn/api/handlers/users.py
+++ b/fmn/api/handlers/users.py
@@ -17,10 +17,10 @@ router = APIRouter(prefix="/users")
 
 @router.get("", response_model=list[str], tags=["users"])
 async def get_users(
-    search: str,
+    search: str = None,
     identity: Identity = Depends(get_identity_optional),
     fasjson_proxy: FASJSONAsyncProxy = Depends(get_fasjson_proxy),
-):  # pragma: no cover todo
+):
     if not search:
         if identity and identity.name:
             return [identity.name]

--- a/fmn/api/handlers/users.py
+++ b/fmn/api/handlers/users.py
@@ -42,7 +42,7 @@ async def get_user_info(username, fasjson_proxy: FASJSONAsyncProxy = Depends(get
 
 @router.get("/{username}/groups", tags=["users"])
 async def get_user_groups(username, fasjson_proxy: FASJSONAsyncProxy = Depends(get_fasjson_proxy)):
-    return [g["groupname"] for g in await fasjson_proxy.list_user_groups(username=username)]
+    return [g["groupname"] for g in await fasjson_proxy.get_user_groups(username=username)]
 
 
 @router.get("/{username}/destinations", response_model=list[api_models.Destination], tags=["users"])

--- a/tests/api/test_fasjson.py
+++ b/tests/api/test_fasjson.py
@@ -6,6 +6,13 @@ import pytest
 from fmn.api import fasjson
 
 
+@pytest.fixture
+def proxy(fasjson_url):
+    proxy = fasjson.FASJSONAsyncProxy(fasjson_url)
+    proxy.client = mock.AsyncMock()
+    return proxy
+
+
 class TestFASJSONAsyncProxy:
     PAGINATE_TOTAL_PAGES = 5
     PAGINATE_PER_PAGE = 5
@@ -42,52 +49,74 @@ class TestFASJSONAsyncProxy:
 
         return responses
 
-    @pytest.mark.parametrize("testcase", ("single", "paginated", "broken"))
-    async def test_get(self, testcase):
-        fasjson_url = "http://fasjson.test"
-        proxy = fasjson.FASJSONAsyncProxy(fasjson_url)
-        proxy.client = client = mock.AsyncMock()
+    async def test_get(self, proxy):
+        proxy.client.get.return_value = response = mock.Mock()
+        response.json.return_value = sentinel = object()
 
+        result = await proxy.get("url", foo="bar")
+
+        proxy.client.get.assert_awaited_once_with("url", foo="bar")
+        response.raise_for_status.assert_called_once_with()
+        assert result is sentinel
+
+    @mock.patch("fmn.api.fasjson.FASJSONAsyncProxy.get")
+    async def test_get_result(self, proxy_get, proxy):
+        sentinel = object()
+        proxy_get.return_value = {"result": sentinel}
+
+        result = await proxy.get_result("boo")
+
+        proxy_get.assert_awaited_once_with("boo")
+        assert result is sentinel
+
+    @pytest.mark.parametrize("testcase", ("success", "failure-missing-pagination"))
+    async def test_get_paginated(self, testcase, proxy):
         expectation = nullcontext()
 
-        if "single" in testcase:
-            response = mock.Mock()
-            response.json.return_value = {"result": {"boop": "yes"}}
-            client.get.return_value = response
-        elif "paginated" in testcase:
-            client.get.side_effect = self.get_paginated_responses()
-        elif "broken" in testcase:
-            client.get.side_effect = self.get_paginated_responses(broken=True)
-            expectation = pytest.raises(RuntimeError)
+        if "success" in testcase:
+            proxy.client.get.side_effect = self.get_paginated_responses()
+        else:
+            proxy.client.get.side_effect = self.get_paginated_responses(broken=True)
+            expectation = pytest.raises(ValueError)
 
         with expectation:
-            result = await proxy.get("/foo")
+            result = [x async for x in proxy.get_paginated("/foo")]
 
-        if "single" in testcase:
-            assert result == {"boop": "yes"}
-        elif "paginated" in testcase:
+        if "success" in testcase:
             assert isinstance(result, list)
             assert len(result) == self.PAGINATE_TOTAL_PAGES * self.PAGINATE_PER_PAGE
             assert all(i == item["boop"] for i, item in enumerate(result))
 
     @pytest.mark.parametrize(
-        "method, processed_kwargs, passed_through_kwargs, expected_path",
+        "method, kwargs, params, expected_path, is_iterator",
         (
-            ("search_users", {}, {"username": "foo"}, "/search/users/"),
-            ("get_user", {"username": "boop"}, {}, "/users/boop/"),
-            ("list_user_groups", {"username": "boop"}, {}, "/users/boop/groups/"),
+            ("search_users", {}, {"username": "foo"}, "/search/users/", True),
+            ("get_user", {"username": "boop"}, {}, "/users/boop/", False),
+            ("get_user_groups", {"username": "boop"}, {}, "/users/boop/groups/", False),
         ),
     )
-    def test_wrapper_method(self, method, processed_kwargs, passed_through_kwargs, expected_path):
+    async def test_wrapper_method(self, method, kwargs, params, expected_path, is_iterator):
         fasjson_url = "http://fasjson.test"
         proxy = fasjson.FASJSONAsyncProxy(fasjson_url)
-        proxy.get = mock.Mock()
-        proxy.get.return_value = sentinel = object()
+        sentinel = object()
+        if is_iterator:
+            proxy.get_paginated = mock.MagicMock()
+            proxy.get_paginated.return_value.__aiter__.return_value = [sentinel]
+        else:
+            proxy.get_result = mock.AsyncMock()
+            proxy.get_result.return_value = sentinel
 
-        retval = getattr(proxy, method)(**(processed_kwargs | passed_through_kwargs))
+        passed_through_kwargs = {"params": params} if params else {}
 
-        assert retval is sentinel
-        proxy.get.assert_called_once_with(expected_path, **passed_through_kwargs)
+        coro = getattr(proxy, method)(**(kwargs | params))
+        if is_iterator:
+            retval = [x async for x in coro]
+            assert retval == [sentinel]
+            proxy.get_paginated.assert_called_once_with(expected_path, **passed_through_kwargs)
+        else:
+            retval = await coro
+            assert retval is sentinel
+            proxy.get_result.assert_called_once_with(expected_path, **passed_through_kwargs)
 
 
 def test_get_fasjson_proxy():


### PR DESCRIPTION
```
commit 8f89c80639a358aa5e6dd27e40fa7a752831955a
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Nov 16 16:43:09 2022 +0100

    Refactor FASJSONAsyncProxy
    
    How it was used in request handlers wasn’t tested, therefore they used
    the class improperly. This separates simply calling and endpoint and
    "unpaginating" better and implements the latter as an (async) iterator.
    
    Fixes: #656
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit aa82fda2dadaa6dffb915328ac705cb3a7052fc4
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Nov 16 16:50:19 2022 +0100

    Test get_users() and allow not specifying search
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```