### PR TITLE
Count the generated notifications and display them in the UI

### DIFF
--- a/fmn/api/api_models.py
+++ b/fmn/api/api_models.py
@@ -76,6 +76,7 @@ class Rule(BaseModel):
     disabled: bool = False
     tracking_rule: TrackingRule
     generation_rules: list[GenerationRule]
+    generated_last_week: int = 0
 
 
 class GenerationRulePreview(GenerationRule):

--- a/fmn/database/migrations/versions/59e22969e199_add_generated_table.py
+++ b/fmn/database/migrations/versions/59e22969e199_add_generated_table.py
@@ -1,0 +1,34 @@
+"""Add the generated table
+
+Revision ID: 59e22969e199
+Revises: a6c12ef04ee5
+Create Date: 2023-02-03 14:04:42.631498
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "59e22969e199"
+down_revision = "a6c12ef04ee5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "generated",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("rule_id", sa.Integer(), nullable=False),
+        sa.Column("when", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.Column("count", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["rule_id"], ["rules.id"], name=op.f("generated_rule_id_rules_fkey"), ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("generated_pkey")),
+    )
+    op.create_index(op.f("generated_when_index"), "generated", ["when"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("generated_when_index"), table_name="generated")
+    op.drop_table("generated")

--- a/fmn/database/model/__init__.py
+++ b/fmn/database/model/__init__.py
@@ -1,5 +1,6 @@
 from .destination import Destination  # noqa: F401
 from .filter import Filter  # noqa: F401
+from .generated import Generated  # noqa: F401
 from .generation_rule import GenerationRule  # noqa: F401
 from .rule import Rule  # noqa: F401
 from .tracking_rule import TrackingRule  # noqa: F401

--- a/fmn/database/model/generated.py
+++ b/fmn/database/model/generated.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, func
+from sqlalchemy.orm import relationship
+
+from ..main import Base
+
+
+class Generated(Base):
+    __tablename__ = "generated"
+
+    id = Column(Integer, primary_key=True, nullable=False)
+
+    rule_id = Column(Integer, ForeignKey("rules.id", ondelete="CASCADE"), nullable=False)
+    rule = relationship("Rule", back_populates="generated")
+
+    when = Column(
+        DateTime(timezone=False),
+        index=True,
+        default=datetime.now,
+        server_default=func.now(),
+        nullable=False,
+    )
+    count = Column(Integer, default=0)

--- a/fmn/database/model/rule.py
+++ b/fmn/database/model/rule.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import relationship, selectinload
 from sqlalchemy.sql import Select, expression
 
 from ..main import Base
+from .generated import Generated
 from .generation_rule import GenerationRule
 from .tracking_rule import TrackingRule
 from .user import User
@@ -38,6 +39,7 @@ class Rule(Base):
     generation_rules = relationship(
         GenerationRule, back_populates="rule", cascade="all, delete-orphan"
     )
+    generated = relationship(Generated, back_populates="rule", cascade="all, delete-orphan")
 
     @classmethod
     @cache

--- a/frontend/src/api/rules.ts
+++ b/frontend/src/api/rules.ts
@@ -2,7 +2,7 @@ import { useUserStore } from "@/stores/user";
 import type { QueryFunction } from "react-query/types/core";
 import { useMutation, useQuery, useQueryClient } from "vue-query";
 import { apiDelete, apiGet, apiPost, apiPut } from "./index";
-import type { Notification, Rule } from "./types";
+import type { Notification, Rule, RuleCreation } from "./types";
 
 // Get all rules
 export const useRulesQuery = () => {
@@ -59,7 +59,7 @@ export const useDeleteRuleMutation = () => {
 };
 
 // Preview a rule
-export const usePreviewRuleQuery = (data: Omit<Rule, "id">) => {
+export const usePreviewRuleQuery = (data: RuleCreation) => {
   const doApiPost: QueryFunction<Notification[]> = () => apiPost(url, data);
   const url = "/api/v1/rule-preview";
   console.log("Previewing rule:", data);

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -80,9 +80,12 @@ export interface Rule {
   id: number;
   name: string;
   disabled: boolean;
+  generated_last_week: number;
   tracking_rule: TrackingRuleEditing;
   generation_rules: GenerationRule[];
 }
+
+export type RuleCreation = Omit<Rule, "id" | "generated_last_week">;
 
 interface PostErrorDetail {
   loc: string[];

--- a/frontend/src/components/RuleListItem.vue
+++ b/frontend/src/components/RuleListItem.vue
@@ -74,5 +74,6 @@ const tracking_rule = TRACKING_RULES.find(
         />
       </template>
     </div>
+    <div>Notifications in the past 7 days: {{ rule.generated_last_week }}</div>
   </CListGroupItem>
 </template>

--- a/frontend/src/components/rule-edit/generation-rule/GenerationRuleModal.vue
+++ b/frontend/src/components/rule-edit/generation-rule/GenerationRuleModal.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-import type { GenerationRule, Rule, TrackingRuleEditing } from "@/api/types";
+import type {
+  GenerationRule,
+  RuleCreation,
+  TrackingRuleEditing,
+} from "@/api/types";
 import {
   CModal,
   CModalBody,
@@ -32,7 +36,7 @@ const previzData = computed(() => {
   if (!root || !root.context) {
     return null;
   }
-  const result: Omit<Rule, "id"> = {
+  const result: RuleCreation = {
     name: root.context._value.name as string,
     disabled: false,
     tracking_rule: root.context._value.tracking_rule as TrackingRuleEditing,

--- a/frontend/src/components/rule-edit/generation-rule/NotificationPreview.vue
+++ b/frontend/src/components/rule-edit/generation-rule/NotificationPreview.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { usePreviewRuleQuery } from "@/api/rules";
-import type { Rule } from "@/api/types";
+import type { RuleCreation } from "@/api/types";
 import { CListGroup, CListGroupItem, CSpinner } from "@coreui/bootstrap-vue";
 import { formatRelative } from "date-fns";
 import { enUS } from "date-fns/locale";
 
 const props = defineProps<{
-  data: Omit<Rule, "id">;
+  data: RuleCreation;
 }>();
 
 const { isLoading, isError, data, error } = usePreviewRuleQuery(props.data);

--- a/tests/consumer/test_consumer.py
+++ b/tests/consumer/test_consumer.py
@@ -5,6 +5,7 @@ import pytest
 from aio_pika.exceptions import AMQPConnectionError
 from fedora_messaging.config import conf as fm_config
 from fedora_messaging.exceptions import Nack
+from sqlalchemy import select
 
 from fmn.cache.tracked import Tracked, TrackedCache
 from fmn.consumer.consumer import Consumer
@@ -114,6 +115,12 @@ async def test_consumer_call_tracked(
         "body": "Body of message on dummy.topic",
         "headers": {"Subject": "Message on dummy.topic", "To": "dummy@example.com"},
     }
+
+    result = await c.db.execute(select(model.Generated))
+    generated = list(result.scalars())
+    assert len(generated) == 1
+    assert generated[0].count == 1
+
     await c.db.close()
 
 

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -1,7 +1,12 @@
+import asyncio
+from datetime import datetime
 from unittest import mock
+
+from sqlalchemy import select
 
 from fmn.core import cli, config
 from fmn.core.version import __version__
+from fmn.database.model import Generated, Rule, TrackingRule, User
 
 
 @cli.cli.command("test")
@@ -37,3 +42,43 @@ def test_settings_defaults(cli_runner):
     result = cli_runner.invoke(cli.cli, ["test"])
     assert result.exit_code == 0
     assert config._settings_file == config.DEFAULT_CONFIG_FILE
+
+
+async def test_cleanup_generated_count(mocker, cli_runner, db_async_session):
+    # Delete old entries
+    tr = TrackingRule(id=1, name="artifacts-owned", params={"username": "dummy"})
+    rule = Rule(id=1, name="dummy", user=User(name="dummy"), tracking_rule=tr, generation_rules=[])
+    db_async_session.add(Generated(rule=rule, count=1, when=datetime(2020, 1, 1, 0, 0, 0)))
+    await db_async_session.commit()
+
+    mocker.patch("fmn.core.cli.async_session_maker", return_value=db_async_session)
+    loop = asyncio.get_event_loop()
+
+    result = await loop.run_in_executor(
+        None, cli_runner.invoke, cli.cli, ["cleanup", "generated-count"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.startswith("Expiring 1 entr")
+    db_result = await db_async_session.execute(select(Generated))
+    assert len(list(db_result.all())) == 0
+
+
+async def test_cleanup_generated_count_no_old(mocker, cli_runner, db_async_session):
+    # Don't delete recent entries
+    tr = TrackingRule(id=1, name="artifacts-owned", params={"username": "dummy"})
+    rule = Rule(id=1, name="dummy", user=User(name="dummy"), tracking_rule=tr, generation_rules=[])
+    db_async_session.add(Generated(rule=rule, count=1))
+    await db_async_session.commit()
+
+    mocker.patch("fmn.core.cli.async_session_maker", return_value=db_async_session)
+    loop = asyncio.get_event_loop()
+
+    result = await loop.run_in_executor(
+        None, cli_runner.invoke, cli.cli, ["cleanup", "generated-count"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "Nothing to clean up.\n"
+    db_result = await db_async_session.execute(select(Generated))
+    assert len(list(db_result.all())) == 1


### PR DESCRIPTION
Count the number of notifications generated over the last week, and display it.

It's really not pretty at the moment, maybe @ryanlerch could have a look at it when he gets the time?

Missing: a cleanup script that would remove entries in the new table after some time. This script should be called with Openshift's periodic tasks.