### PR TITLE
Update dependency cashews to v7

### DIFF
--- a/fmn/cache/util.py
+++ b/fmn/cache/util.py
@@ -2,13 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from functools import cache as ft_cache
 from functools import partial
 from typing import Any
-
-from cashews.formatter import get_templates_for_func, template_to_pattern
-from cashews.key import get_func_params
 
 from ..core import config
 
@@ -38,16 +35,3 @@ def cache_arg(arg: str, scope: str | None = None) -> Callable[[str, str | None],
 
 cache_ttl = partial(cache_arg, "ttl")
 lock_ttl = partial(cache_arg, "lock_ttl")
-
-
-def _get_pattern_for_cached_calls_iter(func: Callable, **kwargs: dict[str, Any]) -> Iterator[str]:
-    # This is taken from cashews.validation.invalidate_func(), minus the actual deletion part. This
-    # allows making decisions on the (cached) return values.
-    values = {**{param: "*" for param in get_func_params(func)}, **kwargs}
-    for template in get_templates_for_func(func):
-        yield template_to_pattern(template, **values)
-
-
-@ft_cache
-def get_pattern_for_cached_calls(func: Callable, **kwargs: dict[str, Any]) -> list[str]:
-    return list(_get_pattern_for_cached_calls_iter(func, **kwargs))

--- a/poetry.lock
+++ b/poetry.lock
@@ -613,13 +613,13 @@ files = [
 
 [[package]]
 name = "cashews"
-version = "6.4.0"
+version = "7.1.0"
 description = "cache tools with async power"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "cashews-6.4.0-py3-none-any.whl", hash = "sha256:6b7121a0629a17aa72d22bf4007462a9fbcdcd418b8ec1083f2806950c265e58"},
-    {file = "cashews-6.4.0.tar.gz", hash = "sha256:0f5ec89b4e8d2944e9403c5fc24fb2947003d279e338de40f2fd3ebc9145c4e3"},
+    {file = "cashews-7.1.0-py3-none-any.whl", hash = "sha256:b7c1ae4d49df6fdbff88e5025d3c1156515f58724c5b96fc9a9d081afada82a8"},
+    {file = "cashews-7.1.0.tar.gz", hash = "sha256:058df55a39cb15697d331e7e41c2882b58d0d323f5671316105cc78668af7705"},
 ]
 
 [package.dependencies]
@@ -631,7 +631,7 @@ diskcache = ["diskcache (>=5.0.0)"]
 lint = ["mypy (>=1.5.0)", "types-redis"]
 redis = ["redis (>=4.3.1,!=5.0.1)"]
 speedup = ["bitarray (<3.0.0)", "hiredis", "xxhash (<4.0.0)"]
-tests = ["hypothesis", "pytest", "pytest-asyncio (==0.23.3)"]
+tests = ["hypothesis (==6.100.2)", "pytest (==8.2.0)", "pytest-asyncio (==0.23.6)", "pytest-cov (==5.0.0)", "pytest-rerunfailures (==14.0)"]
 
 [[package]]
 name = "certifi"
@@ -3315,7 +3315,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4649,4 +4648,4 @@ sqlite = ["aiosqlite"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "b8e70da824ccb895dfa0d54669249d0d37938a6e9c0c08abc629807b3e5dad35"
+content-hash = "1a1ecce2280a07b1c7925dcce5796e4884e68b28da8a7694f507385212512ac3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ SQLAlchemy = {version = "^1.4.41 || ^2.0.0", optional = true}
 sqlalchemy-helpers = {version = ">=0.11", optional = true}
 httpx-gssapi = {version = "^0.1.7 || ^0.2.0 || ^0.3.0", optional = true}
 backoff = {version = "^2.2.1", optional = true}
-cashews = {extras = ["redis"], version = "^5.1.0 || ^6.0.0", optional = true}
+cashews = {extras = ["redis"], version = "^7.0.0", optional = true}
 matrix-nio = {version = "^0.20.1 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0", optional = true}
 
 # Message schemas. The reference list of all message schemas is in

--- a/tests/cache/test_util.py
+++ b/tests/cache/test_util.py
@@ -5,7 +5,6 @@
 from unittest import mock
 
 import pytest
-from cashews import cache
 
 from fmn.cache import util
 from fmn.core.config import get_settings
@@ -31,43 +30,3 @@ def test_cashews_cache_arg(scope):
 
     assert fn.cache_info().misses == 1
     assert fn.cache_info().hits == 2
-
-
-@pytest.mark.parametrize("with_arg", ("with-arg", "without-arg"))
-@pytest.mark.parametrize("with_self", ("with-self", "without-self"))
-def test_get_pattern_for_cached_calls(with_self, with_arg):
-    class TestClass:
-        def __str__(self):
-            return "TestClass()"
-
-        if with_arg == "with-arg":
-
-            @cache(ttl="1h")
-            def test_method(self, arg):
-                return "this is test_method"
-
-        else:
-
-            @cache(ttl="1h")
-            def test_method(self):
-                return "this is test_method"
-
-    test_object = TestClass()
-
-    if with_self == "with-self":
-        kwargs = {"self": test_object}
-        expected_self = "TestClass()"
-    else:
-        kwargs = {}
-        expected_self = "*"
-
-    patterns = util.get_pattern_for_cached_calls(test_object.test_method, **kwargs)
-
-    assert any(
-        (
-            f":self:{expected_self}:" in pattern
-            if with_arg == "with-arg"
-            else pattern.endswith(f":self:{expected_self}")
-        )
-        for pattern in patterns
-    )


### PR DESCRIPTION
Version 7 of cashews removed a couple functions related to cache key patterns which we used for targeted invalidation. Now, cached methods use tags by which we invalidate, but this was buggy before 7.0.0, so require it.

Augments #1074