### PR TITLE
Tweak the add destination button

### DIFF
--- a/frontend/src/components/rule-edit/generation-rule/GenerationRuleList.vue
+++ b/frontend/src/components/rule-edit/generation-rule/GenerationRuleList.vue
@@ -79,11 +79,14 @@ const editedRule = computed(() =>
       <div class="text-center">
         <CButton
           @click.prevent="() => handleButtonClicked(-1)"
-          :color="generation_rules.length === 0 ? 'primary' : 'secondary'"
+          :color="generation_rules.length === 0 ? 'primary' : 'outline-primary'"
           class="my-1"
         >
           <CIcon :icon="cilPlus" />
-          Add Destination
+          <template v-if="generation_rules.length === 0"
+            >Add Destination</template
+          >
+          <template v-else>Add Another Destination</template>
         </CButton>
       </div>
     </CListGroupItem>


### PR DESCRIPTION
Slightly tweak the add destination button to be the primary outline and "add another destination" when destinations > 0

Signed-off-by: Ryan Lerch <rlerch@redhat.com>