### PR TITLE
Fix RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,11 +25,11 @@ build:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
     post_install:
-      # Install dependencies with poetry
-      - poetry install --all-extras
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --all-extras
+
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:


### PR DESCRIPTION
# What does this change do?

readthedocs build is currently failing, this should fix it according to https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry
I already fixed the builds for Anitya and Anitya messaging schema.

# How should we test your change?

- Merge it and look at the build on readthedocs.com

# Checklist for Submitter

- [ ] Added a [changelog fragment](https://github.com/fedora-infra/fmn/blob/develop/docs/contributing.md#changelog)
- [ ] Added or updated other documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached for UI changes
- [ ] Have db migrations been tested, if there are any?
