### PR TITLE
Require ruff >= 0.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3184,7 +3184,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4494,4 +4493,4 @@ sqlite = ["aiosqlite"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "ff1c9de66d218a0514aec32eb2d956137145ed80c6fdc21e5987cd163b41a965"
+content-hash = "860908b3e2dfff74067c5034c423c66e6e53126d7d3159e7761da352f82f87a2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ greenlet = "^1.1.2 || ^2.0.0 || ^3.0.0"
 toml = "^0.10.2"
 pytest-mock = "^3.8.2"
 respx = "^0.20.0"
-ruff = "^0.0.253 || ^0.0.254 || ^0.0.256 || ^0.0.257 || ^0.0.259 || ^0.0.260 || ^0.0.261 || ^0.0.262 || ^0.0.265 || ^0.0.269 || ^0.0.270 || ^0.0.271 || ^0.0.272 || ^0.0.273 || ^0.0.274 || ^0.0.275 || ^0.0.276 || ^0.0.277 || ^0.0.278 || ^0.0.282 || ^0.0.283 || ^0.0.284 || ^0.0.285 || ^0.0.286 || ^0.0.287 || ^0.0.288 || ^0.0.289 || ^0.0.290 || ^0.0.291 || ^0.0.292 || ^0.1.0 || ^0.2.0 || ^0.3.0"
+ruff = "^0.2.0 || ^0.3.0"
 towncrier = "^22.12.0 || ^23.0.0"
 sphinx = "^6.1.3 || ^7.0.0"
 myst-parser = "^1.0.0 || ^2.0.0"
@@ -204,13 +204,15 @@ markers = "alembic_table_deleted: When the alembic version table has been delete
 line-length = 100
 
 [tool.ruff]
-select = ["E", "F", "W", "I", "UP", "S", "B", "RUF"]
 line-length = 100
 target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "S", "B", "RUF"]
 ignore = ["UP038"]
 allowed-confusables = ["’"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "fmn/api/*" = ["B008", "RUF012"]
 "fmn/backends/__init__.py" = ["F401"]
 "fmn/core/config.py" = ["RUF012"]


### PR DESCRIPTION
This version moved around some configuration keys and complains if they are in the old location.