### PR TITLE
Don't cause transaction serialization failures in the cache

### DIFF
--- a/changelog.d/922.fixed
+++ b/changelog.d/922.fixed
@@ -1,0 +1,1 @@
+Avoid causing transaction serialization failures in the cache by making those transactions read-only

--- a/fmn/cache/base.py
+++ b/fmn/cache/base.py
@@ -35,7 +35,14 @@ def configure_cache(db_manager=None, **kwargs):
     cache.setup(settings.cache.url, **args)
     # Bind the engine for the cached value
     db_manager = db_manager or get_manager()
-    cache_db_session_maker.configure(bind=db_manager.engine)
+    cache_db_session_maker.configure(
+        bind=db_manager.engine.execution_options(
+            # Don't cause transaction serialization failures in the cache:
+            # https://www.postgresql.org/docs/current/sql-set-transaction.html
+            postgresql_readonly=True,
+            postgresql_deferrable=True,
+        )
+    )
 
 
 class CachedValue:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ schemas = [
 addopts = "--cov-config .coveragerc --cov=fmn --cov-report term --cov-report xml --cov-report html"
 asyncio_mode = "auto"
 timeout = 60
+markers = "alembic_table_deleted: When the alembic version table has been deleted in the test"
 
 [tool.black]
 line-length = 100

--- a/tests/api/handlers/test_misc.py
+++ b/tests/api/handlers/test_misc.py
@@ -219,6 +219,7 @@ class TestMisc(BaseTestAPIV1Handler):
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"detail": "OK"}
 
+    @pytest.mark.alembic_table_deleted
     async def test_readiness_not_setup(self, client, db_async_session):
         await db_async_session.execute(text("DROP TABLE IF EXISTS alembic_version"))
         await db_async_session.flush()


### PR DESCRIPTION
The cached values transactions don't need to be read-write, they only retrieve values from the database.

Fixes: #922
