### PR TITLE
Consistently show artifact type in the frontend

### DIFF
--- a/frontend/src/components/rule-edit/tracking-rule/ArtifactsFollowedParams.vue
+++ b/frontend/src/components/rule-edit/tracking-rule/ArtifactsFollowedParams.vue
@@ -22,7 +22,7 @@ const resultsToOptions = (results: Artifact[]) => {
       (o) => o.label === ARTIFACT_CATEGORY_LABELS[artifact.type]
     )[0];
     category.options.push({
-      label: artifact.name,
+      label: `${artifact.type}/${artifact.name}`,
       value: artifact,
     });
   });


### PR DESCRIPTION
Previously, newly added artifacts only were listed with their names but when editing, existing artifacts were shown with their types.

In this example, `rpms/0ad` was an existing artifact tracked by the rule, `apron` was added:

![image](https://user-images.githubusercontent.com/820624/229124752-4b533a32-5948-4d35-87b2-8d8143984d66.png)
