### PR TITLE
Consumer: get a session from the sessionmaker on each incoming message

### DIFF
--- a/fmn/cache/rules.py
+++ b/fmn/cache/rules.py
@@ -27,7 +27,7 @@ class RulesCache:
     @cache.locked(key="rules", prefix="v1", ttl="1h")
     async def _get_rules(self):
         if self.db is None:
-            raise RuntimeError("You must use set the db attribute first.")
+            raise RuntimeError("You must set the db attribute first.")
         log.debug("Building the rules cache")
         result = await self.db.execute(Rule.select_related().filter_by(disabled=False))
         log.debug("Built the rules cache")

--- a/tests/database/test_setup.py
+++ b/tests/database/test_setup.py
@@ -2,9 +2,11 @@ from contextlib import nullcontext
 from unittest import mock
 
 import pytest
+from sqlalchemy import inspect
 
 from fmn.core.config import get_settings
 from fmn.database import setup
+from fmn.database.main import metadata
 
 
 @pytest.mark.parametrize("db_empty", (True, False))
@@ -45,3 +47,20 @@ def test_setup_db_schema(get_sync_engine, inspect, metadata, Config, stamp, db_e
         engine.begin.assert_not_called()
         metadata.create_all.assert_not_called()
         Config.assert_not_called()
+
+
+def test_setup_db_schema_with_session(db_sync_session, db_sync_engine):
+    metadata.drop_all(bind=db_sync_engine)
+
+    setup.setup_db_schema(db_sync_session)
+
+    inspection_result = inspect(db_sync_engine)
+    assert list(sorted(inspection_result.get_table_names())) == [
+        "destinations",
+        "filters",
+        "generated",
+        "generation_rules",
+        "rules",
+        "tracking_rules",
+        "users",
+    ]


### PR DESCRIPTION
Otherwise we get this kind of exception:
```
sqlalchemy.exc.InterfaceError: (sqlalchemy.dialects.postgresql.asyncpg.InterfaceError) <class 'asyncpg.exceptions._base.InterfaceError'>: cannot perform operation: another operation is in progress
```

The fact that the sessionmaker has a connection pool should solve the potential performance issue.