### PR TITLE
Fix startup crash after the FastAPI update to 0.91.0

### DIFF
--- a/fmn/api/main.py
+++ b/fmn/api/main.py
@@ -43,19 +43,17 @@ async def global_execution_handler(
     )
 
 
-@app.on_event("startup")
-def add_middlewares():
-    app.add_middleware(
-        ServerErrorMiddleware,
-        handler=global_execution_handler,
-    )
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=get_settings().cors_origins.split(" "),
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+app.add_middleware(
+    ServerErrorMiddleware,
+    handler=global_execution_handler,
+)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=get_settings().cors_origins.split(" "),
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.on_event("startup")

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -3,23 +3,18 @@ from unittest import mock
 from fmn.api import main
 
 
-@mock.patch("fmn.api.main.get_settings")
-@mock.patch("fmn.api.main.app")
-def test_add_middlewares(app, get_settings):
-    get_settings.return_value = mock.Mock(cors_origins="https://foo")
-    main.add_middlewares()
-
-    calls = [
-        mock.call(
-            main.CORSMiddleware,
-            allow_origins=["https://foo"],
-            allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
-        )
-    ]
-    app.add_middleware.assert_has_calls(calls)
-    assert app.add_middleware.call_count == 2
+def test_add_middlewares():
+    mw = main.app.user_middleware
+    assert len(mw) == 2
+    assert mw[0].cls == main.CORSMiddleware
+    assert mw[0].options == dict(
+        allow_origins=["https://notifications.fedoraproject.org"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    assert mw[1].cls == main.ServerErrorMiddleware
+    assert mw[1].options == dict(handler=main.global_execution_handler)
 
 
 @mock.patch("fmn.api.main.init_async_model")


### PR DESCRIPTION
Since FastAPI 0.91.0, Starlette does not accept adding middleware to an already running application. Change the way we add middleware to fit that.

Ref: https://github.com/tiangolo/fastapi/releases/tag/0.91.0