### PR TITLE
Fix a Pagure API call

### DIFF
--- a/fmn/api/handlers/misc.py
+++ b/fmn/api/handlers/misc.py
@@ -53,7 +53,7 @@ async def get_owned_artifacts(
     artifacts = {}
 
     for user in users:
-        for project in await distgit_proxy.get_projects(username=user):
+        for project in await distgit_proxy.get_user_projects(username=user):
             artifacts[project["fullname"]] = {"type": project["namespace"], "name": project["name"]}
 
     for group in groups:

--- a/fmn/backends/pagure.py
+++ b/fmn/backends/pagure.py
@@ -105,6 +105,18 @@ class PagureAsyncProxy(APIClient):
 
     @handle_http_error(list)
     @cache(ttl=cache_ttl("pagure"), prefix="v1")
+    async def get_user_projects(self, *, username: str) -> list[dict[str, Any]]:
+        return [
+            p
+            for p in await self.get_projects(username=username)
+            if any(
+                username in p.get("access_users", {}).get(role.name.lower(), [])
+                for role in PagureRole.USER_ROLES_MAINTAINER_SET
+            )
+        ]
+
+    @handle_http_error(list)
+    @cache(ttl=cache_ttl("pagure"), prefix="v1")
     async def get_project_users(
         self, *, project_path: str, roles: PagureRole = PagureRole.USER_ROLES_MAINTAINER
     ) -> list[str]:

--- a/fmn/rules/tracking_rules.py
+++ b/fmn/rules/tracking_rules.py
@@ -47,7 +47,7 @@ class ArtifactsOwned(TrackingRule):
 
     async def prime_cache(self, cache):
         for username in self.usernames:
-            owned = await self._requester.distgit.get_projects(username=username)
+            owned = await self._requester.distgit.get_user_projects(username=username)
             for artifact_type in ArtifactType:
                 getattr(cache, artifact_type.name).update(
                     p["name"] for p in owned if p["namespace"] == artifact_type.value

--- a/tests/api/test_handlers.py
+++ b/tests/api/test_handlers.py
@@ -457,12 +457,14 @@ class TestMisc(BaseTestAPIV1Handler):
                     "fullname": "containers/pants",
                     "name": "pants",
                     "namespace": "containers",
+                    "access_users": {"admin": ["dudemcpants"]},
                 },
                 {
                     "description": "trousers rpms",
                     "fullname": "rpms/trousers",
                     "name": "trousers",
                     "namespace": "rpms",
+                    "access_users": {"admin": ["dudemcpants"]},
                 },
             ],
         }

--- a/tests/rules/tracking_rules/conftest.py
+++ b/tests/rules/tracking_rules/conftest.py
@@ -15,6 +15,13 @@ class MockPagureAsyncProxy:
             for atype in ArtifactType
         ]
 
+    async def get_user_projects(self, *, username):
+        return [
+            {"namespace": atype.value, "name": f"{atype.value}-{num}"}
+            for num in range(1, 3)
+            for atype in ArtifactType
+        ]
+
     async def _get_project_users_groups(self, *, project_path):
         # The mock artifact names are of the form "art-<expected_user_group_name>".
         return [project_path.split("/", 1)[1][4:]]


### PR DESCRIPTION
When calling `/api/0/projects?username=joe`, Pagure returns all the projects that Joe has commit to, directly *or through a group*.

As there does not seem to be a way to only get the direct access projects, filter the reply.

This is something @ryanlerch  and I noticed.