### PR TITLE
Bring back flake8 configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,3 +40,9 @@ commands=
     rm -rf _build
     rm -rf _source
     sphinx-build -W -b html -d {envtmpdir}/doctrees .  _build/html
+
+# We use Ruff instead of flake8 but configure it appropriately so it doesn’t
+# complain, e.g. if it’s run via a global hook.
+[flake8]
+max-line-length = 100
+extend-ignore = E203


### PR DESCRIPTION
This was removed when we switched to using Ruff instead of a collection of individual linter and static analysis tools.

The reason to bring it back is that flake8 doesn’t complain about overly long lines, if it’s configured to be run e.g. by the editor or a global pre-commit hook.