### PR TITLE
Deduplicate notifications when sending them.

### DIFF
--- a/fmn/rules/notification.py
+++ b/fmn/rules/notification.py
@@ -1,44 +1,49 @@
-from typing import Annotated, Literal, TypedDict
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
 
 
-class EmailNotificationHeaders(TypedDict):
+class FrozenModel(BaseModel):
+    class Config:
+        frozen = True
+
+
+class EmailNotificationHeaders(FrozenModel):
     To: str
     Subject: str
 
 
-class EmailNotificationContent(BaseModel):
+class EmailNotificationContent(FrozenModel):
     headers: EmailNotificationHeaders
     body: str
 
 
-class EmailNotification(BaseModel):
+class EmailNotification(FrozenModel):
     protocol: Literal["email"]
     content: EmailNotificationContent
 
 
-class IRCNotificationContent(BaseModel):
+class IRCNotificationContent(FrozenModel):
     to: str
     message: str
 
 
-class IRCNotification(BaseModel):
+class IRCNotification(FrozenModel):
     protocol: Literal["irc"]
     content: IRCNotificationContent
 
 
-class MatrixNotificationContent(BaseModel):
+class MatrixNotificationContent(FrozenModel):
     to: str
     message: str
 
 
-class MatrixNotification(BaseModel):
+class MatrixNotification(FrozenModel):
     protocol: Literal["matrix"]
     content: MatrixNotificationContent
 
 
-class Notification(BaseModel):
+class Notification(FrozenModel):
     __root__: Annotated[
         EmailNotification | IRCNotification | MatrixNotification, Field(discriminator="protocol")
     ]

--- a/tests/database/model/test_rule.py
+++ b/tests/database/model/test_rule.py
@@ -41,7 +41,7 @@ class TestRule(ModelTestBase):
         result = [n async for n in db_async_obj.handle(message, requester)]
         tr_matches.assert_called_once_with(message, requester)
         assert len(result) == 3
-        assert [n.content.headers["To"] for n in result] == ["n1", "n2", "n3"]
+        assert [n.content.headers.dict()["To"] for n in result] == ["n1", "n2", "n3"]
 
     async def test_handle_no_match(db_async_session, db_async_obj, mocker, make_mocked_message):
         message = make_mocked_message(topic="dummy", body={"foo": "bar"})


### PR DESCRIPTION
A single message should not generate several times the same notification for the same user.

Fixes: #792