### PR TITLE
Add a collectd module to export the cache build stats to collectd

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,12 +21,12 @@ jobs:
       # fmn/database/migrations directory, therefore it has to use absolute imports.
       - name: Enforce relative imports in package (except Alembic migrations)
         run: >
-          find fmn -name \*.py -a \! -path fmn/database/migrations/env.py -print0
+          find fmn -name \*.py -a \! -path fmn/database/migrations/env.py -a \! -path fmn/core/collectd.py -print0
           | xargs -0 absolufy-imports --never
 
-      - name: Preserve absolute import in Alembic env.py file
+      - name: Preserve absolute import in files that are called externally
         run: >
-          absolufy-imports fmn/database/migrations/env.py
+          absolufy-imports fmn/database/migrations/env.py fmn/core/collectd.py
 
   backend-ci:
     strategy:

--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -48,8 +48,6 @@ pip install redis
 cd frontend
 npm install
 
-env
-
 if [ "$FEDORA_ENV" == "staging" ]; then
     npm run build:staging
 else

--- a/.s2i/run-collectd.sh
+++ b/.s2i/run-collectd.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Contributors to the Fedora Project
+#
+# SPDX-License-Identifier: MIT
+
+set -e
+
+# We install the app in a specific virtualenv:
+export PATH=/opt/app-root/src/.local/venvs/fmn/bin:$PATH
+
+# Run collectd
+collectd -f -C /etc/fmn/collectd.conf

--- a/changelog.d/PRXXX.feature
+++ b/changelog.d/PRXXX.feature
@@ -1,0 +1,1 @@
+Send the cache building stats to collectd

--- a/config/collectd-fmn.conf.example
+++ b/config/collectd-fmn.conf.example
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Contributors to the Fedora Project
+#
+# SPDX-License-Identifier: MIT
+
+TypesDB "/usr/share/collectd/fmn-types.db"
+
+<LoadPlugin python>
+  Globals true
+</LoadPlugin>
+
+<Plugin python>
+  LogTraces true
+  Interactive false
+  # ModulePath "/opt/app-root/src"
+  Import "fmn.core.collectd"
+
+  <Module "fmn.core.collectd">
+    ## Interval between two collections. The collectd default of 10 seconds is
+    ## way too short, this plugin sets the default to 1h (3600s). Adjust
+    ## depending on how frequently the cache is rebuilt. Remember that if you
+    ## change the interval, you'll have to recreate your RRD files.
+    # Interval 3600
+  </Module>
+</Plugin>

--- a/config/collectd-types.db
+++ b/config/collectd-types.db
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Contributors to the Fedora Project
+#
+# SPDX-License-Identifier: MIT
+
+fmn_cache        value:GAUGE:0:U

--- a/devel/ansible/playbook.yml
+++ b/devel/ansible/playbook.yml
@@ -23,3 +23,4 @@
     - consumer
     - sender
     - redis
+    - collectd

--- a/devel/ansible/roles/collectd/handlers/main.yml
+++ b/devel/ansible/roles/collectd/handlers/main.yml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Contributors to the Fedora Project
+#
+# SPDX-License-Identifier: MIT
+
+- name: restart collectd
+  service:
+    name: collectd
+    state: restarted

--- a/devel/ansible/roles/collectd/tasks/main.yml
+++ b/devel/ansible/roles/collectd/tasks/main.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Contributors to the Fedora Project
+#
+# SPDX-License-Identifier: MIT
+
+- name: install packages
+  dnf:
+    name:
+      - collectd
+      - collectd-python
+      - collectd-rrdtool
+      - collectd-write_syslog
+
+- name: allow collectd to do network connections
+  seboolean:
+    name: collectd_tcp_network_connect
+    persistent: true
+    state: true
+
+- name: get FMN's virtualenv
+  shell:
+    cmd: "poetry run python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())'"
+    chdir: /home/vagrant/fmn/
+  register: fmn_venv_lib
+  changed_when: false
+
+- name: get FMN's virtualenv
+  shell:
+    cmd: "poetry run python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib(True))'"
+    chdir: /home/vagrant/fmn/
+  register: fmn_venv_arch
+  changed_when: false
+
+- name: copy the collectd config file over
+  template:
+    src: collectd.conf
+    dest: /etc/collectd.conf
+  notify:
+    - restart collectd
+
+- name: copy the collectd types DB
+  copy:
+    remote_src: true
+    src: /home/vagrant/fmn/config/collectd-types.db
+    dest: /usr/share/collectd/fmn-types.db
+  notify:
+    - restart collectd
+
+- name: set the collectd service to start
+  service:
+    name: collectd
+    enabled: true
+    state: started

