### PR TITLE
Fix ArtifactsGroupOwned.prime_cache

### DIFF
--- a/tests/rules/tracking_rules/conftest.py
+++ b/tests/rules/tracking_rules/conftest.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from fmn.backends import PagureRole
 from fmn.cache.tracked import Tracked
 from fmn.core.constants import ArtifactType
 
@@ -21,7 +22,18 @@ class MockPagureAsyncProxy:
     get_project_users = get_project_groups = _get_project_users_groups
 
     async def get_group_projects(self, *, name, acl):
-        return [{"name": f"{acl}-{num}"} for num in range(1, 3)]
+        assert isinstance(name, str)
+        assert isinstance(acl, PagureRole)
+        return [
+            {
+                "name": f"{artifact_type.value}-{num}",
+                "namespace": artifact_type.value,
+                "fullname": f"{artifact_type.value}/{artifact_type.value}-{num}",
+                "access_groups": {role.name.lower(): [name] for role in PagureRole.GROUP_ROLES_SET},
+            }
+            for artifact_type in ArtifactType
+            for num in range(1, 3)
+        ]
 
 
 @pytest.fixture

--- a/tests/rules/tracking_rules/test_artifacts_group_owned.py
+++ b/tests/rules/tracking_rules/test_artifacts_group_owned.py
@@ -25,8 +25,8 @@ async def test_artifacts_group_owned_cache(requester, cache):
     tr = ArtifactsGroupOwned(requester, ["group1"], owner="testuser")
     await tr.prime_cache(cache)
     assert cache == Tracked(
-        packages=set(["rpms-1", "rpms-2"]),
-        containers=set(["containers-1", "containers-2"]),
-        modules=set(["modules-1", "modules-2"]),
-        flatpaks=set(["flatpaks-1", "flatpaks-2"]),
+        packages=set(["rpms/rpms-1", "rpms/rpms-2"]),
+        containers=set(["containers/containers-1", "containers/containers-2"]),
+        modules=set(["modules/modules-1", "modules/modules-2"]),
+        flatpaks=set(["flatpaks/flatpaks-1", "flatpaks/flatpaks-2"]),
     )


### PR DESCRIPTION
I broke this when refactoring how we query DistGit/Pagure. In the course, clarify which PagureRole values are relevant for groups (which can’t be owners) and use this for iterating over non-aliased values.

Fixes: #736

Signed-off-by: Nils Philippsen <nils@redhat.com>