### PR TITLE
Vagrant: Let sender talk to fmn host on RabbitMQ

### DIFF
--- a/devel/ansible/roles/sender/files/config.toml
+++ b/devel/ansible/roles/sender/files/config.toml
@@ -1,6 +1,6 @@
 # A sample configuration for the FMN sender. This file is in the TOML format.
 
-amqp_url = "amqp://tinystage.tinystage.test/%2Ffmn"
+amqp_url = "amqp://fedoramessages:fedoramessages@tinystage.tinystage.test/%2Ffmn"
 queue = "email"
 
 [handler]


### PR DESCRIPTION
Previously, it used no credentials which means connecting as "guest”.

Signed-off-by: Nils Philippsen <nils@redhat.com>