### PR TITLE
Vagrant: Let API talk to FASJSON via Kerberos

### DIFF
--- a/devel/ansible/roles/api/files/fmn-api.service
+++ b/devel/ansible/roles/api/files/fmn-api.service
@@ -5,8 +5,8 @@ Wants=network-online.target
 
 [Service]
 User=vagrant
-Environment=
-    GSS_USE_PROXY=yes
+Environment= \
+    GSS_USE_PROXY=yes \
     FEDORA_MESSAGING_CONF=/etc/fmn/api.toml
 WorkingDirectory=/home/vagrant/fmn
 ExecStart=poetry run uvicorn fmn.api.main:app \


### PR DESCRIPTION
Previously, the fmn-api.service unit file was usable (systemctl/systemd didn’t complain), but the environment settings weren’t effective. This caused fasjson to refuse serving requests made by the API backend.

Signed-off-by: Nils Philippsen <nils@redhat.com>