### PR TITLE
Allow rule names to be None in the outgoing messages

### DIFF
--- a/changelog.d/879.fixed
+++ b/changelog.d/879.fixed
@@ -1,0 +1,1 @@
+API: Allow rule names to be None in the outgoing Fedora messages

--- a/changelog.d/879.fixed
+++ b/changelog.d/879.fixed
@@ -1,1 +1,2 @@
-API: Allow rule names to be None in the outgoing Fedora messages
+API: Allow rule names to be None in the outgoing Fedora messages.
+Message schema: make rule.id and user.name required as well.

--- a/fmn/messages/rule.py
+++ b/fmn/messages/rule.py
@@ -12,7 +12,7 @@ RULE_SCHEMA = {
             "description": "The ID of the rule",
         },
         "name": {
-            "type": "string",
+            "type": ["string", "null"],
             "description": "The name of the rule",
         },
     },

--- a/fmn/messages/rule.py
+++ b/fmn/messages/rule.py
@@ -16,6 +16,7 @@ RULE_SCHEMA = {
             "description": "The name of the rule",
         },
     },
+    "required": ["id"],
 }
 USER_SCHEMA = {
     "type": "object",
@@ -25,6 +26,7 @@ USER_SCHEMA = {
             "description": "The FAS username",
         }
     },
+    "required": ["name"],
 }
 
 

--- a/tests/messages/test_base.py
+++ b/tests/messages/test_base.py
@@ -3,20 +3,33 @@
 # SPDX-License-Identifier: MIT
 
 import pytest
-from fedora_messaging.message import ValidationError
+from jsonschema.exceptions import ValidationError
 
 from fmn.messages.rule import RuleCreateV1
 
 
 def test_messages_base():
-    message = RuleCreateV1({"rule": {}, "user": {}})
+    message = RuleCreateV1({"rule": {"id": 1}, "user": {"name": "dummy"}})
     assert message.app_name == "FMN"
     assert message.app_icon == "https://apps.fedoraproject.org/img/icons/fedmsg.png"
-
-
-def test_messages_rule_no_name():
-    message = RuleCreateV1({"rule": {"name": None}, "user": {}})
     try:
         message.validate()
     except ValidationError as e:
         pytest.fail(e)
+
+
+def test_messages_rule_no_name():
+    message = RuleCreateV1({"rule": {"id": 1, "name": None}, "user": {"name": "dummy"}})
+    try:
+        message.validate()
+    except ValidationError as e:
+        pytest.fail(e)
+
+
+@pytest.mark.parametrize(
+    "body", [{"rule": {}, "user": {"name": "dummy"}}, {"rule": {"id": 1}, "user": {}}]
+)
+def test_messages_rule_missing_values(body):
+    message = RuleCreateV1(body)
+    with pytest.raises(ValidationError):
+        message.validate()

--- a/tests/messages/test_base.py
+++ b/tests/messages/test_base.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
+import pytest
+from fedora_messaging.message import ValidationError
+
 from fmn.messages.rule import RuleCreateV1
 
 
@@ -9,3 +12,11 @@ def test_messages_base():
     message = RuleCreateV1({"rule": {}, "user": {}})
     assert message.app_name == "FMN"
     assert message.app_icon == "https://apps.fedoraproject.org/img/icons/fedmsg.png"
+
+
+def test_messages_rule_no_name():
+    message = RuleCreateV1({"rule": {"name": None}, "user": {}})
+    try:
+        message.validate()
+    except ValidationError as e:
+        pytest.fail(e)


### PR DESCRIPTION
Fixes: #879 