--- a/devel/ansible/roles/collectd/templates/collectd.conf
+++ b/devel/ansible/roles/collectd/templates/collectd.conf
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Contributors to the Fedora Project
+#
+# SPDX-License-Identifier: MIT
+
+Hostname    "{{ ansible_hostname }}"
+FQDNLookup   true
+#BaseDir     "/usr/var/lib/collectd"
+#PIDFile     "/usr/var/run/collectd.pid"
+#PluginDir   "/usr/lib/collectd"
+#Interval     10
+#ReadThreads  5
+
+# This is the default but it needs to be defined so we can add more DB files later.
+TypesDB     "/usr/share/collectd/types.db"
+
+LoadPlugin logfile
+
+<Plugin LogFile>
+    LogLevel "info"
+    File STDOUT
+    Timestamp true
+</Plugin>
+
+# Write data to disk
+LoadPlugin csv
+<Plugin "csv">
+  DataDir "/var/lib/collectd/csv"
+  StoreRates true
+</Plugin>
+LoadPlugin rrdtool
+<Plugin "rrdtool">
+  DataDir "/var/lib/collectd/rrd"
+  CacheFlush 120
+  WritesPerSecond 50
+</Plugin>
+
+# FMN
+
+TypesDB "/usr/share/collectd/fmn-types.db"
+
+<LoadPlugin python>
+  Globals true
+</LoadPlugin>
+
+<Plugin python>
+  LogTraces true
+  Interactive false
+  ModulePath "{{ fmn_venv_lib.stdout }}"
+  ModulePath "{{ fmn_venv_arch.stdout }}"
+  ModulePath "/home/vagrant/fmn"
+  Import "fmn.core.collectd"
+
+  <Module "fmn.core.collectd">
+    ## Interval between two collections. The collectd default of 10 seconds is
+    ## way too short, this plugin sets the default to 1h (3600s). Adjust
+    ## depending on how frequently the cache is rebuilt. Remember that if you
+    ## change the interval, you'll have to recreate your RRD files.
+    # Interval 3600
+  </Module>
+</Plugin>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,7 @@ def run_apidoc(_):
             os.path.join(topdir, "fmn"),
             # exclude patterns:
             os.path.join(topdir, "fmn", "database", "migrations"),
+            os.path.join(topdir, "fmn", "core", "collectd.py"),
         ]
     )
 

