### PR TITLE
Revert "Streamline Python tests in CI"

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,8 +31,6 @@ jobs:
   backend-ci:
     strategy:
       fail-fast: false
-      matrix:
-        pyver: [310, 311, 312]
     runs-on: ubuntu-latest
     container: fedorapython/fedora-python-tox:latest
     steps:
@@ -45,8 +43,14 @@ jobs:
         run: |
           dnf install -y krb5-devel libpq-devel gettext
 
+      - name: Install base Python dependencies
+        run: |
+          python3 -m pip install --upgrade tox
+          python3 -m pip install --upgrade "poetry>=1.5.0"
+          poetry --version
+
       - name: execute tox
-        run: tox -e py${{ matrix.pyver }} -- -v
+        run: tox -- -v
 
   frontend-ci:
     strategy:

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ sitepackages = false
 allowlist_externals =
     poetry
 commands_pre =
-    pip install poetry
     poetry install --all-extras
 commands =
   poetry run pytest -o 'addopts=--cov-config .coveragerc --cov=fmn --cov-report term-missing --cov-report xml --cov-report html' --asyncio-mode auto tests/ {posargs}


### PR DESCRIPTION
This broke the `build` task depending on `backend-ci` and reverts commit ab592d8dea7c060e6c842866d4a834d49ab00bde.

Apparently, you can’t depend on a test matrix in GitHub actions 🙁.