### PR TITLE
Add a way to extend the email message body

### DIFF
--- a/changelog.d/916.added
+++ b/changelog.d/916.added
@@ -1,0 +1,1 @@
+Add a way to extend the email notification's body with, for example, a git patch

--- a/fmn/database/model/destination.py
+++ b/fmn/database/model/destination.py
@@ -2,8 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
+import logging
 from typing import TYPE_CHECKING
 
+from httpx import AsyncClient, HTTPStatusError
 from sqlalchemy import Column, ForeignKey, Integer, String, UnicodeText
 from sqlalchemy.orm import relationship
 
@@ -14,6 +16,9 @@ if TYPE_CHECKING:
     from fedora_messaging.message import Message
 
     from ...rules.notification import Notification
+
+
+log = logging.getLogger(__name__)
 
 
 class Destination(Base):
@@ -29,16 +34,20 @@ class Destination(Base):
     protocol = Column(String(length=255), nullable=False)
     address = Column(UnicodeText, nullable=False)
 
-    def generate(self, message: "Message") -> "Notification.content":
+    async def generate(self, message: "Message") -> "Notification.content":
         app_name = f"[{message.app_name}] " if message.app_name else ""
         url = message.url if message.url else ""
         if self.protocol == "email":
+            body = f"{str(message)}\n{url}"
+            extra = await get_extra(message)
+            if extra:
+                body = f"{body}\n{extra}"
             return {
                 "headers": {
                     "To": self.address,
                     "Subject": f"{app_name}{message.summary}",
                 },
-                "body": f"{str(message)}\n{url}",
+                "body": body,
             }
         elif self.protocol == "irc":
             return {"to": self.address, "message": f"{app_name}{message.summary} {url}"}
@@ -46,3 +55,16 @@ class Destination(Base):
             return {"to": self.address, "message": f"{app_name}{message.summary} {url}"}
         else:
             raise ValueError(f"Unknown destination protocol: {self.protocol}")
+
+
+async def get_extra(message: "Message"):
+    http_client = AsyncClient(timeout=10)
+    if getattr(message, "patch_url", None) is not None:
+        try:
+            response = await http_client.get(message.patch_url)
+            response.raise_for_status()
+        except HTTPStatusError as e:
+            log.info(f"Could not retrieve patch at {message.patch_url}: {e}")
+        else:
+            return f"\n{response.text}\n"
+    return ""

--- a/fmn/database/model/generation_rule.py
+++ b/fmn/database/model/generation_rule.py
@@ -44,5 +44,5 @@ class GenerationRule(Base):
             return
         for destination in self.destinations:
             yield Notification.parse_obj(
-                {"protocol": destination.protocol, "content": destination.generate(message)}
+                {"protocol": destination.protocol, "content": await destination.generate(message)}
             )

--- a/poetry.lock
+++ b/poetry.lock
@@ -2570,14 +2570,14 @@ files = [
 
 [[package]]
 name = "pagure-messages"
-version = "1.0.0"
+version = "1.1.0"
 description = "A schema package for messages sent by pagure"
 category = "main"
 optional = true
 python-versions = "*"
 files = [
-    {file = "pagure-messages-1.0.0.tar.gz", hash = "sha256:342afd57c034b09bfa48da1909993f1890365d7ba5f837f7c1c6fead37738114"},
-    {file = "pagure_messages-1.0.0-py2.py3-none-any.whl", hash = "sha256:a400bffa8d20e672906410e0e5427d090da87a3af1406607552a4524c7275914"},
+    {file = "pagure-messages-1.1.0.tar.gz", hash = "sha256:2509c21f953c51b49c377b0d0982201fec0089f9cc7af5b788ee87379b6f647f"},
+    {file = "pagure_messages-1.1.0-py2.py3-none-any.whl", hash = "sha256:d651987ab4a49f303e6f1861536cd604a572418ab185a023ea2ab793fdcba264"},
 ]
 
 [package.dependencies]

--- a/tests/database/model/test_destination.py
+++ b/tests/database/model/test_destination.py
@@ -2,12 +2,15 @@
 #
 # SPDX-License-Identifier: MIT
 
+from unittest import mock
+
+import httpx
 import pytest
 
-from fmn.database.model import Destination
+from fmn.database.model.destination import Destination, get_extra
 
 
-def test_email(make_mocked_message):
+async def test_email(make_mocked_message):
     d = Destination(id=1, protocol="email", address="dummy@example.com")
     message = make_mocked_message(
         topic="dummy",
@@ -18,41 +21,85 @@ def test_email(make_mocked_message):
             "url": "https://dummy.org/dummylink",
         },
     )
