### PR TITLE
Handle backend errors

### DIFF
--- a/fmn/api/handlers/misc.py
+++ b/fmn/api/handlers/misc.py
@@ -86,6 +86,7 @@ async def get_artifacts(
         },
     ]
     namespaces = [at.value for at in ArtifactType]
+    # TODO: handle error 500 in distgit_proxy.get_projects()
     for project in await distgit_proxy.get_projects(pattern=f"*{name}*"):
         for index, namespace in enumerate(namespaces):
             if project["namespace"] == namespace:

--- a/fmn/backends/fasjson.py
+++ b/fmn/backends/fasjson.py
@@ -9,7 +9,7 @@ from cashews import cache
 from httpx_gssapi import HTTPSPNEGOAuth
 
 from ..cache.util import cache_ttl, get_pattern_for_cached_calls
-from .base import APIClient, NextPageParams
+from .base import APIClient, NextPageParams, handle_http_error
 
 if TYPE_CHECKING:
     from fedora_messaging.message import Message
@@ -61,6 +61,7 @@ class FASJSONAsyncProxy(APIClient):
     async def get_user(self, *, username: str) -> dict:
         return await self.get_payload(f"/users/{username}/")
 
+    @handle_http_error(list)
     @cache(ttl=cache_ttl("fasjson"), prefix="v1")
     async def get_user_groups(self, *, username: str) -> dict:
         return await self.get_payload(f"/users/{username}/groups/")

--- a/fmn/backends/pagure.py
+++ b/fmn/backends/pagure.py
@@ -11,7 +11,7 @@ from cashews import cache
 from httpx import URL, QueryParams
 
 from ..cache.util import cache_ttl, get_pattern_for_cached_calls
-from .base import APIClient, NextPageParams
+from .base import APIClient, NextPageParams, handle_http_error
 
 if TYPE_CHECKING:
     from fedora_messaging.message import Message
@@ -74,6 +74,7 @@ class PagureAsyncProxy(APIClient):
 
         return None, None
 
+    @handle_http_error(list)
     @cache(ttl=cache_ttl("pagure"), prefix="v1")
     async def get_projects(
         self,
@@ -102,6 +103,7 @@ class PagureAsyncProxy(APIClient):
             )
         ]
 
+    @handle_http_error(list)
     @cache(ttl=cache_ttl("pagure"), prefix="v1")
     async def get_project_users(
         self, *, project_path: str, roles: PagureRole = PagureRole.USER_ROLES_MAINTAINER
@@ -116,6 +118,7 @@ class PagureAsyncProxy(APIClient):
         }
         return sorted(usernames)
 
+    @handle_http_error(list)
     @cache(ttl=cache_ttl("pagure"), prefix="v1")
     async def get_project_groups(
         self, *, project_path: str, roles: PagureRole = PagureRole.GROUP_ROLES_MAINTAINER
@@ -130,6 +133,7 @@ class PagureAsyncProxy(APIClient):
         }
         return sorted(groupnames)
 
+    @handle_http_error(list)
     @cache(ttl=cache_ttl("pagure"), prefix="v1")
     async def get_group_projects(
         self, *, name: str, acl: PagureRole | None = None

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -179,3 +179,23 @@ class TestAPIClient:
             assert isinstance(result, list)
             assert len(result) == self.PAGINATE_TOTAL_PAGES * self.PAGINATE_PER_PAGE
             assert all(i == item["boop"] for i, item in enumerate(result))
+
+
+@pytest.mark.parametrize("testcase", ("success", "raises-exception"))
+async def test_handle_http_error(testcase, mocker):
+    async def fn_to_be_decorated():
+        if "raises-exception" in testcase:
+            raise httpx.HTTPStatusError(
+                "Boo.", request=None, response=httpx.Response(status_code=404)
+            )
+        else:
+            return ["item"]
+
+    decorated_fn = base.handle_http_error(list)(fn_to_be_decorated)
+
+    result = await decorated_fn()
+
+    if "success" in testcase:
+        assert result == ["item"]
+    else:
+        assert result == []

--- a/tests/backends/test_fasjson.py
+++ b/tests/backends/test_fasjson.py
@@ -4,6 +4,7 @@ import re
 from itertools import chain
 from unittest import mock
 
+import httpx
 import pytest
 
 from fmn.backends import fasjson
@@ -64,6 +65,15 @@ class TestFASJSONAsyncProxy(BaseTestAsyncProxy):
             assert params["page"] == 2
         else:
             assert next_url is None
+
+    async def test_get_user_groups_failure(self, respx_mocker, proxy_unmocked_client):
+        route = respx_mocker.get(f"{self.expected_api_url}/users/boop/groups/").mock(
+            side_effect=httpx.Response(status_code=500)
+        )
+
+        response = await proxy_unmocked_client.get_user_groups(username="boop")
+        assert route.called
+        assert response == []
 
     @pytest.mark.parametrize(
         "testcase",


### PR DESCRIPTION
In case the project does not exist in Pagure, or the user does not exist in FASJSON, we need to handle the HTTP error or the consumer will crash.

Also deal with the service being unavailable (5xx errors) in the same way. The returned default values are not cached.