### PR TITLE
Better handling of sender errors

### DIFF
--- a/fmn/sender/cli.py
+++ b/fmn/sender/cli.py
@@ -28,8 +28,6 @@ async def _main(handler, consumer):
         await asyncio.wait_for(handler.setup(), timeout=HANDLER_CONNECT_TIMEOUT)
     except asyncio.exceptions.TimeoutError as e:
         raise HandlerError(f"the handler could not connect in {HANDLER_CONNECT_TIMEOUT}s") from e
-    except HandlerError as e:
-        raise HandlerError(f"the handler could not connect: {e}") from e
 
     # Shutdown in case of unexpected disconnections
     shutdown_on_closed = asyncio.create_task(_shutdown(handler.closed, consumer))

--- a/fmn/sender/cli.py
+++ b/fmn/sender/cli.py
@@ -11,6 +11,8 @@ from .config import get_config, get_handler, setup_logging
 from .consumer import Consumer
 from .handler import HandlerError
 
+HANDLER_CONNECT_TIMEOUT = 60
+
 
 def shutdown(result, consumer):
     if asyncio.isfuture(result):
@@ -25,7 +27,9 @@ def shutdown(result, consumer):
 
 async def _main(handler, consumer):
     try:
-        await handler.setup()
+        await asyncio.wait_for(handler.setup(), timeout=HANDLER_CONNECT_TIMEOUT)
+    except asyncio.exceptions.TimeoutError as e:
+        raise HandlerError(f"the handler could not connect in {HANDLER_CONNECT_TIMEOUT}s") from e
     except HandlerError as e:
         raise HandlerError(f"the handler could not connect: {e}") from e
     # Shutdown in case of unexpected disconnections

--- a/fmn/sender/cli.py
+++ b/fmn/sender/cli.py
@@ -9,6 +9,7 @@ import click
 
 from .config import get_config, get_handler, setup_logging
 from .consumer import Consumer
+from .handler import HandlerError
 
 
 def shutdown(result, consumer):
@@ -23,7 +24,10 @@ def shutdown(result, consumer):
 
 
 async def _main(handler, consumer):
-    await handler.setup()
+    try:
+        await handler.setup()
+    except HandlerError as e:
+        raise HandlerError(f"the handler could not connect: {e}") from e
     # Shutdown in case of unexpected disconnections
     handler.closed.add_done_callback(partial(shutdown, consumer=consumer))
     await consumer.connect()

--- a/fmn/sender/consumer.py
+++ b/fmn/sender/consumer.py
@@ -43,11 +43,14 @@ class Consumer:
                     break
                 async with message.process():
                     await self._handler.handle(json.loads(message.body))
+        await self._queue_iter.close()
 
     async def stop(self):
         log.info("Stopping messages consumption")
         if self._queue_iter:
             await self._queue_iter.on_message(CLOSING)
+            # Close the queue now or closing the connection just below will cancel the iterator
+            # and raise an exception in start()
             await self._queue_iter.close()
         if self._connection:
             await self._connection.close()

--- a/fmn/sender/handler.py
+++ b/fmn/sender/handler.py
@@ -22,6 +22,10 @@ class Handler:
         raise NotImplementedError
 
 
+class HandlerError(Exception):
+    pass
+
+
 class PrintHandler(Handler):
     async def handle(self, message):
         print("Received:", message)

--- a/fmn/sender/handler.py
+++ b/fmn/sender/handler.py
@@ -3,13 +3,12 @@
 # SPDX-License-Identifier: MIT
 
 import asyncio
+from functools import cached_property
 
 
 class Handler:
     def __init__(self, config):
         self._config = config
-        # Triggered when there is an error and the app should stop
-        self.closed = asyncio.get_event_loop().create_future()
 
     async def setup(self):
         # Here we connect to the destination server if relevant.
@@ -17,6 +16,14 @@ class Handler:
 
     async def stop(self):
         pass
+
+    @cached_property
+    def closed(self):
+        """Default `closed` Future, can be overridden in child classes.
+
+        It should be triggered when there is an error and the app should stop.
+        """
+        return asyncio.get_event_loop().create_future()
 
     async def handle(self, message):
         raise NotImplementedError

--- a/fmn/sender/handler.py
+++ b/fmn/sender/handler.py
@@ -2,10 +2,14 @@
 #
 # SPDX-License-Identifier: MIT
 
