### PR TITLE
Move the Delete rule button into the rule redit page

### DIFF
--- a/frontend/src/components/RuleListItem.vue
+++ b/frontend/src/components/RuleListItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { CButton, CListGroupItem } from "@coreui/bootstrap-vue";
-import { cilPen, cilTrash } from "@coreui/icons";
+import { CListGroupItem } from "@coreui/bootstrap-vue";
+import { cilPen } from "@coreui/icons";
 import { CIcon } from "@coreui/icons-vue";
 
 import { TRACKING_RULES } from "../api/constants";
@@ -10,14 +10,6 @@ import DestinationTag from "./DestinationTag.vue";
 const props = defineProps<{
   rule: Rule;
 }>();
-
-const emit = defineEmits<{
-  (e: "delete", rule: Rule): void;
-}>();
-
-const handleDeleteClicked = async () => {
-  emit("delete", props.rule);
-};
 
 const tracking_rule = TRACKING_RULES.find(
   (o) => o.name === props.rule.tracking_rule.name
@@ -70,14 +62,6 @@ const tracking_rule = TRACKING_RULES.find(
       >
         <CIcon :icon="cilPen" />
       </router-link>
-      <CButton
-        @click.prevent="handleDeleteClicked"
-        color="danger"
-        variant="outline"
-        class="ms-1"
-      >
-        <CIcon :icon="cilTrash" />
-      </CButton>
     </div>
   </CListGroupItem>
 </template>

--- a/frontend/src/components/RulesList.vue
+++ b/frontend/src/components/RulesList.vue
@@ -1,15 +1,12 @@
 <script setup lang="ts">
 import { TRACKING_RULES } from "@/api/constants";
-import { useDeleteRuleMutation } from "@/api/rules";
-import type { PostError, Rule, TrackingRule } from "@/api/types";
-import { useToastStore } from "@/stores/toast";
+import type { Rule, TrackingRule } from "@/api/types";
 import {
   CCard,
   CCardBody,
   CListGroup,
   CListGroupItem,
 } from "@coreui/bootstrap-vue";
-import type { AxiosError } from "axios";
 import { computed, ref } from "vue";
 import RuleListItem from "../components/RuleListItem.vue";
 
@@ -26,37 +23,6 @@ const filteringOptions = computed(() => [
       .filter((o) => typeof o !== "undefined") as TrackingRule[]
   ),
 ]);
-
-// Deleting rules
-const toastStore = useToastStore();
-const { mutateAsync } = useDeleteRuleMutation();
-
-const handleDelete = async (rule: Rule) => {
-  console.log("Will delete the rule:", rule);
-  try {
-    await mutateAsync(rule.id);
-    // Success!
-    toastStore.addToast({
-      color: "success",
-      title: "Rule deleted",
-      content: `Rule "${rule.name}" has been successfully deleted.`,
-    });
-  } catch (err) {
-    const error = err as AxiosError<PostError>;
-    console.log("Got error response from server:", error);
-    if (!error.response) {
-      return;
-    }
-    const errors = error.response.data.detail
-      .map((e) => `${e.loc[-1]}: ${e.msg}`)
-      .join("\n");
-    toastStore.addToast({
-      color: "danger",
-      title: "Deletion failed!",
-      content: `Rule "${rule.name}" could not be deleted!\n${errors}`,
-    });
-  }
-};
 </script>
 
 <template>
@@ -99,7 +65,6 @@ const handleDelete = async (rule: Rule) => {
         )"
         :key="rule.id"
         :rule="rule"
-        @delete="handleDelete"
       />
     </CListGroup>
   </template>


### PR DESCRIPTION
Move the delete rule button into the rule edit page. This is where we are going to put the disable rule switch too, as there were becoming too many actions on the rules list page.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>