### PR TITLE
UI: Guard against data loss in rule creation (#897)

### DIFF
--- a/frontend/src/components/NewRuleForm.vue
+++ b/frontend/src/components/NewRuleForm.vue
@@ -27,11 +27,10 @@ const trackingRuleName = ref("");
 
 const generationRulesCount = ref(0);
 
-// Dirty state to track unsaved changes
-const isDirty = ref(false)
-const markDirty = () => {
-  isDirty.value = true
-}
+const newRuleForm = ref<{ node: FormKitNode } | null>(null);
+const isDirty = computed(
+  () => newRuleForm.value?.node.context?.state.dirty === true,
+);
 
 const formReady = computed(
   () => trackingRuleName.value !== "" && generationRulesCount.value > 0,
@@ -48,7 +47,6 @@ const handleSubmit = async (
   try {
     await mutateAsync(data as Rule);
     // Success!
-    isDirty.value = false;
     toastStore.addToast({
       color: "success",
       title: "Rule created",
@@ -65,28 +63,22 @@ const handleSubmit = async (
   }
 };
 
-// Mark form to have unsaved changes on input
 const handleTrackingRuleSelected = (name: string) => {
   trackingRuleName.value = name;
-  markDirty();
 };
 const handleGenerationRulesChanged = (rules: GenerationRule[]) => {
   generationRulesCount.value = rules.length;
-  markDirty();
 };
 
-// Add a a guarded cancel button to avoid losing unsaved changes
-const onCancel = async () => {
-  if (!isDirty.value || window.confirm("Discard the unsaved changes?")) {
-    isDirty.value = false;
-    router.push("/");
-  }
+const onCancel = () => {
+  router.push("/");
 };
 
 // Warning on tab close or hard navigation away
 const beforeUnloadHandler = (e: BeforeUnloadEvent) => {
   if (!isDirty.value) return;
   e.preventDefault();
+  e.returnValue = "";
 };
 onMounted(() => {
   window.addEventListener("beforeunload", beforeUnloadHandler);
@@ -101,14 +93,14 @@ onBeforeRouteLeave((_to, _from, next) => {
     next();
     return;
   }
-  if (window.confirm("You have in-app unsaved changes. Discard them?")) next();
+  if (window.confirm("You have not saved the new rule yet. Discard new rule?")) next();
   else next(false)
 });
 
 </script>
 
 <template>
-  <FormKit type="form" id="new-rule" @submit="handleSubmit" :actions="false" @input="markDirty">
+  <FormKit type="form" id="new-rule" @submit="handleSubmit" :actions="false" ref="newRuleForm">
     <!-- Track if the user has made changes in the form-->  
 
     <CRow class="mb-2 align-items-center">
@@ -126,7 +118,6 @@ onBeforeRouteLeave((_to, _from, next) => {
           label-class="fw-bold mb-0"
           placeholder="Optional Rule Title"
           input-class="form-control"
-          @input="markDirty"
         />
         <TrackingRule @selected="handleTrackingRuleSelected" />
       </CCol>

--- a/frontend/src/components/NewRuleForm.vue
+++ b/frontend/src/components/NewRuleForm.vue
@@ -13,8 +13,8 @@ import { CCol, CRow } from "@coreui/vue";
 import type { FormKitGroupValue, FormKitNode } from "@formkit/core";
 import { FormKit } from "@formkit/vue";
 import type { AxiosError } from "axios";
-import { computed, ref } from "vue";
-import { useRouter } from "vue-router";
+import { computed, ref, onMounted, onBeforeUnmount } from "vue";
+import { useRouter, onBeforeRouteLeave } from "vue-router";
 import GenerationRuleList from "./rule-edit/generation-rule/GenerationRuleList.vue";
 import TrackingRule from "./rule-edit/tracking-rule/TrackingRule.vue";
 
@@ -26,6 +26,13 @@ const { mutateAsync } = useAddRuleMutation();
 const trackingRuleName = ref("");
 
 const generationRulesCount = ref(0);
+
+// Dirty state to track unsaved changes
+const isDirty = ref(false)
+const markDirty = () => {
+  isDirty.value = true
+}
+
 const formReady = computed(
   () => trackingRuleName.value !== "" && generationRulesCount.value > 0,
 );
@@ -41,6 +48,7 @@ const handleSubmit = async (
   try {
     await mutateAsync(data as Rule);
     // Success!
+    isDirty.value = false;
     toastStore.addToast({
       color: "success",
       title: "Rule created",
@@ -57,36 +65,55 @@ const handleSubmit = async (
   }
 };
 
+// Mark form to have unsaved changes on input
 const handleTrackingRuleSelected = (name: string) => {
   trackingRuleName.value = name;
+  markDirty();
 };
 const handleGenerationRulesChanged = (rules: GenerationRule[]) => {
   generationRulesCount.value = rules.length;
+  markDirty();
 };
+
+// Add a a guarded cancel button to avoid losing unsaved changes
+const onCancel = async () => {
+  if (!isDirty.value || window.confirm("Discard the unsaved changes?")) {
+    isDirty.value = false;
+    router.push("/");
+  }
+};
+
+// Warning on tab close or hard navigation away
+const beforeUnloadHandler = (e: BeforeUnloadEvent) => {
+  if (!isDirty.value) return;
+  e.preventDefault();
+};
+onMounted(() => {
+  window.addEventListener("beforeunload", beforeUnloadHandler);
+});
+onBeforeUnmount(() => {
+  window.removeEventListener("beforeunload", beforeUnloadHandler);
+});
+
+// Warn on in-app navigation away/route changes
+onBeforeRouteLeave((_to, _from, next) => {
+  if (!isDirty.value) {
+    next();
+    return;
+  }
+  if (window.confirm("You have in-app unsaved changes. Discard them?")) next();
+  else next(false)
+});
+
 </script>
 
 <template>
-  <FormKit type="form" id="new-rule" @submit="handleSubmit" :actions="false">
+  <FormKit type="form" id="new-rule" @submit="handleSubmit" :actions="false" @input="markDirty">
+    <!-- Track if the user has made changes in the form-->  
+
     <CRow class="mb-2 align-items-center">
       <CCol xs="auto" class="flex-fill">
         <h4>Create a new Rule</h4>
-      </CCol>
-      <CCol xs="auto">
-        <router-link
-          to="/"
-          class="btn btn-outline-secondary d-inline-block mx-2"
-        >
-          Cancel
-        </router-link>
-        <div class="d-inline-block mx-2">
-          <FormKit
-            type="submit"
-            :class="['btn', 'btn-primary', 'form-control-lg']"
-            :disabled="!formReady"
-          >
-            Create Rule
-          </FormKit>
-        </div>
       </CCol>
     </CRow>
 
@@ -99,6 +126,7 @@ const handleGenerationRulesChanged = (rules: GenerationRule[]) => {
           label-class="fw-bold mb-0"
           placeholder="Optional Rule Title"
           input-class="form-control"
+          @input="markDirty"
         />
         <TrackingRule @selected="handleTrackingRuleSelected" />
       </CCol>
@@ -110,5 +138,28 @@ const handleGenerationRulesChanged = (rules: GenerationRule[]) => {
         />
       </CCol>
     </CRow>
+    
+    <!-- Moved the primary action button from the top-right to the bottom -->
+    <CRow class="mt-3">
+      <CCol class="d-flex justify-content-end gap-3">
+        <button
+          type="button"
+          class="btn btn-secondary"
+          @click="onCancel"
+          aria-label="Cancel rule creation"
+        >
+          Cancel
+        </button>
+        <FormKit
+          type="submit"
+          :class="['btn', 'btn-primary', 'form-control-lg']"
+          :disabled="!formReady"
+          aria-label="Save rule"
+        >
+          Save Rule
+        </FormKit>
+      </CCol>
+    </CRow>
+
   </FormKit>
 </template>


### PR DESCRIPTION
<!--
Contributor documentation is at
https://github.com/fedora-infra/fmn/blob/develop/docs/contributing.md
-->

# What does this change do?
- Renames "Create Rule" button to 'Save Rule" for clarity
- Moves the action buttons from the top-right to the bottom-right of the form.
- Warning messages: When the user tries to leave the page (mid-creation) without saving the new rule, and when they click the cancel button. 

<!-- Reference the issue ID that this PR fixes, if applicable: -->
Fixes: #897 

# How should we test your change?
1. Start the FMN frontend (pnpm dev).
2.  Go to Create a new Rule (/dev/new-rule).
3. Type a rule title and select a tracking rule.
4. Try each of these scenarios:
    - Click Cancel; should prompt once to discard changes.
    - Navigate to another route inside the app; should prompt once.
    - Refresh or close the tab; browser shows a warning message.
    
UI Screenshot
<img width="1593" height="522" alt="image" src="https://github.com/user-attachments/assets/18827783-5654-4ca6-bab1-5ab2ed536981" />

-

# Checklist for Submitter
- [x] Manual test plan described
- [x] Screenshots attached for UI changes
- [x] No database changes required
