### PR TITLE
Don’t block API when sending bus messages

### DIFF
--- a/fmn/api/messaging.py
+++ b/fmn/api/messaging.py
@@ -1,8 +1,10 @@
+import asyncio
 import logging
 import sys
 import traceback
 
 import backoff
+from fastapi.concurrency import run_in_threadpool
 from fedora_messaging import api
 from fedora_messaging import exceptions as fm_exceptions
 
@@ -13,19 +15,21 @@ def backoff_hdlr(details):
     log.warning(f"Publishing message failed. Retrying. {traceback.format_tb(sys.exc_info()[2])}")
 
 
+def giveup_hdlr(details):
+    log.error(f"Publishing message failed. Giving up. {traceback.format_tb(sys.exc_info()[2])}")
+
+
 @backoff.on_exception(
     backoff.expo,
     (fm_exceptions.ConnectionException, fm_exceptions.PublishException),
     max_tries=3,
     on_backoff=backoff_hdlr,
+    on_giveup=giveup_hdlr,
 )
 def _publish(message):
     api.publish(message)
 
 
-def publish(message):
-    try:
-        _publish(message)
-    except (fm_exceptions.BaseException):
-        log.error(f"Publishing message failed. Giving up. {traceback.format_tb(sys.exc_info()[2])}")
-        return
+async def publish(message):
+    # Fire and forget
+    asyncio.ensure_future(run_in_threadpool(_publish, message=message))

--- a/tests/api/test_messaging.py
+++ b/tests/api/test_messaging.py
@@ -1,17 +1,34 @@
+from unittest import mock
+
+import pytest
 from fedora_messaging import exceptions as fm_exceptions
 
 from fmn.api import messaging
 from fmn.messages.rule import RuleCreateV1
 
 
-def test_publish(mocker):
+def test__publish(mocker):
     api_publish = mocker.patch("fedora_messaging.api.publish")
-    messaging.publish(RuleCreateV1({"rule": {}, "user": {}}))
+    messaging._publish(RuleCreateV1({"rule": {}, "user": {}}))
     api_publish.assert_called_once()
 
 
-def test_publish_with_errors(mocker):
+def test__publish_with_errors(mocker):
     api_publish = mocker.patch("fedora_messaging.api.publish")
     api_publish.side_effect = fm_exceptions.ConnectionException()
-    messaging.publish(RuleCreateV1({"rule": {}, "user": {}}))
+    with pytest.raises(fm_exceptions.ConnectionException):
+        messaging._publish(RuleCreateV1({"rule": {}, "user": {}}))
     assert api_publish.call_count == 3
+
+
+async def test_publish(mocker):
+    run_in_threadpool = mocker.patch("fmn.api.messaging.run_in_threadpool", new=mock.MagicMock())
+    run_in_threadpool.return_value = awaitable_sentinel = object()
+    ensure_future = mocker.patch("asyncio.ensure_future")
+
+    message = RuleCreateV1({"rule": {}, "user": {}})
+
+    await messaging.publish(message)
+
+    run_in_threadpool.assert_called_with(messaging._publish, message=message)
+    ensure_future.assert_called_with(awaitable_sentinel)


### PR DESCRIPTION
Bus messages are sent in a FastAPI background task, which are executed after an API call has been serviced. However, this still blocks the (implicit) DB commit from the `gen_db_session()` dependency as `fedora_messaging` is synchronous code.

With this change, the synchronous code is run in the FastAPI thread pool and not being awaited.

In the course, move logging the final exception when backoff attempts are exceeded to a handler function instead of dealing with it on our own.

Fixes: #678

Signed-off-by: Nils Philippsen <nils@redhat.com>