### PR TITLE
UI: clarify blank means All in Applications (#876)

### DIFF
--- a/frontend/src/components/rule-edit/generation-rule/BaseFilterApplication.vue
+++ b/frontend/src/components/rule-edit/generation-rule/BaseFilterApplication.vue
@@ -11,6 +11,7 @@ const props = defineProps<{
   name: string;
   label: string;
   placeholder?: string;
+  help?: string;
 }>();
 
 const url = "/api/v1/applications";
@@ -33,5 +34,6 @@ const getApplications = async () => {
     :msOptions="getApplications"
     searchable
     :close-on-select="false"
+    :help="props.help"
   />
 </template>

--- a/frontend/src/components/rule-edit/generation-rule/FilterApplication.vue
+++ b/frontend/src/components/rule-edit/generation-rule/FilterApplication.vue
@@ -13,5 +13,6 @@ import BaseFilterApplication from "./BaseFilterApplication.vue";
     name="applications"
     label="Applications"
     placeholder="Choose applications"
+    help="If you leave this field empty, the rule applies to all applications (including new ones added later)"
   />
 </template>

--- a/frontend/src/forms/index.ts
+++ b/frontend/src/forms/index.ts
@@ -53,6 +53,12 @@ export const config = defaultConfig({
         input: "form-check-input",
         help: "text-muted",
       },
+      multiselect: {
+        help: "text-muted",
+      },
+      multiselectasyncdefault: {
+        help: "text-muted",
+      },
     }),
   },
 });


### PR DESCRIPTION
<!--
Contributor documentation is at
https://github.com/fedora-infra/fmn/blob/develop/docs/contributing.md
-->

# What does this change do?
This pull request adds helper text to clarify that leaving the Applications field blank/unselected means the rule applies to all applications (including new ones added later).

It also adds a tooltip icon next to the label with the text: “Leaving this unselected means your rule applies to every application.”


<!-- Reference the issue ID that this PR fixes, if applicable: -->
Fixes: #876

# How should we test your change?

1. Run the frontend locally (npm run dev).
2. Open the New Rule form.
3. In the Applications field:
    - Hover over ⓘ to see the tooltip.
4. Confirm helper text is visible under the field.

-

<img width="791" height="586" alt="image" src="https://github.com/user-attachments/assets/5860b0e7-51f0-4ecd-a95f-b3b0e301efe7" />
