### PR TITLE
IRC sender: handle libera.chat somtimes not sending us the LOGGED_IN response

### DIFF
--- a/changelog.d/884.fixed
+++ b/changelog.d/884.fixed
@@ -1,0 +1,1 @@
+IRC sender: handle libera.chat not sending us the LOGGED_IN response

--- a/poetry.lock
+++ b/poetry.lock
@@ -3104,6 +3104,21 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.1.0"
+description = "pytest plugin to abort hanging tests"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pytest-timeout-2.1.0.tar.gz", hash = "sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9"},
+    {file = "pytest_timeout-2.1.0-py3-none-any.whl", hash = "sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6"},
+]
+
+[package.dependencies]
+pytest = ">=5.0.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -4429,4 +4444,4 @@ sqlite = ["aiosqlite"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d0d29c25bd3c2097db7d9071998641a5b22f287994ef3398abfebd48266d2b49"
+content-hash = "e809a10955b075e57a4ecb10ef37c709ca5031881f9f4144534f7bd536492663"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ sphinx = "^6.1.3"
 myst-parser = "^1.0.0"
 diskcache = "^5.4.0"
 reuse = "^1.1.2"
+pytest-timeout = "^2.1.0"
 
 [tool.poetry.extras]
 api = [
@@ -177,6 +178,7 @@ schemas = [
 [tool.pytest.ini_options]
 addopts = "--cov-config .coveragerc --cov=fmn --cov-report term --cov-report xml --cov-report html"
 asyncio_mode = "auto"
+timeout = 60
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
We'll rely on the private notice that Nickserv sends us in case there is no `LOGGED_IN` response.

Fixes: #884