+import asyncio
+
 
 class Handler:
     def __init__(self, config):
         self._config = config
+        # Triggered when there is an error and the app should stop
+        self.closed = asyncio.get_event_loop().create_future()
 
     async def setup(self):
         # Here we connect to the destination server if relevant.

--- a/fmn/sender/irc.py
+++ b/fmn/sender/irc.py
@@ -54,6 +54,9 @@ class IRCClient(AioSimpleIRCClient):
         await self.connection.connect(*args, **kwargs)
         try:
             await self._connection_future
+        except asyncio.exceptions.CancelledError:
+            self.connection.disconnect("Connection cancelled")
+            raise
         except ServerConnectionError as e:
             message = e.args[0]
             self.closed.set_result(message)

--- a/fmn/sender/irc.py
+++ b/fmn/sender/irc.py
@@ -19,7 +19,6 @@ class IRCHandler(Handler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._client = IRCClient()
-        self.closed = self._client.closed
 
     async def setup(self):
         irc_url = urlparse(self._config["irc_url"])
@@ -35,6 +34,10 @@ class IRCHandler(Handler):
     async def stop(self):
         log.debug("Stopping IRC handler...")
         await self._client.disconnect()
+
+    @property
+    def closed(self):
+        return self._client.closed
 
     async def handle(self, message):
         log.info("Sending messsage to %s: %s", message["to"], message["message"])

--- a/fmn/sender/irc.py
+++ b/fmn/sender/irc.py
@@ -50,8 +50,10 @@ class IRCClient(AioSimpleIRCClient):
         # This is not async yet.
         return self.connection.privmsg(*args, **kwargs)
 
-    def on_welcome(self, connection, event):
-        self._connection_future.set_result(connection)
-
     async def disconnect(self):
         return self.connection.disconnect()
+
+    def on_900(self, connection, event):
+        # When logged in.
+        # See IRCv3: https://ircv3.net/specs/extensions/sasl-3.1.html#numerics-used-by-this-extension
+        self._connection_future.set_result(connection)

--- a/fmn/sender/irc.py
+++ b/fmn/sender/irc.py
@@ -63,7 +63,7 @@ class IRCClient(AioSimpleIRCClient):
         except ServerConnectionError as e:
             message = e.args[0]
             self.closed.set_result(message)
-            raise HandlerError(message) from e
+            raise HandlerError(f"the handler could not connect: {message}") from e
 
     async def privmsg(self, *args, **kwargs):
         # This is not async yet.

--- a/tests/sender/test_cli.py
+++ b/tests/sender/test_cli.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import asyncio
 from textwrap import dedent
 from unittest.mock import AsyncMock, MagicMock
 
@@ -34,27 +35,33 @@ def config_file(tmp_path):
     return config_path
 
 
-def test_cli(config_file, mocker):
-    mocked_handler = MagicMock(spec=Handler)
-    mocker.patch("fmn.sender.cli.get_handler", return_value=mocked_handler)
-    mocked_consumer = MagicMock(spec=Consumer)
-    mocker.patch("fmn.sender.cli.Consumer", return_value=mocked_consumer)
+@pytest.fixture
+def mocked_handler(mocker):
+    handler = MagicMock(spec=Handler)
+    handler.closed = asyncio.get_event_loop().create_future()
+    mocker.patch("fmn.sender.cli.get_handler", return_value=handler)
+    return handler
 
+
+@pytest.fixture
+def mocked_consumer(mocker):
+    consumer = MagicMock(spec=Consumer)
+    mocker.patch("fmn.sender.cli.Consumer", return_value=consumer)
+    return consumer
+
+
+def test_cli(config_file, mocked_handler, mocked_consumer):
     runner = CliRunner()
     result = runner.invoke(cli.main, ["-c", config_file])
 
-    mocked_handler.setup.assert_called_once_with()
-    mocked_consumer.connect.assert_called_once_with()
-    mocked_consumer.start.assert_called_once_with()
+    mocked_handler.setup.assert_awaited_once_with()
+    mocked_consumer.connect.assert_awaited_once_with()
+    mocked_consumer.start.assert_awaited_once_with()
     assert result.exit_code == 0
     assert result.output == ""
 
 
-def test_cli_keyboardinterrupt(config_file, mocker):
-    mocked_handler = MagicMock(spec=Handler)
-    mocker.patch("fmn.sender.cli.get_handler", return_value=mocked_handler)
-    mocked_consumer = MagicMock(spec=Consumer)
-    mocker.patch("fmn.sender.cli.Consumer", return_value=mocked_consumer)
+def test_cli_keyboardinterrupt(config_file, mocked_handler, mocked_consumer):
     mocked_consumer.start = AsyncMock(side_effect=KeyboardInterrupt)
 
     runner = CliRunner()
@@ -62,3 +69,29 @@ def test_cli_keyboardinterrupt(config_file, mocker):
 
     assert result.exit_code == 1
     assert result.output == "\nAborted!\n"
+
+
+def test_cli_generic_error(config_file, mocked_handler, mocked_consumer):
+    mocked_consumer.start = AsyncMock(side_effect=RuntimeError("dummy error"))
+
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["-c", config_file])
+
+    assert result.exit_code == 1
+    assert result.output == "Shutting down: exception caught\nError: dummy error\n"
+    mocked_consumer.stop.assert_awaited_once_with()
+
+
+def test_cli_handler_closed(config_file, mocker, mocked_handler, mocked_consumer):
+    async def _close():
+        mocked_handler.closed.set_result("dummy close")
+        # give it time to call consumer.stop()
+        await asyncio.sleep(1)
+
+    mocked_consumer.start = AsyncMock(side_effect=_close)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["-c", config_file])
+
+    mocked_consumer.stop.assert_awaited_once_with()
+    assert result.output == "Shutting down: dummy close\n"

