### PR TITLE
Fix getting projects by group

### DIFF
--- a/fmn/api/distgit.py
+++ b/fmn/api/distgit.py
@@ -32,14 +32,13 @@ class DistGitClient:
                 artifacts.append({"type": p["namespace"], "name": p["name"]})
 
         artifacts = []
-        endpoint = "/api/0/projects"
         for name in names:
-            params = {"short": "true", "fork": "false"}
-
             if user_or_group == "user":
-                params["owner"] = name
+                params = {"short": "true", "fork": "false", "page": 1, "owner": name}
+                endpoint = "/api/0/projects"
             elif user_or_group == "group":
-                params["username"] = f"@{name}"
+                params = {"projects": "true", "page": 1}
+                endpoint = f"/api/0/group/{name}"
             else:
                 raise ValueError("Argument user_or_group must be either user or group")
 

--- a/fmn/rules/services/distgit.py
+++ b/fmn/rules/services/distgit.py
@@ -60,8 +60,8 @@ class DistGitService:
         elif user_or_group == "group":
             projects = self._all_values(
                 "projects",
-                f"{self.url}api/0/projects",
-                {"namespace": artifact_type, "username": f"@{name}", "short": "1"},
+                f"{self.url}api/0/group/{name}",
+                {"projects": "true"},
             )
         else:
             raise ValueError("Argument user_or_group must be either user or group, duh.")

--- a/tests/api/test_handlers.py
+++ b/tests/api/test_handlers.py
@@ -321,9 +321,12 @@ class TestMisc(BaseTestAPIV1Handler):
         # async_respx_mocker.route(host="distgit.test").pass_through()
 
         if ownertype == "user":
+            distgit_endpoint = f"{settings.services.distgit_url}/api/0/projects"
             params = {"fork": "false", "short": "true", "page": 1, "owner": "dudemcpants"}
         elif ownertype == "group":
-            params = {"fork": "false", "short": "true", "page": 1, "username": "@dudegroup"}
+            name = "dudegroup"
+            distgit_endpoint = f"{settings.services.distgit_url}/api/0/group/{name}"
+            params = {"projects": "true", "page": 1}
 
         distgit_json_response = {
             "pagination": {
@@ -345,9 +348,7 @@ class TestMisc(BaseTestAPIV1Handler):
             ],
         }
 
-        route = async_respx_mocker.get(
-            f"{settings.services.distgit_url}/api/0/projects", params=params
-        ).mock(
+        route = async_respx_mocker.get(distgit_endpoint, params=params).mock(
             side_effect=[
                 Response(
                     status.HTTP_200_OK,


### PR DESCRIPTION
Previously, we were using the following distgit/pagure endpoint to return a list of projects that a group has commit access to:

/api/0/projects?username=@mygroupname

while this does work to return a list of projects that a user has commit access to (without the @ prefix) i can't find any mention of the @ prefix to denote a group in the pagure docs, and testing thge API with this endpoint and the @ prefix returned nothing.

Therefore, this PR re-implements this endpoint to use:

/api/0/group/mygroupname?projects=true

to return a list of projects the group has commit access to.

Additionally, note that this changes it in the sync rules code, as well as the async API code.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>