--- a/fmn/core/collectd.py
+++ b/fmn/core/collectd.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Contributors to the Fedora Project
+#
+# SPDX-License-Identifier: MIT
+
+import asyncio
+import os
+from datetime import datetime
+from functools import partial
+
+import collectd
+from cashews import cache
+
+from fmn.cache import configure_cache
+
+CONFIG = {
+    "Interval": "3600",
+    "Hostname": None,
+}
+
+
+class Collector:
+    def __init__(self, config):
+        self.config = config
+        self._loop = None
+
+    def setup(self):
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        configure_cache()
+
+    def shutdown(self):
+        self._loop.run_until_complete(cache.close())
+        # Now shutdown the asyncio loop. Use a Runner when Python 3.11 is more widespread
+        to_cancel = asyncio.all_tasks(self._loop)
+        for task in to_cancel:
+            task.cancel()
+        self._loop.run_until_complete(asyncio.gather(*to_cancel, return_exceptions=True))
+        self._loop.run_until_complete(self._loop.shutdown_asyncgens())
+        self._loop.run_until_complete(self._loop.shutdown_default_executor())
+        asyncio.set_event_loop(None)
+        self._loop.close()
+
+    def collect(self):
+        self._loop.run_until_complete(self._collect())
+
+    async def _collect(self):
+        now = datetime.now().timestamp()
+        async for key in cache.scan("duration:*"):
+            _, name, when = key.split(":", 2)
+            duration = await cache.get(key)
+            if duration is None:
+                collectd.debug(f"Not dispatching {name} at {when}: value is None")
+                continue
+            when = datetime.fromisoformat(when).timestamp()
+            if now - when > int(self.config["Interval"]) * 24:
+                collectd.debug(f"Not dispatching {name} at {when}: too old")
+                continue
+            collectd.debug(f"Dispatching {name} at {when}: {duration!r}")
+            await self._loop.run_in_executor(
+                None,
+                partial(
+                    self._dispatch,
+                    duration,
+                    name,
+                    timestamp=when,
+                    category="cache",
+                ),
+            )
+
+    def _dispatch(self, value, name, timestamp=None, subname=None, category=None):
+        vl = collectd.Values()
+        vl.type = "fmn_cache"
+        vl.plugin = category or name
+        vl.time = timestamp
+        hostname = self.config.get("Hostname")
+        if hostname is not None:
+            vl.host = hostname
+        vl.interval = int(self.config["Interval"])
+        type_instance = name
+        if subname is not None:
+            type_instance = f"{type_instance}-{subname}"
+        vl.type_instance = type_instance
+        if not hasattr(value, "__iter__"):
+            value = [value]
+        vl.dispatch(values=value)
+
+
+def configure(plugin_config):
+    config = CONFIG.copy()
+    for conf_entry in plugin_config.children:
+        collectd.debug(f"{conf_entry.key} = {conf_entry.values}")
+        try:
+            if conf_entry.key == "SetEnv":
+                envvar, value = conf_entry.values
+                os.environ[envvar] = value
+            else:
+                if len(conf_entry.values) != 1:
+                    raise ValueError
+                config[conf_entry.key] = conf_entry.values[0]
+        except ValueError:
+            collectd.warning(
+                f"Invalid configuration value for {conf_entry.key}: {conf_entry.values!r}"
+            )
+            continue
+
+    collector = Collector(config=config)
+    collectd.register_init(collector.setup)
+    collectd.register_shutdown(collector.shutdown)
+    collectd.register_read(collector.collect, int(config["Interval"]))
+
+
+collectd.register_config(configure)