-    result = d.generate(message)
+    result = await d.generate(message)
     assert result == {
         "headers": {"To": "dummy@example.com", "Subject": "[dummy] dummy summary"},
         "body": "dummy content\nhttps://dummy.org/dummylink",
     }
 
 
-def test_irc(make_mocked_message):
+async def test_email_with_extra(make_mocked_message, mocker):
+    mocker.patch(
+        "fmn.database.model.destination.get_extra", mock.AsyncMock(return_value="DUMMY EXTRA")
+    )
+    d = Destination(id=1, protocol="email", address="dummy@example.com")
+    message = make_mocked_message(
+        topic="dummy",
+        body={
+            "summary": "dummy summary",
+            "content": "dummy content",
+            "app": "dummy",
+            "url": "https://dummy.org/dummylink",
+        },
+    )
+    result = await d.generate(message)
+    assert result == {
+        "headers": {"To": "dummy@example.com", "Subject": "[dummy] dummy summary"},
+        "body": "dummy content\nhttps://dummy.org/dummylink\nDUMMY EXTRA",
+    }
+
+
+async def test_irc(make_mocked_message):
     d = Destination(id=1, protocol="irc", address="dummy")
     message = make_mocked_message(
         topic="dummy",
         body={"summary": "dummy summary", "app": "dummy", "url": "https://dummy.org/dummylink"},
     )
-    result = d.generate(message)
+    result = await d.generate(message)
     assert result == {
         "to": "dummy",
         "message": "[dummy] dummy summary https://dummy.org/dummylink",
     }
 
 
-def test_matrix(make_mocked_message):
+async def test_matrix(make_mocked_message):
     d = Destination(id=1, protocol="matrix", address="@dummy:example.com")
     message = make_mocked_message(
         topic="dummy",
         body={"summary": "dummy summary", "app": "dummy", "url": "https://dummy.org/dummylink"},
     )
-    result = d.generate(message)
+    result = await d.generate(message)
     assert result == {
         "to": "@dummy:example.com",
         "message": "[dummy] dummy summary https://dummy.org/dummylink",
     }
 
 
-def test_unknown_protocol(make_mocked_message):
+async def test_unknown_protocol(make_mocked_message):
     d = Destination(id=1, protocol="unknown", address="dummy")
     message = make_mocked_message(topic="dummy", body={"summary": "dummy summary"})
     with pytest.raises(ValueError):
-        d.generate(message)
+        await d.generate(message)
+
+
+@pytest.mark.parametrize(
+    "attr_name,value,expected",
+    [("patch_url", "http://example.com/patch.patch", "DUMMY EXTRA"), ("patch_url", None, "")],
+)
+async def test_get_extra(make_mocked_message, respx_mocker, attr_name, value, expected):
+    message = make_mocked_message(topic="dummy.topic", body={"summary": "dummy summary"})
+    setattr(message, attr_name, value)
+    if value is not None:
+        respx_mocker.get(value).mock(side_effect=httpx.Response(200, text=expected))
+
+    result = await get_extra(message)
+    assert result == (f"\n{expected}\n" if expected else "")
+
+
+async def test_get_extra_request_failure(make_mocked_message, respx_mocker):
+    message = make_mocked_message(topic="dummy.topic", body={"summary": "dummy summary"})
+    message.patch_url = "http://example.com/patch.patch"
+    respx_mocker.get("http://example.com/patch.patch").mock(side_effect=httpx.Response(500))
+
+    result = await get_extra(message)
+    assert result == ""


### PR DESCRIPTION
This will allow schemas to define a `patch_url` attribute that will be retrieved when the email notification is generated.

Fixes: #916