### PR TITLE
Cache the DB request to get all the rules

### DIFF
--- a/fmn/cache/cli.py
+++ b/fmn/cache/cli.py
@@ -25,7 +25,7 @@ def get_tracked():
         await init_async_model()
         requester = Requester(get_settings().services)
         rules_cache = RulesCache()
-        tracked_cache = TrackedCache(rules_cache=rules_cache)
+        tracked_cache = TrackedCache(requester=requester, rules_cache=rules_cache)
         async with async_session_maker() as db:
             rules_cache.db = db
             return await tracked_cache.get_tracked(requester)
@@ -38,7 +38,8 @@ def get_tracked():
 def delete_tracked():
     """Invalidate the current tracked value."""
     configure_cache()
+    requester = Requester(get_settings().services)
     rules_cache = RulesCache()
-    tracked_cache = TrackedCache(rules_cache=rules_cache)
+    tracked_cache = TrackedCache(requester=requester, rules_cache=rules_cache)
     asyncio.run(tracked_cache.invalidate())
     print("Tracked cache invalidated.")

--- a/fmn/cache/rules.py
+++ b/fmn/cache/rules.py
@@ -1,0 +1,45 @@
+import logging
+from typing import TYPE_CHECKING
+
+from cashews import cache
+from cashews.formatter import get_templates_for_func
+
+from ..database.model import Rule
+
+if TYPE_CHECKING:
+    from fedora_messaging.message import Message
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+log = logging.getLogger(__name__)
+
+
+class RulesCache:
+    """Cache the rules currently in the database."""
+
+    def __init__(self):
+        self.db: "AsyncSession" | None = None
+
+    @cache.early(
+        key="rules", prefix="v1", ttl="1d", early_ttl="22h"
+    )
+    @cache.locked(key="rules", prefix="v1", ttl="1h")
+    async def get_rules(self):
+        if self.db is None:
+            raise RuntimeError("You must use set the db attribute first.")
+        log.debug("Building the rules cache")
+        result = await self.db.execute(Rule.select_related().filter_by(disabled=False))
+        log.debug("Built the rules cache")
+        return list(result.scalars())
+
+    async def invalidate(self):
+        log.debug("Invalidating the rules cache")
+        cache_key = list(get_templates_for_func(self.get_rules))[0]
+        await cache.delete(cache_key)
+
+    async def invalidate_on_message(self, message: "Message"):
+        if (
+            message.topic.endswith("fmn.rule.create.v1")
+            or message.topic.endswith("fmn.rule.update.v1")
+            or message.topic.endswith("fmn.rule.delete.v1")
+        ):
+            await self.invalidate()

--- a/fmn/cache/rules.py
+++ b/fmn/cache/rules.py
@@ -5,6 +5,7 @@ from cashews import cache
 from cashews.formatter import get_templates_for_func
 
 from ..database.model import Rule
+from .util import cache_early_ttl, cache_ttl
 
 if TYPE_CHECKING:
     from fedora_messaging.message import Message
@@ -20,7 +21,7 @@ class RulesCache:
         self.db: "AsyncSession" | None = None
 
     @cache.early(
-        key="rules", prefix="v1", ttl="1d", early_ttl="22h"
+        key="rules", prefix="v1", ttl=cache_ttl("rules"), early_ttl=cache_early_ttl("rules")
     )
     @cache.locked(key="rules", prefix="v1", ttl="1h")
     async def get_rules(self):

--- a/fmn/cache/rules.py
+++ b/fmn/cache/rules.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -34,8 +35,8 @@ class RulesCache:
 
     async def invalidate(self):
         log.debug("Invalidating the rules cache")
