### PR TITLE
Consumer: end the transaction after each message

### DIFF
--- a/fmn/consumer/consumer.py
+++ b/fmn/consumer/consumer.py
@@ -57,6 +57,8 @@ class Consumer:
         except Exception:
             await self.db.rollback()
             raise
+        else:
+            await self.db.commit()
 
     async def handle(self, message: message.Message):
         await self.refresh_cache_if_needed(message)

--- a/tests/consumer/test_consumer.py
+++ b/tests/consumer/test_consumer.py
@@ -61,11 +61,13 @@ def test_consumer_call_not_tracked(
     make_mocked_message,
 ):
     c = Consumer()
+    commit_spy = mocker.spy(c.db, "commit")
     message = make_mocked_message(topic="dummy.topic", body={"foo": "bar"})
     c(message)
     mocked_cache.invalidate_on_message.assert_called_with(message)
     c._requester.invalidate_on_message.assert_called_with(message)
     c.send_queue.send.assert_not_called()
+    commit_spy.assert_called_once()
 
 
 async def test_consumer_call_tracked(


### PR DESCRIPTION
Otherwise the consumer is stuck in a transaction and does not see newer rules.