### PR TITLE
Run tests with Python 3.12

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,6 +31,8 @@ jobs:
   backend-ci:
     strategy:
       fail-fast: false
+      matrix:
+        pyver: [310, 311]
     runs-on: ubuntu-latest
     container: fedorapython/fedora-python-tox:latest
     steps:
@@ -43,14 +45,8 @@ jobs:
         run: |
           dnf install -y krb5-devel libpq-devel gettext
 
-      - name: Install base Python dependencies
-        run: |
-          python3 -m pip install --upgrade tox
-          python3 -m pip install --upgrade "poetry>=1.5.0"
-          poetry --version
-
       - name: execute tox
-        run: tox -- -v
+        run: tox -e py${{ matrix.pyver }} -- -v
 
   frontend-ci:
     strategy:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pyver: [310, 311]
+        pyver: [310, 311, 312]
     runs-on: ubuntu-latest
     container: fedorapython/fedora-python-tox:latest
     steps:

--- a/fmn/sender/consumer.py
+++ b/fmn/sender/consumer.py
@@ -38,7 +38,7 @@ class Consumer:
     async def start(self):
         log.info("Starting consuming messages")
         async with self._queue.iterator() as self._queue_iter:
-            async for message in self._queue_iter:
+            async for message in self._queue_iter:  # pragma: no branch
                 if message == CLOSING:
                     log.debug("Got close message, breaking out of the loop")
                     break

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 
 [tox]
 minversion = 3.10.0
-envlist = py310,py311,docs,black,lint
+envlist = py310,py311,py312,docs,black,lint
 isolated_build = true
 skip_missing_interpreters = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ sitepackages = false
 allowlist_externals =
     poetry
 commands_pre =
+    pip install poetry
     poetry install --all-extras
 commands =
   poetry run pytest -o 'addopts=--cov-config .coveragerc --cov=fmn --cov-report term-missing --cov-report xml --cov-report html' --asyncio-mode auto tests/ {posargs}


### PR DESCRIPTION
```
commit 8190e9298941698414604d0c61b4ceac3464d533
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue Feb 27 11:44:05 2024 +0100

    Fix coverage issue with infinite iterator
    
    With Python 3.12, coverage flagged the “iterator exhausted” branch as
    not visited because a closing message will always break out of it.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 0320d102bedecbde3f5cb73cea98fbf4fba18b7b
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue Feb 27 11:16:29 2024 +0100

    Streamline Python tests in CI
    
    Run different Python versions in parallel and rely on the provided
    versions of poetry and tox.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 8dec2018cc21df63ea953ed350d43f5aa4a5f2c0
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue Feb 27 11:47:56 2024 +0100

    Run test suite with Python 3.12 locally and in CI
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```