### PR TITLE
Add a footer to email notifications

### DIFF
--- a/changelog.d/895.added
+++ b/changelog.d/895.added
@@ -1,0 +1,1 @@
+Add a footer to email notifications with a link to the rule that generated it

--- a/fmn/core/config.py
+++ b/fmn/core/config.py
@@ -60,6 +60,7 @@ class ServicesModel(BaseModel):
 
 
 class Settings(BaseSettings):
+    public_url: str = "https://notifications.fedoraproject.org"
     cors_origins: str = "https://notifications.fedoraproject.org"
     oidc_provider_url: str = "https://id.fedoraproject.org/openidc"
     oidc_conf_endpoint: str = "/.well-known/openid-configuration"

--- a/fmn/rules/notification.py
+++ b/fmn/rules/notification.py
@@ -19,6 +19,19 @@ class EmailNotificationHeaders(FrozenModel):
 class EmailNotificationContent(FrozenModel):
     headers: EmailNotificationHeaders
     body: str
+    footer: str | None = None
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.model_dump(exclude=["footer"]) == other.model_dump(exclude=["footer"])
+        return super().__eq__(other)
+
+    def __hash__(self):
+        # Don't include the footer in the hash to be able to use set() to de-duplicate
+        # notifications coming from different rules.
+        internal_dict = self.__dict__.copy()
+        del internal_dict["footer"]
+        return hash(self.__class__) + hash(tuple(internal_dict.values()))
 
 
 class EmailNotification(FrozenModel):

--- a/fmn/sender/email.py
+++ b/fmn/sender/email.py
@@ -28,7 +28,10 @@ class EmailHandler(Handler):
         notif["From"] = self._config["from"]
         for name, value in message["headers"].items():
             notif[name] = value
-        notif.set_content(message["body"])
+        body = message["body"]
+        if message.get("footer") is not None:
+            body = f"{body}\n\n-- \n{message['footer']}"
+        notif.set_content(body)
         log.info("Sending email to %s with subject %s", notif["To"], notif["Subject"])
         try:
             await self._smtp.send_message(notif)

--- a/tests/consumer/test_consumer.py
+++ b/tests/consumer/test_consumer.py
@@ -149,6 +149,7 @@ async def test_consumer_call_tracked(
     assert n.content == EmailNotificationContent(
         body="Body of message on dummy.topic\n",
         headers={"Subject": "Message on dummy.topic", "To": "dummy@example.com"},
+        footer="Sent by Fedora Notifications: https://notifications.fedoraproject.org/rules/1",
     )
 
     result = await db_async_session.execute(select(model.Generated))

--- a/tests/consumer/test_send_queue.py
+++ b/tests/consumer/test_send_queue.py
@@ -49,7 +49,10 @@ async def test_send_queue_send(connection, notif):
     sq._exchange.publish.assert_called_once()
     assert sq._exchange.publish.call_args.kwargs.get("routing_key") == "send.email"
     sent_msg = sq._exchange.publish.call_args.args[0]
-    assert sent_msg.body == b'{"headers": {"To": "dummy", "Subject": "dummy"}, "body": "dummy"}'
+    assert (
+        sent_msg.body == b'{"headers": {"To": "dummy", "Subject": "dummy"}, '
+        b'"body": "dummy", "footer": null}'
+    )
 
 
 async def test_send_queue_close(connection):

--- a/tests/rules/test_notification.py
+++ b/tests/rules/test_notification.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Contributors to the Fedora Project
+#
+# SPDX-License-Identifier: MIT
+
+from fmn.rules.notification import EmailNotificationContent, IRCNotificationContent
+
+
+def test_compare_other():
+    content = EmailNotificationContent(headers={"To": "dummy", "Subject": "dummy"}, body="dummy")
+    other = IRCNotificationContent(to="dummy", message="dummy")
+    assert content != other


### PR DESCRIPTION
The footer contains the link to the rule that generated the notification.

Fixes: #895