--- a/tests/sender/test_cli.py
+++ b/tests/sender/test_cli.py
@@ -89,9 +89,7 @@ def test_cli_handler_setup_error(config_file, mocked_handler, mocked_consumer):
     result = runner.invoke(cli.main, ["-c", config_file])
 
     assert result.exit_code == 1
-    expected = (
-        "Shutting down: exception caught\nError: the handler could not connect: dummy error\n"
-    )
+    expected = "Shutting down: exception caught\nError: dummy error\n"
     assert result.output == expected
     mocked_consumer.stop.assert_awaited_once_with()
 

--- a/tests/sender/test_cli.py
+++ b/tests/sender/test_cli.py
@@ -123,5 +123,5 @@ def test_cli_handler_closed(config_file, mocker, mocked_handler, mocked_consumer
     runner = CliRunner()
     result = runner.invoke(cli.main, ["-c", config_file])
 
-    mocked_consumer.stop.assert_awaited_once_with()
     assert result.output == "Shutting down: dummy close\n"
+    mocked_consumer.stop.assert_awaited_once_with()

--- a/tests/sender/test_irc.py
+++ b/tests/sender/test_irc.py
@@ -91,11 +91,11 @@ async def test_irc_disconnect_expected(handler):
     await handler.setup()
     await handler.stop()
     # We didn't call the shutdown handler
-    assert handler.closed.done() is False
+    assert not handler.closed.done()
 
 
 async def test_irc_disconnect_not_connected(handler):
     handler._client.connected = False
     await handler.stop()
     # We didn't call the shutdown handler
-    assert handler.closed.done() is False
+    assert not handler.closed.done()

--- a/tests/sender/test_irc.py
+++ b/tests/sender/test_irc.py
@@ -53,7 +53,7 @@ async def test_irc_connect(mocker, transport):
 
     await handler.stop()
 
-    transport.write.assert_called_with(b"QUIT\r\n")
+    transport.write.assert_called_with(b"QUIT :FMN is shutting down\r\n")
     transport.close.assert_called_with()
 
 
@@ -68,3 +68,18 @@ async def test_irc_error_while_connected(handler, error_type):
     await handler.setup()
     _send_event(handler, transport, error_type, "server", "user", ["dummy error"])
     await handler.closed
+
+
+async def test_irc_disconnect_expected(handler):
+    _send_event(handler, transport, "900", "server", "user")
+    await handler.setup()
+    await handler.stop()
+    # We didn't call the shutdown handler
+    assert handler.closed.done() is False
+
+
+async def test_irc_disconnect_not_connected(handler):
+    handler._client.connected = False
+    await handler.stop()
+    # We didn't call the shutdown handler
+    assert handler.closed.done() is False


### PR DESCRIPTION
Quite a few commits in this PR, I hope they are clear enough.

Now, when a protocol handler errors out, the sender component should shutdown (and get restarted by OpenShift)