--- a/tests/core/test_collectd.py
+++ b/tests/core/test_collectd.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Contributors to the Fedora Project
+#
+# SPDX-License-Identifier: MIT
+
+import asyncio
+import sys
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+
+@pytest.fixture
+def collectd(monkeypatch):
+    mod = Mock(name="collectd-api")
+    with monkeypatch.context() as mp:
+        mp.setitem(sys.modules, "collectd", mod)
+        from fmn.core import collectd
+
+    return collectd
+
+
+@pytest.fixture
+def created_values(collectd):
+    """Record created Values instances"""
+    values = []
+
+    def _create_values():
+        v = Mock()
+        values.append(v)
+        print("creating valueset", v)
+        return v
+
+    collectd.collectd.Values = _create_values
+    return values
+
+
+@pytest.fixture
+def scan_result(collectd, monkeypatch):
+    cache = Mock()
+    monkeypatch.setattr(collectd, "cache", cache)
+    scan_result = AsyncMock()
+    cache.scan.return_value = scan_result
+    results = []
+    scan_result.__aiter__.return_value = results
+    return results
+
+
+def test_registration(collectd):
+    collectd.collectd.register_config.assert_called_once()
+
+
+class ConfigItem:
+    def __init__(self, key=None, values=None):
+        self.parent = None
+        self.children = []
+        self.key = key
+        self.values = values or []
+        if not hasattr(self.values, "__iter__"):
+            self.values = [self.values]
+
+    def add_child(self, item):
+        item.parent = self
+        self.children.append(item)
+
+
+def test_configure(collectd, monkeypatch):
+    collector = Mock()
+    Collector = Mock(return_value=collector)
+    monkeypatch.setattr("fmn.core.collectd.Collector", Collector)
+    config = ConfigItem()
+    config.add_child(ConfigItem(key="SetEnv", values=("foo", "bar")))
+    config.add_child(ConfigItem(key="Interval", values=42))
+    collectd.configure(config)
+    Collector.assert_called_once_with(config={"Interval": 42, "Hostname": None})
+    collectd.collectd.register_init.assert_called_once_with(collector.setup)
+    collectd.collectd.register_shutdown.assert_called_once_with(collector.shutdown)
+    collectd.collectd.register_read.assert_called_once_with(collector.collect, 42)
+
+
+def test_configure_invalid(collectd, monkeypatch):
+    config = ConfigItem()
+    config.add_child(ConfigItem(key="foobar", values=("multiple", "values")))
+    Collector = Mock()
+    monkeypatch.setattr("fmn.core.collectd.Collector", Collector)
+
+    collectd.configure(config)
+    collectd.collectd.warning.assert_called_once_with(
+        "Invalid configuration value for foobar: ('multiple', 'values')"
+    )
+    Collector.assert_called_once_with(config={"Interval": "3600", "Hostname": None})
+
+
+def test_collector_setup_shutdown(collectd, monkeypatch):
+    configure_cache = Mock()
+    monkeypatch.setattr(collectd, "configure_cache", configure_cache)
+    collector = collectd.Collector({})
+    collector.setup()
+    configure_cache.assert_called_once()
+    loop = asyncio.get_event_loop()
+    assert loop.is_closed() is False
+
+    async def do_nothing():
+        await asyncio.sleep(120)
+
+    # Create a task to make sure it gets cancelled on shutdown
+    task = loop.create_task(do_nothing())
+
+    collector.shutdown()
+    assert loop.is_closed()
+    with pytest.raises(RuntimeError):
+        assert asyncio.get_event_loop()
+    assert task.cancelled
+
+
+def test_collect(collectd, monkeypatch, created_values, scan_result):
+    dt1 = datetime(2023, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
+    dt2 = datetime(2023, 1, 1, 1, 30, 0, tzinfo=timezone.utc)
+    dt3 = datetime(2022, 12, 31, 0, 0, 0, tzinfo=timezone.utc)
+    scan_result.extend(
+        [
+            f"duration:statname:{dt1.isoformat()}",
+            f"duration:statname:{dt2.isoformat()}",
+            f"duration:statname:{dt3.isoformat()}",
+        ]
+    )
+    collectd.cache.get = AsyncMock(side_effect=lambda key: 42)
+    mocked_dt = Mock()
+    mocked_dt.now = Mock(return_value=datetime(2023, 1, 1, 1, 0, 0, tzinfo=timezone.utc))
+    mocked_dt.fromisoformat = datetime.fromisoformat
+    monkeypatch.setattr(collectd, "datetime", mocked_dt)
+
+    collector = collectd.Collector({"Interval": 3600})
+    collector.setup()
+    collector.collect()
+
+    assert len(created_values) == 2
+    assert all(v.type == "fmn_cache" for v in created_values)
+    assert all(v.plugin == "cache" for v in created_values)
+    assert all(v.interval == 3600 for v in created_values)
+    assert all(v.type_instance == "statname" for v in created_values)
+    for index, dt in enumerate((dt1, dt2)):
+        assert created_values[index].time == dt.timestamp()
+        created_values[index].dispatch.assert_called_once_with(values=[42])
+
+
+def test_collect_none(collectd, created_values, scan_result):
+    scan_result.extend(
+        [
+            f"duration:statname:{datetime.now().isoformat()}",
+        ]
+    )
+    collectd.cache.get = AsyncMock(side_effect=lambda key: None)
+
+    collector = collectd.Collector({})
+    collector.setup()
+    collector.collect()
+
+    assert len(created_values) == 0
+
+
+def test_collect_with_hostname(collectd, created_values, scan_result):
+    scan_result.extend(
+        [
+            f"duration:statname:{datetime.now().isoformat()}",
+        ]
+    )
+    collectd.cache.get = AsyncMock(side_effect=lambda key: 42)
+
+    collector = collectd.Collector({"Interval": 3600, "Hostname": "dummyhost.example.com"})
+    collector.setup()
+    collector.collect()
+
+    assert len(created_values) == 1
+    assert created_values[0].host == "dummyhost.example.com"
+
+
+def test_dispatch_with_subname(collectd, created_values):
+    collector = collectd.Collector({"Interval": 3600})
+    collector._dispatch(42, "statname", datetime.now().timestamp(), "statsubname", "category")
+    assert len(created_values) == 1
+    assert created_values[0].type_instance == "statname-statsubname"
+
+
+def test_dispatch_with_multiple_values(collectd, created_values):
+    collector = collectd.Collector({"Interval": 3600})
+    collector._dispatch([42, 43], "statname")
+    assert len(created_values) == 1
+    created_values[0].dispatch.assert_called_once_with(values=[42, 43])


### PR DESCRIPTION
This adds a module for the collectd python plugin that will send the build stats currently stored in Redis to a collectd server.