### PR TITLE
Logging: delay string interpolation and use consistent logger name

### DIFF
--- a/fmn/api/handlers/misc.py
+++ b/fmn/api/handlers/misc.py
@@ -113,7 +113,7 @@ async def preview_rule(
     for gr in rule.generation_rules:
         gr.destinations = [api_models.Destination(protocol="preview", address="preview")]
 
-    log.debug("Previewing rule:", rule)
+    log.debug("Previewing rule: %s", rule)
     user = User(name=identity.name)
     rule_db = db_rule_from_api_rule(rule, user)
     rule_db.id = 0
@@ -121,7 +121,7 @@ async def preview_rule(
     # TODO make the delta a setting
     # TODO: this takes ridiculously long.
     async for message in get_last_messages(1):
-        log.debug(f"Processing message: {message.body}")
+        log.debug("Processing message: %s", message.body)
         async for notif in rule_db.handle(message, requester):
             notifs.append(notif)
     return notifs

--- a/fmn/api/handlers/users.py
+++ b/fmn/api/handlers/users.py
@@ -229,7 +229,7 @@ async def create_user_rule(
 ):
     if username != identity.name:
         raise HTTPException(status_code=403, detail="Not allowed to edit someone else's rules")
-    log.info("Creating rule:", rule)
+    log.info("Creating rule: %s", rule)
     user = await User.async_get_or_create(db_session, name=username)
     rule_db = db_rule_from_api_rule(rule, user)
     db_session.add(rule_db)

--- a/fmn/api/messaging.py
+++ b/fmn/api/messaging.py
@@ -12,11 +12,11 @@ log = logging.getLogger(__name__)
 
 
 def backoff_hdlr(details):
-    log.warning(f"Publishing message failed. Retrying. {traceback.format_tb(sys.exc_info()[2])}")
+    log.warning("Publishing message failed. Retrying. %s", traceback.format_tb(sys.exc_info()[2]))
 
 
 def giveup_hdlr(details):
-    log.error(f"Publishing message failed. Giving up. {traceback.format_tb(sys.exc_info()[2])}")
+    log.error("Publishing message failed. Giving up. %s", traceback.format_tb(sys.exc_info()[2]))
 
 
 @backoff.on_exception(

--- a/fmn/backends/base.py
+++ b/fmn/backends/base.py
@@ -20,7 +20,7 @@ def handle_http_error(default_factory):
             try:
                 return await f(*args, **kw)
             except HTTPStatusError as e:
-                log.warning(f"Request failed: {e}")
+                log.warning("Request failed: %s", e)
                 return default_factory()
 
         return wrapper

--- a/fmn/cache/tracked.py
+++ b/fmn/cache/tracked.py
@@ -60,7 +60,7 @@ class TrackedCache:
             await rule.tracking_rule.prime_cache(tracked, self._requester)
         after = monotonic()
         duration = after - before
-        log.debug(f"Built the tracked cache in {duration:.2f} seconds")
+        log.debug("Built the tracked cache in %.2f seconds", duration)
         return tracked
 
     async def invalidate(self):

--- a/fmn/consumer/send_queue.py
+++ b/fmn/consumer/send_queue.py
@@ -14,13 +14,13 @@ log = logging.getLogger(__name__)
 
 
 async def backoff_hdlr(details):
-    log.warning(f"Publishing message failed. Retrying. {traceback.format_tb(sys.exc_info()[2])}")
+    log.warning("Publishing message failed. Retrying. %s", traceback.format_tb(sys.exc_info()[2]))
     self = details["args"][0]
     await self.connect()
 
 
 def giveup_hdlr(details):
-    log.error(f"Publishing message failed. Giving up. {traceback.format_tb(sys.exc_info()[2])}")
+    log.error("Publishing message failed. Giving up. %s", traceback.format_tb(sys.exc_info()[2]))
 
 
 class SendQueue:

--- a/fmn/database/model/rule.py
+++ b/fmn/database/model/rule.py
@@ -59,7 +59,7 @@ class Rule(Base):
         )
 
     async def handle(self, message: "Message", requester: "Requester"):
-        log.debug(f"Rule {self.id} handling message {message.id}")
+        log.debug("Rule %s handling message %s", self.id, message.id)
         if not await self.tracking_rule.matches(message, requester):
             return
         for generation_rule in self.generation_rules:

--- a/fmn/sender/consumer.py
+++ b/fmn/sender/consumer.py
@@ -5,7 +5,7 @@ from aio_pika import connect_robust
 
 from ..core.amqp import get_url_from_config
 
-_log = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 CLOSING = object()
@@ -32,7 +32,7 @@ class Consumer:
         await self._queue.bind("amq.direct", f"send.{self._destination}")
 
     async def start(self):
-        _log.info("Starting consuming messages")
+        log.info("Starting consuming messages")
         async with self._queue.iterator() as self._queue_iter:
             async for message in self._queue_iter:
                 if message == CLOSING:
@@ -41,7 +41,7 @@ class Consumer:
                     await self._handler.handle(json.loads(message.body))
 
     async def stop(self):
-        _log.info("Stopping messages consumption")
+        log.info("Stopping messages consumption")
         if self._queue_iter:
             await self._queue_iter.on_message(CLOSING)
             await self._queue_iter.close()

--- a/fmn/sender/email.py
+++ b/fmn/sender/email.py
@@ -5,7 +5,7 @@ from aiosmtplib import SMTP
 
 from .handler import Handler
 
-_log = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 class EmailHandler(Handler):
@@ -25,5 +25,5 @@ class EmailHandler(Handler):
         for name, value in message["headers"].items():
             notif[name] = value
         notif.set_content(message["body"])
-        _log.info("Sending email to %s with subject %s", notif["To"], notif["Subject"])
+        log.info("Sending email to %s with subject %s", notif["To"], notif["Subject"])
         await self._smtp.send_message(notif)

--- a/fmn/sender/email.py
+++ b/fmn/sender/email.py
@@ -25,5 +25,5 @@ class EmailHandler(Handler):
         for name, value in message["headers"].items():
             notif[name] = value
         notif.set_content(message["body"])
-        _log.info(f"Sending email to {notif['To']} with subject {notif['Subject']}")
+        _log.info("Sending email to %s with subject %s", notif["To"], notif["Subject"])
         await self._smtp.send_message(notif)

--- a/fmn/sender/irc.py
+++ b/fmn/sender/irc.py
@@ -7,7 +7,7 @@ from irc.connection import AioFactory
 
 from .handler import Handler
 
-_log = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 class IRCHandler(Handler):
@@ -21,14 +21,14 @@ class IRCHandler(Handler):
             password=irc_url.password,
             connect_factory=AioFactory(ssl=(irc_url.scheme == "ircs")),
         )
-        _log.debug("IRC connection established")
+        log.debug("IRC connection established")
 
     async def stop(self):
-        _log.debug("Stopping IRC handler...")
+        log.debug("Stopping IRC handler...")
         await self._client.disconnect()
 
     async def handle(self, message):
-        _log.info("Sending messsage to %s: %s", message["to"], message["message"])
+        log.info("Sending messsage to %s: %s", message["to"], message["message"])
         await self._client.privmsg(message["to"], message["message"])
 
 

--- a/fmn/sender/irc.py
+++ b/fmn/sender/irc.py
@@ -28,7 +28,7 @@ class IRCHandler(Handler):
         await self._client.disconnect()
 
     async def handle(self, message):
-        _log.info(f"Sending messsage to {message['to']}: {message['message']}")
+        _log.info("Sending messsage to %s: %s", message["to"], message["message"])
         await self._client.privmsg(message["to"], message["message"])
 
 

--- a/fmn/sender/matrix.py
+++ b/fmn/sender/matrix.py
@@ -35,7 +35,7 @@ class MatrixHandler(Handler):
         await self._client.disconnect()
 
     async def handle(self, message):
-        _log.info(f"Sending messsage to {message['to']}: {message['message']}")
+        _log.info("Sending message to %s: %s", message["to"], message["message"])
         room_id = await self.get_dm_room(message["to"])
         await self.send_dm(room_id, message["message"])
         await self._client.sync(timeout=30000)

--- a/fmn/sender/matrix.py
+++ b/fmn/sender/matrix.py
@@ -6,7 +6,7 @@ from nio import AsyncClient
 
 from .handler import Handler
 
-_log = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 class MatrixHandler(Handler):
@@ -17,25 +17,25 @@ class MatrixHandler(Handler):
         self._client.user_id = self._user_id
         self._client.access_token = self._config["token"]
         self._client.device_id = "FMN"
-        _log.debug("Establishing connection to Matrix")
+        log.debug("Establishing connection to Matrix")
         await self._client.sync(timeout=30000, full_state=True, set_presence="online")
-        _log.debug("Synchronized")
+        log.debug("Synchronized")
         self._dm_rooms_cache = {}
         await self.update_dm_rooms_cache()
-        _log.debug("Room list updated")
+        log.debug("Room list updated")
         self.loop = asyncio.get_event_loop()
         # Periodically refresh the DM rooms cache
         self._dm_rooms_cache_refresh_task = self.loop.create_task(self.refresh_dm_rooms_cache())
 
     async def stop(self):
-        _log.debug("Stopping Matrix handler...")
+        log.debug("Stopping Matrix handler...")
         self._dm_rooms_cache_refresh_task.cancel()
         with suppress(asyncio.TimeoutError, asyncio.CancelledError):
             await asyncio.wait_for(self._dm_rooms_cache_refresh_task, 1)
         await self._client.disconnect()
 
     async def handle(self, message):
-        _log.info("Sending message to %s: %s", message["to"], message["message"])
+        log.info("Sending message to %s: %s", message["to"], message["message"])
         room_id = await self.get_dm_room(message["to"])
         await self.send_dm(room_id, message["message"])
         await self._client.sync(timeout=30000)


### PR DESCRIPTION
commit 84ff88cab65203acf682abb1089454c0a1d55cb9
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue Feb 21 12:59:49 2023 +0100

    Delay string interpolation when logging
    
    Python loggers interpolate additional arguments only into strings if the
    logging level needs to render the string. This avoids interpolating the
    arguments unnecessarily, especially in the case of debugging output.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 9e2b06c62bc696c6ced2ce264092e9d5b4ce5939
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue Feb 21 13:03:06 2023 +0100

    Consistently use `log` as the logger name
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>