-        cache_key = list(get_templates_for_func(self.get_rules))[0]
-        await cache.delete(cache_key)
+        cache_keys = get_templates_for_func(self.get_rules)
+        await asyncio.gather(*(cache.delete(key) for key in cache_keys))
 
     async def invalidate_on_message(self, message: "Message"):
         if (

--- a/fmn/cache/tracked.py
+++ b/fmn/cache/tracked.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from cashews import cache
 from cashews.formatter import get_templates_for_func
 
+from .util import cache_early_ttl, cache_ttl
+
 if TYPE_CHECKING:
     from fedora_messaging.message import Message
 
@@ -57,7 +59,9 @@ class TrackedCache:
         log.debug(f"Built the tracked cache in {duration:.2f} seconds")
         return tracked
 
-    @cache.early(key="tracked", prefix="v1", ttl="1d", early_ttl="22h")
+    @cache.early(
+        key="tracked", prefix="v1", ttl=cache_ttl("tracked"), early_ttl=cache_early_ttl("tracked")
+    )
     async def get_tracked(self):
         return await self.build()
 

--- a/fmn/cache/tracked.py
+++ b/fmn/cache/tracked.py
@@ -47,8 +47,11 @@ class TrackedCache:
         self._requester = requester
         self._rules_cache = rules_cache
 
+    @cache.early(
+        key="tracked", prefix="v1", ttl=cache_ttl("tracked"), early_ttl=cache_early_ttl("tracked")
+    )
     @cache.locked(key="tracked", prefix="v1", ttl="1h")
-    async def build(self):
+    async def get_tracked(self):
         log.debug("Building the tracked cache")
         before = monotonic()
         tracked = Tracked()
@@ -58,12 +61,6 @@ class TrackedCache:
         duration = after - before
         log.debug(f"Built the tracked cache in {duration:.2f} seconds")
         return tracked
-
-    @cache.early(
-        key="tracked", prefix="v1", ttl=cache_ttl("tracked"), early_ttl=cache_early_ttl("tracked")
-    )
-    async def get_tracked(self):
-        return await self.build()
 
     async def invalidate(self):
         log.debug("Invalidating the tracked cache")

--- a/fmn/cache/tracked.py
+++ b/fmn/cache/tracked.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from time import monotonic
@@ -64,8 +65,8 @@ class TrackedCache:
 
     async def invalidate(self):
         log.debug("Invalidating the tracked cache")
-        cache_key = list(get_templates_for_func(self.get_tracked))[0]
-        await cache.delete(cache_key)
+        cache_keys = get_templates_for_func(self.get_tracked)
+        await asyncio.gather(*(cache.delete(key) for key in cache_keys))
 
     async def invalidate_on_message(self, message: "Message"):
         if (

--- a/fmn/cache/util.py
+++ b/fmn/cache/util.py
@@ -30,7 +30,7 @@ def cache_arg(arg: str, scope: str | None = None) -> Callable[[str, str | None],
 
         if scope:
             try:
-                return getattr(settings.cache.scoped_args[scope], arg)
+                return getattr(getattr(settings.cache.scoped_args, scope), arg)
             except (AttributeError, KeyError):
                 pass
 
@@ -40,6 +40,7 @@ def cache_arg(arg: str, scope: str | None = None) -> Callable[[str, str | None],
 
 
 cache_ttl = partial(cache_arg, "ttl")
+cache_early_ttl = partial(cache_arg, "early_ttl")
 
 
 def _get_pattern_for_cached_calls_iter(func: Callable, **kwargs: dict[str, Any]) -> Iterator[str]:

--- a/fmn/consumer/consumer.py
+++ b/fmn/consumer/consumer.py
@@ -26,7 +26,7 @@ class Consumer:
             config.set_settings_file(fm_config["consumer_config"]["settings_file"])
         self._rules_cache = RulesCache()
         self._requester = Requester(config.get_settings().services)
-        self._tracked_cache = TrackedCache(rules_cache=self._rules_cache)
+        self._tracked_cache = TrackedCache(requester=self._requester, rules_cache=self._rules_cache)
         self.send_queue = SendQueue(fm_config["consumer_config"]["send_queue"])
         self.loop = asyncio.get_event_loop()
         self._ready = self.loop.create_task(self.setup())
@@ -94,7 +94,7 @@ class Consumer:
         # tracked messages will still run though all the rules though, so this could be improved I
         # suppose, maybe by changing the cache datastructure to point each entry in the cache to the
         # rules that produced it.
-        tracked = await self._tracked_cache.get_tracked(self._requester)
+        tracked = await self._tracked_cache.get_tracked()
         for msg_attr in ("packages", "containers", "modules", "flatpaks", "usernames"):
             if not set(getattr(message, msg_attr)).isdisjoint(getattr(tracked, msg_attr)):
                 log.debug(f"Message {message.id} is tracked by {msg_attr}")

--- a/fmn/core/config.py
+++ b/fmn/core/config.py
@@ -11,9 +11,17 @@ CashewsTTLTypes = int | float | str | timedelta
 
 class CacheArgsModel(BaseModel):
     ttl: CashewsTTLTypes | None = None
+    early_ttl: CashewsTTLTypes | None = None
 
     class Config:
         extra = "allow"
+
+
+class CacheScopedArgsModel(BaseModel):
+    tracked: CacheArgsModel = CacheArgsModel(ttl="1d", early_ttl="22h")
+    rules: CacheArgsModel = CacheArgsModel(ttl="1d", early_ttl="22h")
+    pagure: CacheArgsModel | None = None
+    fasjson: CacheArgsModel | None = None
 
 
 class CacheModel(BaseModel):
@@ -21,7 +29,7 @@ class CacheModel(BaseModel):
     setup_args: dict[str, Any] | None = None
 
     default_args: CacheArgsModel = CacheArgsModel(ttl="1h")
-    scoped_args: dict[str, CacheArgsModel] = {}
+    scoped_args: CacheScopedArgsModel = CacheScopedArgsModel()
 
 
 class SQLAlchemyModel(BaseModel):

--- a/tests/cache/test_rules.py
+++ b/tests/cache/test_rules.py
@@ -1,0 +1,52 @@
+import pytest
+from cashews import cache
+from cashews.formatter import get_templates_for_func
+
+from fmn.cache.rules import RulesCache
+from fmn.database import model
+
+
+async def test_no_db():
+    rc = RulesCache()
+    with pytest.raises(RuntimeError):
+        await rc.get_rules()
+
+
+async def test_rule_disabled(db_async_session):
+    rc = RulesCache()
+    rc.db = db_async_session
+    user = model.User(name="dummy")
+    rule = model.Rule(user=user, name="the name", disabled=True)
+    db_async_session.add_all([user, rule])
+    await db_async_session.commit()
+    rules = await rc.get_rules()
+    assert rules == []
+
+
+@pytest.mark.cashews_cache(enabled=True)
+async def test_invalidate(mocker):
+    mocker.patch.object(cache, "delete")
+    rc = RulesCache()
+    await rc.invalidate()
+    cache_key = list(get_templates_for_func(rc.get_rules))[0]
+    cache.delete.assert_called_with(cache_key)
+
+
+@pytest.mark.parametrize(
+    "topic,expected",
+    [
+        ("dummy.topic", False),
+        ("fmn.rule.create.v1", True),
+        ("fmn.rule.update.v1", True),
+        ("fmn.rule.delete.v1", True),
+    ],
+)
+async def test_invalidate_on_message(mocker, topic, expected, make_mocked_message):
+    message = make_mocked_message(topic=topic, body={})
+    rc = RulesCache()
+    mocker.patch.object(rc, "invalidate")
+    await rc.invalidate_on_message(message)
+    if expected:
+        rc.invalidate.assert_called_once_with()
+    else:
+        rc.invalidate.assert_not_called()

--- a/tests/cache/test_tracked.py
+++ b/tests/cache/test_tracked.py
@@ -33,7 +33,7 @@ async def test_build_tracked(mocker, requester, db_async_session, rules_cache):
     db_async_session.add_all([rule, tr])
     prime_cache = mocker.patch.object(tr, "prime_cache")
     tracked_cache = TrackedCache(requester=requester, rules_cache=rules_cache)
-    tracked = await tracked_cache.build()
+    tracked = await tracked_cache.get_tracked()
     prime_cache.assert_called_once_with(tracked, requester)
 
 
@@ -42,12 +42,10 @@ async def test_get_tracked(mocker, requester):
     rules_cache = mocker.AsyncMock()
     rules_cache.get_rules.return_value = []
     tracked_cache = TrackedCache(requester=requester, rules_cache=rules_cache)
-    mocker.patch.object(tracked_cache, "build", return_value="tracked_value")
     result1 = await tracked_cache.get_tracked()
     result2 = await tracked_cache.get_tracked()
-    tracked_cache.build.assert_called_once_with()
-    assert result1 == "tracked_value"
-    assert result2 == "tracked_value"
+    rules_cache.get_rules.assert_called_once_with()
+    assert result1 == result2
 
 
 @pytest.mark.cashews_cache(enabled=True)

--- a/tests/cache/test_util.py
+++ b/tests/cache/test_util.py
@@ -16,15 +16,15 @@ async def test_cache_configure(mocker):
     cache.setup.assert_called_with(cache_settings.url, **cache_settings.setup_args or {})
 
 
-@pytest.mark.parametrize("scope", (None, "scope", "unconfigured scope"))
+@pytest.mark.parametrize("scope", (None, "pagure", "unconfigured scope"))
 def test_cashews_cache_arg(scope):
     settings = get_settings()
 
     expected = settings.cache.default_args.ttl
 
     if scope:
-        settings.cache.scoped_args["scope"] = mock.Mock(ttl=5)
-        if scope == "scope":
+        settings.cache.scoped_args.pagure = mock.Mock(ttl=5)
+        if scope == "pagure":
             expected = 5
 
     with mock.patch("fmn.cache.util.config.get_settings", return_value=settings):


### PR DESCRIPTION
It could be a very big request and it's run on each tracked message. The first changeset caches it for a while, and invalidates the cache when a corresponding message is received.

Also rework the `cache_ttl()` function to use it on the `tracked` and `rules` caches.