### PR TITLE
Straighten out API for querying artifacts

### DIFF
--- a/frontend/src/api/generated.ts
+++ b/frontend/src/api/generated.ts
@@ -43,12 +43,20 @@ export interface paths {
     /** Get Applications */
     get: operations["get_applications_api_v1_applications_get"];
   };
-  "/api/v1/artifacts/owned": {
-    /** Get Owned Artifacts */
-    get: operations["get_owned_artifacts_api_v1_artifacts_owned_get"];
-  };
   "/api/v1/artifacts": {
-    /** Get Artifacts */
+    /**
+     * Get Artifacts 
+     * @description This handler queries artifacts from Pagure
+     * 
+     * Proxying Pagure queries lets the API cache results to reduce load on the
+     * backend service.
+     * 
+     * :param names: Name patterns of artifacts which should be returned
+     * 
+     * :param users: Names of users whose artifacts should be returned
+     * 
+     * :param groups: Names of groups whose artifacts should be returned
+     */
     get: operations["get_artifacts_api_v1_artifacts_get"];
   };
   "/api/v1/healthz/live": {
@@ -62,6 +70,10 @@ export interface paths {
   "/api/v1/admin/rules": {
     /** Get Rules */
     get: operations["get_rules_api_v1_admin_rules_get"];
+  };
+  "/api/v1/admin/users": {
+    /** Get Users */
+    get: operations["get_users_api_v1_admin_users_get"];
   };
   "/api/v1/admin/rules/{id}": {
     /** Patch Rule */
@@ -78,13 +90,6 @@ export interface components {
       type: components["schemas"]["ArtifactType"];
       /** Name */
       name: string;
-    };
-    /** ArtifactOptionsGroup */
-    ArtifactOptionsGroup: {
-      /** Label */
-      label: string;
-      /** Options */
-      options: (components["schemas"]["Option_Artifact_"])[];
     };
     /**
      * ArtifactType 
@@ -110,28 +115,6 @@ export interface components {
       protocol: string;
       /** Address */
       address: string;
-    };
-    /** EmailNotification */
-    EmailNotification: {
-      /**
-       * Protocol 
-       * @enum {string}
-       */
-      protocol: "email";
-      content: components["schemas"]["EmailNotificationContent"];
-    };
-    /** EmailNotificationContent */
-    EmailNotificationContent: {
-      headers: components["schemas"]["EmailNotificationHeaders"];
-      /** Body */
-      body: string;
-    };
-    /** EmailNotificationHeaders */
-    EmailNotificationHeaders: {
-      /** To */
-      To: string;
-      /** Subject */
-      Subject: string;
     };
     /** Filters */
     Filters: {
@@ -166,22 +149,6 @@ export interface components {
       /** Detail */
       detail?: (components["schemas"]["ValidationError"])[];
     };
-    /** IRCNotification */
-    IRCNotification: {
-      /**
-       * Protocol 
-       * @enum {string}
-       */
-      protocol: "irc";
-      content: components["schemas"]["IRCNotificationContent"];
-    };
-    /** IRCNotificationContent */
-    IRCNotificationContent: {
-      /** To */
-      to: string;
-      /** Message */
-      message: string;
-    };
     /** ListParamTrackingRule */
     ListParamTrackingRule: {
       /**
@@ -191,22 +158,6 @@ export interface components {
       name: "artifacts-owned" | "artifacts-group-owned" | "users-followed";
       /** Params */
       params: (string)[];
-    };
-    /** MatrixNotification */
-    MatrixNotification: {
-      /**
-       * Protocol 
-       * @enum {string}
-       */
-      protocol: "matrix";
-      content: components["schemas"]["MatrixNotificationContent"];
-    };
-    /** MatrixNotificationContent */
-    MatrixNotificationContent: {
-      /** To */
-      to: string;
-      /** Message */
-      message: string;
     };
     /** NewRule */
     NewRule: {
@@ -231,14 +182,6 @@ export interface components {
       name: "related-events";
       /** Params */
       params?: string;
-    };
-    /** Notification */
-    Notification: components["schemas"]["EmailNotification"] | components["schemas"]["IRCNotification"] | components["schemas"]["MatrixNotification"];
-    /** Option[Artifact] */
-    Option_Artifact_: {
-      /** Label */
-      label: string;
-      value: components["schemas"]["Artifact"];
     };
     /** Rule */
     Rule: {
@@ -300,8 +243,8 @@ export type external = Record<string, never>;
 
 export interface operations {
 
+  /** Get Me */
   get_me_api_v1_users_me_get: {
-    /** Get Me */
     responses: {
       /** @description Successful Response */
       200: {
@@ -311,10 +254,10 @@ export interface operations {
       };
     };
   };
+  /** Get Users */
   get_users_api_v1_users_get: {
-    /** Get Users */
-    parameters?: {
-      query?: {
+    parameters: {
+      query: {
         search?: string;
       };
     };
@@ -333,8 +276,8 @@ export interface operations {
       };
     };
   };
+  /** Get User Info */
   get_user_info_api_v1_users__username__info_get: {
-    /** Get User Info */
     parameters: {
       path: {
         username: Record<string, never>;
@@ -355,8 +298,8 @@ export interface operations {
       };
     };
   };
+  /** Get User Groups */
   get_user_groups_api_v1_users__username__groups_get: {
-    /** Get User Groups */
     parameters: {
       path: {
         username: Record<string, never>;
@@ -377,8 +320,8 @@ export interface operations {
       };
     };
   };
+  /** Get User Destinations */
   get_user_destinations_api_v1_users__username__destinations_get: {
-    /** Get User Destinations */
     parameters: {
       path: {
         username: Record<string, never>;
@@ -399,8 +342,8 @@ export interface operations {
       };
     };
   };
+  /** Get User Rules */
   get_user_rules_api_v1_users__username__rules_get: {
-    /** Get User Rules */
     parameters: {
       path: {
         username: Record<string, never>;
@@ -421,8 +364,8 @@ export interface operations {
       };
     };
   };
+  /** Create User Rule */
   create_user_rule_api_v1_users__username__rules_post: {
-    /** Create User Rule */
     parameters: {
       path: {
         username: Record<string, never>;
@@ -448,8 +391,8 @@ export interface operations {
       };
     };
   };
+  /** Get User Rule */
   get_user_rule_api_v1_users__username__rules__id__get: {
-    /** Get User Rule */
     parameters: {
       path: {
         username: string;
@@ -471,8 +414,8 @@ export interface operations {
       };
     };
   };
+  /** Edit User Rule */
   edit_user_rule_api_v1_users__username__rules__id__put: {
-    /** Edit User Rule */
     parameters: {
       path: {
         username: string;
@@ -499,8 +442,8 @@ export interface operations {
       };
     };
   };
+  /** Delete User Rule */
   delete_user_rule_api_v1_users__username__rules__id__delete: {
-    /** Delete User Rule */
     parameters: {
       path: {
         username: string;
@@ -522,8 +465,8 @@ export interface operations {
       };
     };
   };
+  /** Get Applications */
   get_applications_api_v1_applications_get: {
-    /** Get Applications */
     responses: {
       /** @description Successful Response */
       200: {
@@ -533,10 +476,23 @@ export interface operations {
       };
     };
   };
-  get_owned_artifacts_api_v1_artifacts_owned_get: {
-    /** Get Owned Artifacts */
-    parameters?: {
-      query?: {
+  /**
+   * Get Artifacts 
+   * @description This handler queries artifacts from Pagure
+   * 
+   * Proxying Pagure queries lets the API cache results to reduce load on the
+   * backend service.
+   * 
+   * :param names: Name patterns of artifacts which should be returned
+   * 
+   * :param users: Names of users whose artifacts should be returned
+   * 
+   * :param groups: Names of groups whose artifacts should be returned
+   */
+  get_artifacts_api_v1_artifacts_get: {
+    parameters: {
+      query: {
+        names?: (string)[];
         users?: (string)[];
         groups?: (string)[];
       };
@@ -545,9 +501,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          "application/json": ({
-              [key: string]: string | undefined;
-            })[];
+          "application/json": (components["schemas"]["Artifact"])[];
         };
       };
       /** @description Validation Error */
@@ -558,55 +512,34 @@ export interface operations {
       };
     };
   };
-  get_artifacts_api_v1_artifacts_get: {
-    /** Get Artifacts */
+  /** Liveness Check */
+  liveness_check_api_v1_healthz_live_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": Record<string, never>;
+        };
+      };
+    };
+  };
+  /** Readiness Check */
+  readiness_check_api_v1_healthz_ready_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": Record<string, never>;
+        };
+      };
+    };
+  };
+  /** Get Rules */
+  get_rules_api_v1_admin_rules_get: {
     parameters: {
       query: {
-        name: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": (components["schemas"]["ArtifactOptionsGroup"])[];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  liveness_check_api_v1_healthz_live_get: {
-    /** Liveness Check */
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": Record<string, never>;
-        };
-      };
-    };
-  };
-  readiness_check_api_v1_healthz_ready_get: {
-    /** Readiness Check */
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": Record<string, never>;
-        };
-      };
-    };
-  };
-  get_rules_api_v1_admin_rules_get: {
-    /** Get Rules */
-    parameters?: {
-      query?: {
         disabled?: boolean;
+        username?: string;
       };
     };
     responses: {
@@ -624,8 +557,30 @@ export interface operations {
       };
     };
   };
+  /** Get Users */
+  get_users_api_v1_admin_users_get: {
+    parameters: {
+      query: {
+        search?: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": (components["schemas"]["User"])[];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Patch Rule */
   patch_rule_api_v1_admin_rules__id__patch: {
-    /** Patch Rule */
     parameters: {
       path: {
         id: number;

--- a/frontend/src/components/rule-edit/tracking-rule/ArtifactsFollowedParams.vue
+++ b/frontend/src/components/rule-edit/tracking-rule/ArtifactsFollowedParams.vue
@@ -33,7 +33,7 @@ const apiGetArtifacts = apiGet as QueryFunction<Artifact[]>;
 const route = "/api/v1/artifacts";
 const getArtifacts = async (query: string) => {
   const results = await apiGetArtifacts({
-    queryKey: [route, { name: query }],
+    queryKey: [route, { names: `*${query}*` }],
     meta: undefined,
   });
   return results;

--- a/frontend/src/components/rule-edit/tracking-rule/ArtifactsOwnedSummary.vue
+++ b/frontend/src/components/rule-edit/tracking-rule/ArtifactsOwnedSummary.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
   groups?: string[];
 }>();
 
-const route = "/api/v1/artifacts/owned";
+const route = "/api/v1/artifacts";
 const queryParams = computed(() => ({
   users: props.users,
   groups: props.groups,

--- a/tests/api/handlers/test_misc.py
+++ b/tests/api/handlers/test_misc.py
@@ -39,11 +39,8 @@ class TestMisc(BaseTestAPIV1Handler):
             "planet",
         ]
 
-    @pytest.mark.parametrize("ownertype", ("user", "group"))
-    async def test_get_projects(self, client, respx_mocker, ownertype):
-        settings = get_settings()
-        settings.services.distgit_url = "http://distgit.test"
-
+    @staticmethod
+    def mock_distgit_owned_projects(respx_mocker, settings, ownertype):
         if ownertype == "user":
             distgit_endpoint = f"{settings.services.distgit_url}/api/0/projects"
             params = {"fork": False, "short": False, "username": "dudemcpants"}
@@ -91,22 +88,87 @@ class TestMisc(BaseTestAPIV1Handler):
             ]
         )
 
-        if ownertype == "user":
-            response = client.get(f"{self.path}/artifacts/owned", params={"users": ["dudemcpants"]})
-        elif ownertype == "group":
-            response = client.get(f"{self.path}/artifacts/owned", params={"groups": ["dudegroup"]})
+        return route
 
-        assert route.called
+    @staticmethod
+    def mock_distgit_projects(respx_mocker, settings):
+        distgit_endpoint = f"{settings.services.distgit_url}/api/0/projects"
+        params = {"pattern": "*foobar*"}
+        distgit_json_response = {
+            "pagination": {
+                "pages": 1,
+            },
+            "projects": [
+                {
+                    "description": "foobar containers",
+                    "fullname": "containers/foobar",
+                    "name": "foobar",
+                    "namespace": "containers",
+                },
+                {
+                    "description": "foobar rpms",
+                    "fullname": "rpms/foobar",
+                    "name": "foobar",
+                    "namespace": "rpms",
+                },
+                # Some garbage for the handler to cope with:
+                {
+                    "description": "Hahahhaha!!!",
+                    "fullname": "i-don’t-exist/hahaha",
+                    "name": "hahaha",
+                    "namespace": "i-don’t-exist",
+                    "access_users": {"admin": ["dudemcpants"]},
+                },
+            ],
+        }
 
-        assert response.json() == [
-            {"name": "pants", "type": "containers"},
-            {"name": "trousers", "type": "rpms"},
-        ]
+        route = respx_mocker.get(distgit_endpoint, params=params).mock(
+            side_effect=[
+                Response(
+                    status.HTTP_200_OK,
+                    json=distgit_json_response,
+                )
+            ]
+        )
 
-    def test_get_projects_no_user_or_group(self, client):
-        response = client.get(f"{self.path}/artifacts/owned")
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == []
+        return route
+
+    @pytest.mark.parametrize("testcase", ("user", "group", "user-group", "name", "nothing"))
+    async def test_get_artifacts(self, client, respx_mocker, testcase):
+        settings = get_settings()
+        settings.services.distgit_url = "http://distgit.test"
+
+        routes = {}
+        query_params = {}
+
+        if "user" in testcase:
+            routes["user"] = self.mock_distgit_owned_projects(respx_mocker, settings, "user")
+            query_params["users"] = ["dudemcpants"]
+
+        if "group" in testcase:
+            routes["group"] = self.mock_distgit_owned_projects(respx_mocker, settings, "group")
+            query_params["groups"] = ["dudegroup"]
+
+        if "name" in testcase:
+            routes["name"] = self.mock_distgit_projects(respx_mocker, settings)
+            query_params["names"] = ["*foobar*"]
+
+        response = client.get(f"{self.path}/artifacts", params=query_params)
+        result = response.json()
+
+        for what in ("user", "group", "name"):
+            if what in testcase:
+                assert routes[what].called
+
+        if "user" in testcase or "group" in testcase:
+            assert {"name": "pants", "type": "containers"} in result
+            assert {"name": "trousers", "type": "rpms"} in result
+
+        if "name" in testcase:
+            assert {"name": "foobar", "type": "containers"} in result
+            assert {"name": "foobar", "type": "rpms"} in result
+
+        assert result == sorted(result, key=lambda item: (item["type"], item["name"]))
 
     def test_liveness(self, client):
         response = client.get(f"{self.path}/healthz/live")
@@ -139,54 +201,3 @@ class TestMisc(BaseTestAPIV1Handler):
         response = client.get(f"{self.path}/healthz/ready")
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.json()["detail"] == "Database schema needs to be upgraded"
-
-    async def test_get_artifacts(self, client, respx_mocker):
-        settings = get_settings()
-        settings.services.distgit_url = "http://distgit.test"
-
-        distgit_endpoint = f"{settings.services.distgit_url}/api/0/projects"
-        params = {"pattern": "*foobar*"}
-        distgit_json_response = {
-            "pagination": {
-                "pages": 1,
-            },
-            "projects": [
-                {
-                    "description": "foobar containers",
-                    "fullname": "containers/foobar",
-                    "name": "foobar",
-                    "namespace": "containers",
-                },
-                {
-                    "description": "foobar rpms",
-                    "fullname": "rpms/foobar",
-                    "name": "foobar",
-                    "namespace": "rpms",
-                },
-                # Some garbage for the handler to cope with:
-                {
-                    "description": "Hahahhaha!!!",
-                    "fullname": "i-don’t-exist/hahaha",
-                    "name": "hahaha",
-                    "namespace": "i-don’t-exist",
-                },
-            ],
-        }
-
-        route = respx_mocker.get(distgit_endpoint, params=params).mock(
-            side_effect=[
-                Response(
-                    status.HTTP_200_OK,
-                    json=distgit_json_response,
-                )
-            ]
-        )
-
-        response = client.get(f"{self.path}/artifacts", params={"name": ["foobar"]})
-
-        assert route.called
-
-        assert response.json() == [
-            {"name": "foobar", "type": "containers"},
-            {"name": "foobar", "type": "rpms"},
-        ]


### PR DESCRIPTION
This merges the `/artifacts/owned` endpoint into `/artifacts` and also shifts applying wildcards to name patterns from the backend to the frontend.

Fixes: #779