### PR TITLE
Filter unexpected project namespaces from Pagure

### DIFF
--- a/fmn/core/constants.py
+++ b/fmn/core/constants.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from functools import cache
 
 
 class ArtifactType(Enum):
@@ -7,6 +8,15 @@ class ArtifactType(Enum):
     containers = "containers"
     modules = "modules"
     flatpaks = "flatpaks"
+
+    @classmethod
+    @cache
+    def has_value(cls, value):
+        try:
+            cls(value)
+        except ValueError:
+            return False
+        return True
 
 
 DEFAULT_MATRIX_DOMAIN = "fedora.im"

--- a/tests/api/handlers/test_misc.py
+++ b/tests/api/handlers/test_misc.py
@@ -71,6 +71,14 @@ class TestMisc(BaseTestAPIV1Handler):
                     "namespace": "rpms",
                     "access_users": {"admin": ["dudemcpants"]},
                 },
+                # Some garbage for the handler to cope with:
+                {
+                    "description": "Hahahhaha!!!",
+                    "fullname": "i-don’t-exist/hahaha",
+                    "name": "hahaha",
+                    "namespace": "i-don’t-exist",
+                    "access_users": {"admin": ["dudemcpants"]},
+                },
             ],
         }
 
@@ -154,6 +162,13 @@ class TestMisc(BaseTestAPIV1Handler):
                     "fullname": "rpms/foobar",
                     "name": "foobar",
                     "namespace": "rpms",
+                },
+                # Some garbage for the handler to cope with:
+                {
+                    "description": "Hahahhaha!!!",
+                    "fullname": "i-don’t-exist/hahaha",
+                    "name": "hahaha",
+                    "namespace": "i-don’t-exist",
                 },
             ],
         }


### PR DESCRIPTION
The API endpoints proxying Pagure validate their results but querying Pagure could yield project namespaces not known to FMN (by mistake or new kinds of artifacts introduced) which makes the handler croak.

This was found to be necessary because of a bug in tinystage, where RPM package projects in test data used the `rpm` namespace instead of `rpms`. See fedora-infra/tiny-stage#44.

Fixes: #831