### PR TITLE
Correctly push to root rather than rules

### DIFF
--- a/frontend/src/components/NewRuleForm.vue
+++ b/frontend/src/components/NewRuleForm.vue
@@ -37,7 +37,7 @@ const handleSubmit = async (data: Rule, form: FormKitNode | undefined) => {
       title: "Rule created",
       content: `Rule "${response.name}" has been successfully created.`,
     });
-    router.push("/rules");
+    router.push("/");
   } catch (err) {
     const error = err as AxiosError<PostError>;
     console.log("Got error response from server:", error);

--- a/frontend/src/components/RuleEditForm.vue
+++ b/frontend/src/components/RuleEditForm.vue
@@ -34,7 +34,7 @@ const handleSubmit = async (data: Rule, form: FormKitNode | undefined) => {
       title: "Rule edited",
       content: `Rule "${response.name}" has been successfully edited.`,
     });
-    router.push("/rules");
+    router.push("/");
   } catch (err) {
     const error = err as AxiosError<PostError>;
     console.log("Got error response from server:", error);


### PR DESCRIPTION
Previously, we removed the rules page, and now just use the root page to show the rules. However when creating or editing a rule, we were still redirecting back to /rules. This commit fixes that issue.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>