### PR TITLE
Fix broken consumer tests

### DIFF
--- a/tests/consumer/test_consumer.py
+++ b/tests/consumer/test_consumer.py
@@ -59,7 +59,7 @@ def test_consumer_call_not_tracked(
     c = Consumer()
     message = make_mocked_message(topic="dummy.topic", body={"foo": "bar"})
     c(message)
-    mocked_cache.invalidate_on_message.assert_called_with(message)
+    mocked_cache.invalidate_on_message.assert_called_with(message, c.db, c._requester)
     c._requester.invalidate_on_message.assert_called_with(message)
     c.send_queue.send.assert_not_called()
 


### PR DESCRIPTION
Commit bb4133fb9a7cf2983a3e784afa7296bc865f514c changed how invalidate_on_message() is invoked on the cache object, this updates a test using it.

Signed-off-by: Nils Philippsen <nils@redhat.com>